### PR TITLE
feat(core): add core type definitions for editor

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type {
   Range,
   // Editor options
   AnyExtension,
+  TextDirection,
   FocusPosition,
   EditorOptions,
   ResolvedEditorOptions,
@@ -24,6 +25,10 @@ export type {
   FocusEventProps,
   CreateEventProps,
   ContentErrorProps,
+  PasteEventProps,
+  DropEventProps,
+  MountEventProps,
+  DeleteEventProps,
   EditorEvents,
   EditorEventName,
   // Command types

--- a/packages/core/src/types/Commands.ts
+++ b/packages/core/src/types/Commands.ts
@@ -1,0 +1,114 @@
+import type { EditorState, Transaction } from 'prosemirror-state';
+
+/**
+ * Editor instance type (forward declaration)
+ */
+export interface CommandEditor {
+  readonly view: unknown;
+  readonly state: EditorState;
+}
+
+/**
+ * Props passed to every command function
+ */
+export interface CommandProps {
+  /** The editor instance */
+  editor: CommandEditor;
+
+  /** Current editor state */
+  state: EditorState;
+
+  /** Current transaction (shared in chains) */
+  tr: Transaction;
+
+  /**
+   * Dispatch function - if undefined, command is in "dry run" mode
+   * When undefined, command should only check if it CAN be executed
+   */
+  dispatch: ((tr: Transaction) => void) | undefined;
+
+  /** Start a new command chain */
+  chain: () => ChainedCommands;
+
+  /** Check if commands can be executed (dry run) */
+  can: () => CanCommands;
+
+  /** Access to all single commands */
+  commands: SingleCommands;
+}
+
+/**
+ * A command function that returns true if it was executed successfully
+ */
+export type Command = (props: CommandProps) => boolean;
+
+/**
+ * A command factory that returns a Command
+ * Used for commands that take arguments
+ *
+ * @example
+ * const setHeading: CommandSpec = (level: number) => ({ state, dispatch }) => {
+ *   // ... implementation
+ *   return true;
+ * };
+ */
+export type CommandSpec<Args extends unknown[] = []> = (...args: Args) => Command;
+
+/**
+ * Raw commands as returned by extensions
+ * Keys are command names, values are command specs
+ */
+export type RawCommands = Record<string, CommandSpec<never[]>>;
+
+/**
+ * Single commands that execute immediately
+ * These are accessed via editor.commands.commandName()
+ */
+export type SingleCommands = {
+  [K in keyof RawCommands]: RawCommands[K] extends CommandSpec<infer Args>
+    ? (...args: Args) => boolean
+    : never;
+};
+
+/**
+ * Chained commands that return `this` for fluent API
+ * These are accessed via editor.chain().commandName().run()
+ */
+export type ChainedCommands = {
+  [K in keyof RawCommands]: RawCommands[K] extends CommandSpec<infer Args>
+    ? (...args: Args) => ChainedCommands
+    : never;
+} & {
+  /** Execute the command chain */
+  run: () => boolean;
+};
+
+/**
+ * Commands for checking if execution is possible (dry run)
+ * These are accessed via editor.can().commandName()
+ */
+export type CanCommands = {
+  [K in keyof RawCommands]: RawCommands[K] extends CommandSpec<infer Args>
+    ? (...args: Args) => boolean
+    : never;
+} & {
+  /** Start a chain check */
+  chain: () => CanChainedCommands;
+};
+
+/**
+ * Chained commands for dry-run checking
+ */
+export type CanChainedCommands = {
+  [K in keyof RawCommands]: RawCommands[K] extends CommandSpec<infer Args>
+    ? (...args: Args) => CanChainedCommands
+    : never;
+} & {
+  /** Check if the entire chain can be executed */
+  run: () => boolean;
+};
+
+/**
+ * Keyboard shortcut handler
+ */
+export type KeyboardShortcutCommand = (props: { editor: CommandEditor }) => boolean;

--- a/packages/core/src/types/Content.ts
+++ b/packages/core/src/types/Content.ts
@@ -33,9 +33,10 @@ export interface JSONContent {
  * Content that can be passed to the editor
  * - string: HTML string to be parsed
  * - JSONContent: JSON representation of the document
+ * - JSONContent[]: Array of nodes to insert
  * - null: Empty document
  */
-export type Content = string | JSONContent | null;
+export type Content = string | JSONContent | JSONContent[] | null;
 
 /**
  * Represents a range in the document

--- a/packages/core/src/types/Content.ts
+++ b/packages/core/src/types/Content.ts
@@ -1,0 +1,46 @@
+/**
+ * JSON representation of a ProseMirror node attribute
+ */
+export type JSONAttribute =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONAttribute[]
+  | { [key: string]: JSONAttribute };
+
+/**
+ * JSON representation of a ProseMirror mark
+ */
+export interface JSONMark {
+  type: string;
+  attrs?: Record<string, JSONAttribute>;
+}
+
+/**
+ * JSON representation of a ProseMirror node
+ * This is the format used for serializing/deserializing editor content
+ */
+export interface JSONContent {
+  type: string;
+  attrs?: Record<string, JSONAttribute>;
+  content?: JSONContent[];
+  marks?: JSONMark[];
+  text?: string;
+}
+
+/**
+ * Content that can be passed to the editor
+ * - string: HTML string to be parsed
+ * - JSONContent: JSON representation of the document
+ * - null: Empty document
+ */
+export type Content = string | JSONContent | null;
+
+/**
+ * Represents a range in the document
+ */
+export interface Range {
+  from: number;
+  to: number;
+}

--- a/packages/core/src/types/EditorEvents.ts
+++ b/packages/core/src/types/EditorEvents.ts
@@ -1,0 +1,81 @@
+import type { Transaction } from 'prosemirror-state';
+
+/**
+ * Editor instance type (forward declaration to avoid circular dependency)
+ * Will be properly typed when Editor class is implemented
+ */
+export interface EditorInstance {
+  // Minimal interface - will be extended when Editor is implemented
+  readonly view: unknown;
+  readonly state: unknown;
+}
+
+/**
+ * Props passed to event handlers that include transaction
+ */
+export interface TransactionEventProps {
+  editor: EditorInstance;
+  transaction: Transaction;
+}
+
+/**
+ * Props passed to focus/blur event handlers
+ */
+export interface FocusEventProps {
+  editor: EditorInstance;
+  event: FocusEvent;
+}
+
+/**
+ * Props passed to create event handler
+ */
+export interface CreateEventProps {
+  editor: EditorInstance;
+}
+
+/**
+ * Props passed to content error handler (AD-8: Content Validation)
+ */
+export interface ContentErrorProps {
+  editor: EditorInstance;
+  error: Error;
+  disableCollaboration: () => void;
+}
+
+/**
+ * All editor events with their payload types
+ * Used by EventEmitter for type-safe event handling
+ */
+export interface EditorEvents {
+  /** Fired before editor is created - can modify options */
+  beforeCreate: CreateEventProps;
+
+  /** Fired when editor is created and ready */
+  create: CreateEventProps;
+
+  /** Fired when document content changes */
+  update: TransactionEventProps;
+
+  /** Fired when selection changes (without content change) */
+  selectionUpdate: TransactionEventProps;
+
+  /** Fired on every transaction (content or selection) */
+  transaction: TransactionEventProps;
+
+  /** Fired when editor receives focus */
+  focus: FocusEventProps;
+
+  /** Fired when editor loses focus */
+  blur: FocusEventProps;
+
+  /** Fired before editor is destroyed (no payload) */
+  destroy: undefined;
+
+  /** Fired when content doesn't match schema (AD-8) */
+  contentError: ContentErrorProps;
+}
+
+/**
+ * Event names as a type
+ */
+export type EditorEventName = keyof EditorEvents;

--- a/packages/core/src/types/EditorEvents.ts
+++ b/packages/core/src/types/EditorEvents.ts
@@ -43,6 +43,46 @@ export interface ContentErrorProps {
 }
 
 /**
+ * Props passed to paste event handler
+ */
+export interface PasteEventProps {
+  editor: EditorInstance;
+  event: ClipboardEvent;
+  /** ProseMirror Slice of pasted content */
+  slice: unknown;
+}
+
+/**
+ * Props passed to drop event handler
+ */
+export interface DropEventProps {
+  editor: EditorInstance;
+  event: DragEvent;
+  /** ProseMirror Slice of dropped content */
+  slice: unknown;
+  /** Whether the content was moved (true) or copied (false) */
+  moved: boolean;
+}
+
+/**
+ * Props passed to mount event handler
+ */
+export interface MountEventProps {
+  editor: EditorInstance;
+}
+
+/**
+ * Props passed to delete event handler
+ */
+export interface DeleteEventProps {
+  editor: EditorInstance;
+  /** Start position of deleted content */
+  from: number;
+  /** End position of deleted content */
+  to: number;
+}
+
+/**
  * All editor events with their payload types
  * Used by EventEmitter for type-safe event handling
  */
@@ -73,6 +113,21 @@ export interface EditorEvents {
 
   /** Fired when content doesn't match schema (AD-8) */
   contentError: ContentErrorProps;
+
+  /** Fired when content is pasted */
+  paste: PasteEventProps;
+
+  /** Fired when content is dropped */
+  drop: DropEventProps;
+
+  /** Fired when editor view is mounted to DOM */
+  mount: MountEventProps;
+
+  /** Fired when editor view is unmounted from DOM */
+  unmount: MountEventProps;
+
+  /** Fired when content is deleted */
+  delete: DeleteEventProps;
 }
 
 /**

--- a/packages/core/src/types/EditorOptions.ts
+++ b/packages/core/src/types/EditorOptions.ts
@@ -1,0 +1,156 @@
+import type { Content } from './Content.js';
+import type {
+  CreateEventProps,
+  TransactionEventProps,
+  FocusEventProps,
+  ContentErrorProps,
+} from './EditorEvents.js';
+
+/**
+ * Extension type (forward declaration to avoid circular dependency)
+ * Will be properly typed when Extension class is implemented
+ */
+export interface AnyExtension {
+  name: string;
+  type: 'extension' | 'node' | 'mark';
+}
+
+/**
+ * Autofocus options for the editor
+ * - true: Focus at the end
+ * - false: Don't autofocus
+ * - 'start': Focus at the beginning
+ * - 'end': Focus at the end
+ * - 'all': Select all content
+ * - number: Focus at specific position
+ */
+export type FocusPosition = boolean | 'start' | 'end' | 'all' | number;
+
+/**
+ * Configuration options for creating an Editor instance
+ */
+export interface EditorOptions {
+  /**
+   * HTML element to mount the editor
+   * If not provided, editor runs in "headless" mode
+   */
+  element?: HTMLElement | null;
+
+  /**
+   * Initial content (JSON or HTML string)
+   * @default null (empty document)
+   */
+  content?: Content;
+
+  /**
+   * Extensions to load
+   * @default []
+   */
+  extensions?: AnyExtension[];
+
+  /**
+   * Whether the editor is editable
+   * @default true
+   */
+  editable?: boolean;
+
+  /**
+   * Autofocus behavior on mount
+   * @default false
+   */
+  autofocus?: FocusPosition;
+
+  /**
+   * Enable input rules (markdown shortcuts like **bold**)
+   * @default true
+   */
+  enableInputRules?: boolean;
+
+  /**
+   * Enable paste rules (auto-linking URLs, etc.)
+   * @default true
+   */
+  enablePasteRules?: boolean;
+
+  /**
+   * Validate content against schema (AD-8: Content Validation)
+   * When true, warns about content that doesn't match the schema
+   * @default true
+   */
+  enableContentCheck?: boolean;
+
+  /**
+   * Inject custom CSS into the editor
+   */
+  injectCSS?: boolean;
+
+  /**
+   * HTML attributes to add to the editor element
+   */
+  editorProps?: Record<string, unknown>;
+
+  /**
+   * Parse options for HTML content
+   */
+  parseOptions?: Record<string, unknown>;
+
+  // === Event Callbacks ===
+
+  /**
+   * Called before the editor is created
+   * Can be used to modify options
+   */
+  onBeforeCreate?: (props: CreateEventProps) => void;
+
+  /**
+   * Called when the editor is created and ready
+   */
+  onCreate?: (props: CreateEventProps) => void;
+
+  /**
+   * Called when the document content changes
+   */
+  onUpdate?: (props: TransactionEventProps) => void;
+
+  /**
+   * Called when selection changes (without content change)
+   */
+  onSelectionUpdate?: (props: TransactionEventProps) => void;
+
+  /**
+   * Called on every transaction
+   */
+  onTransaction?: (props: TransactionEventProps) => void;
+
+  /**
+   * Called when editor receives focus
+   */
+  onFocus?: (props: FocusEventProps) => void;
+
+  /**
+   * Called when editor loses focus
+   */
+  onBlur?: (props: FocusEventProps) => void;
+
+  /**
+   * Called before editor is destroyed
+   */
+  onDestroy?: () => void;
+
+  /**
+   * Called when content doesn't match schema (AD-8)
+   * Use this to handle content validation errors gracefully
+   */
+  onContentError?: (props: ContentErrorProps) => void;
+}
+
+/**
+ * Required options that must be resolved before creating the editor
+ */
+export interface ResolvedEditorOptions extends EditorOptions {
+  extensions: AnyExtension[];
+  editable: boolean;
+  enableInputRules: boolean;
+  enablePasteRules: boolean;
+  enableContentCheck: boolean;
+}

--- a/packages/core/src/types/EditorOptions.ts
+++ b/packages/core/src/types/EditorOptions.ts
@@ -4,6 +4,10 @@ import type {
   TransactionEventProps,
   FocusEventProps,
   ContentErrorProps,
+  PasteEventProps,
+  DropEventProps,
+  MountEventProps,
+  DeleteEventProps,
 } from './EditorEvents.js';
 
 /**
@@ -16,15 +20,21 @@ export interface AnyExtension {
 }
 
 /**
+ * Text direction for the editor
+ */
+export type TextDirection = 'ltr' | 'rtl';
+
+/**
  * Autofocus options for the editor
  * - true: Focus at the end
  * - false: Don't autofocus
+ * - null: Explicitly no autofocus
  * - 'start': Focus at the beginning
  * - 'end': Focus at the end
  * - 'all': Select all content
  * - number: Focus at specific position
  */
-export type FocusPosition = boolean | 'start' | 'end' | 'all' | number;
+export type FocusPosition = boolean | 'start' | 'end' | 'all' | number | null;
 
 /**
  * Configuration options for creating an Editor instance
@@ -85,6 +95,12 @@ export interface EditorOptions {
   injectCSS?: boolean;
 
   /**
+   * Nonce for CSP (Content Security Policy) compliance
+   * Added to injected style tags
+   */
+  injectNonce?: string;
+
+  /**
    * HTML attributes to add to the editor element
    */
   editorProps?: Record<string, unknown>;
@@ -93,6 +109,12 @@ export interface EditorOptions {
    * Parse options for HTML content
    */
   parseOptions?: Record<string, unknown>;
+
+  /**
+   * Text direction for RTL language support
+   * @default 'ltr'
+   */
+  textDirection?: TextDirection;
 
   // === Event Callbacks ===
 
@@ -106,6 +128,16 @@ export interface EditorOptions {
    * Called when the editor is created and ready
    */
   onCreate?: (props: CreateEventProps) => void;
+
+  /**
+   * Called when editor view is mounted to DOM
+   */
+  onMount?: (props: MountEventProps) => void;
+
+  /**
+   * Called when editor view is unmounted from DOM
+   */
+  onUnmount?: (props: MountEventProps) => void;
 
   /**
    * Called when the document content changes
@@ -142,6 +174,23 @@ export interface EditorOptions {
    * Use this to handle content validation errors gracefully
    */
   onContentError?: (props: ContentErrorProps) => void;
+
+  /**
+   * Called when content is pasted
+   * Return true to prevent default paste handling
+   */
+  onPaste?: (props: PasteEventProps) => boolean | undefined;
+
+  /**
+   * Called when content is dropped
+   * Return true to prevent default drop handling
+   */
+  onDrop?: (props: DropEventProps) => boolean | undefined;
+
+  /**
+   * Called when content is deleted
+   */
+  onDelete?: (props: DeleteEventProps) => void;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -14,6 +14,7 @@ export type {
 // Editor options
 export type {
   AnyExtension,
+  TextDirection,
   FocusPosition,
   EditorOptions,
   ResolvedEditorOptions,
@@ -26,6 +27,10 @@ export type {
   FocusEventProps,
   CreateEventProps,
   ContentErrorProps,
+  PasteEventProps,
+  DropEventProps,
+  MountEventProps,
+  DeleteEventProps,
   EditorEvents,
   EditorEventName,
 } from './EditorEvents.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,24 +1,26 @@
 /**
- * @domternal/core
- * Framework-agnostic ProseMirror editor engine
+ * Core type definitions for @domternal/core
  */
 
-export const VERSION = '0.0.1';
-
-// === Type exports ===
+// Content types
 export type {
-  // Content types
   JSONAttribute,
   JSONMark,
   JSONContent,
   Content,
   Range,
-  // Editor options
+} from './Content.js';
+
+// Editor options
+export type {
   AnyExtension,
   FocusPosition,
   EditorOptions,
   ResolvedEditorOptions,
-  // Editor events
+} from './EditorOptions.js';
+
+// Editor events
+export type {
   EditorInstance,
   TransactionEventProps,
   FocusEventProps,
@@ -26,7 +28,10 @@ export type {
   ContentErrorProps,
   EditorEvents,
   EditorEventName,
-  // Command types
+} from './EditorEvents.js';
+
+// Command types
+export type {
   CommandEditor,
   CommandProps,
   Command,
@@ -37,12 +42,4 @@ export type {
   CanCommands,
   CanChainedCommands,
   KeyboardShortcutCommand,
-} from './types/index.js';
-
-// Editor class will be implemented here
-// export { Editor } from './Editor';
-
-// Extension system will be implemented here
-// export { Extension } from './Extension';
-// export { Node } from './Node';
-// export { Mark } from './Mark';
+} from './Commands.js';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
+    "lib": ["es2022", "dom"],
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*"],

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,7 +4,12 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
   target: 'es2022',
-  dts: true,
+  dts: {
+    resolve: true,
+    compilerOptions: {
+      composite: false,
+    },
+  },
   sourcemap: true,
   splitting: false,
   treeshake: true,


### PR DESCRIPTION
## Summary

- Add foundational TypeScript types for `@domternal/core` editor engine
- Define JSON content structures, editor options, events, and command system types
- Establish type-safe API foundation for Phase 1 development

## Changes

### New type files in `packages/core/src/types/`

- **Content.ts** - JSON document types (`JSONContent`, `JSONMark`, `JSONAttribute`, `Range`)
- **EditorOptions.ts** - Editor configuration (`EditorOptions`, `ResolvedEditorOptions`, `FocusPosition`)
- **EditorEvents.ts** - Event system (`EditorEvents`, event prop types for all 14 events)
- **Commands.ts** - Command API types (`Command`, `CommandProps`, `ChainedCommands`, `CanCommands`)

### Features

- Full event coverage: lifecycle, content, focus, paste/drop, mount/unmount
- Chainable command types with dry-run support (`can()`)
- Content validation support (`enableContentCheck`, `onContentError`)
- CSP compliance (`injectNonce`)
- RTL support (`textDirection`)
