### PR TITLE
feat(core): add EventEmitter class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,17 @@ PR title follows the same format as commit messages:
 feat(core): add toolbar plugin
 ```
 
-When squash merging, the PR title becomes the final commit message.
+### Merge Strategy
+
+We use **Squash and Merge**. The PR title becomes the final commit message.
 
 ### PR Description
 
 Include:
-- **What** - Brief summary of changes
-- **Why** - Motivation or issue being solved
-- **How to test** - Steps to verify the changes
+- **Summary** - Brief summary of changes (required)
+- **Changes** - List of what was added/modified (required)
+- **Why** - Issue being solved (optional)
+- **Test plan** - Steps to verify the changes (optional)
 
 ## Development
 

--- a/packages/core/src/EventEmitter.test.ts
+++ b/packages/core/src/EventEmitter.test.ts
@@ -74,6 +74,26 @@ describe('EventEmitter', () => {
 
       expect(result).toBe(emitter);
     });
+
+    it('removes all listeners for event when no callback specified', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+      const changeCallback = vi.fn();
+
+      emitter.on('update', callback1);
+      emitter.on('update', callback2);
+      emitter.on('change', changeCallback);
+
+      // Remove ALL update listeners without specifying callback
+      emitter.off('update');
+      emitter.emit('update', { value: 42 });
+      emitter.emit('change', { oldValue: 'a', newValue: 'b' });
+
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).not.toHaveBeenCalled();
+      expect(changeCallback).toHaveBeenCalled();
+    });
   });
 
   describe('emit()', () => {
@@ -200,6 +220,68 @@ describe('EventEmitter', () => {
         .removeAllListeners('change');
 
       expect(callback).toHaveBeenCalledWith({ value: 100 });
+    });
+  });
+
+  describe('listenerCount()', () => {
+    it('returns 0 when no listeners registered', () => {
+      const emitter = new EventEmitter<TestEvents>();
+
+      expect(emitter.listenerCount('update')).toBe(0);
+    });
+
+    it('returns correct count of listeners', () => {
+      const emitter = new EventEmitter<TestEvents>();
+
+      emitter.on('update', vi.fn());
+      emitter.on('update', vi.fn());
+      emitter.on('change', vi.fn());
+
+      expect(emitter.listenerCount('update')).toBe(2);
+      expect(emitter.listenerCount('change')).toBe(1);
+      expect(emitter.listenerCount('destroy')).toBe(0);
+    });
+
+    it('updates count when listeners are removed', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('update', callback);
+      expect(emitter.listenerCount('update')).toBe(1);
+
+      emitter.off('update', callback);
+      expect(emitter.listenerCount('update')).toBe(0);
+    });
+  });
+
+  describe('eventNames()', () => {
+    it('returns empty array when no listeners', () => {
+      const emitter = new EventEmitter<TestEvents>();
+
+      expect(emitter.eventNames()).toEqual([]);
+    });
+
+    it('returns array of event names with listeners', () => {
+      const emitter = new EventEmitter<TestEvents>();
+
+      emitter.on('update', vi.fn());
+      emitter.on('change', vi.fn());
+
+      const names = emitter.eventNames();
+      expect(names).toHaveLength(2);
+      expect(names).toContain('update');
+      expect(names).toContain('change');
+    });
+
+    it('removes event name when all listeners removed', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('update', callback);
+      expect(emitter.eventNames()).toContain('update');
+
+      emitter.off('update', callback);
+      expect(emitter.eventNames()).not.toContain('update');
     });
   });
 });

--- a/packages/core/src/EventEmitter.test.ts
+++ b/packages/core/src/EventEmitter.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from './EventEmitter.js';
+
+// Test event types
+interface TestEvents {
+  update: { value: number };
+  change: { oldValue: string; newValue: string };
+  destroy: undefined;
+}
+
+describe('EventEmitter', () => {
+  describe('on()', () => {
+    it('registers callback and calls it on emit', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('update', callback);
+      emitter.emit('update', { value: 42 });
+
+      expect(callback).toHaveBeenCalledWith({ value: 42 });
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports multiple listeners on same event', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      emitter.on('update', callback1);
+      emitter.on('update', callback2);
+      emitter.emit('update', { value: 10 });
+
+      expect(callback1).toHaveBeenCalledWith({ value: 10 });
+      expect(callback2).toHaveBeenCalledWith({ value: 10 });
+    });
+
+    it('returns this for chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const result = emitter.on('update', vi.fn());
+
+      expect(result).toBe(emitter);
+    });
+  });
+
+  describe('off()', () => {
+    it('removes callback so it is not called on emit', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('update', callback);
+      emitter.off('update', callback);
+      emitter.emit('update', { value: 42 });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('only removes the specified callback', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      emitter.on('update', callback1);
+      emitter.on('update', callback2);
+      emitter.off('update', callback1);
+      emitter.emit('update', { value: 42 });
+
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledWith({ value: 42 });
+    });
+
+    it('returns this for chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const result = emitter.off('update', vi.fn());
+
+      expect(result).toBe(emitter);
+    });
+  });
+
+  describe('emit()', () => {
+    it('calls all registered callbacks with correct data', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('change', callback);
+      emitter.emit('change', { oldValue: 'a', newValue: 'b' });
+
+      expect(callback).toHaveBeenCalledWith({ oldValue: 'a', newValue: 'b' });
+    });
+
+    it('handles events with undefined payload (no arguments)', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.on('destroy', callback);
+      emitter.emit('destroy');
+
+      expect(callback).toHaveBeenCalledWith();
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing if no listeners registered', () => {
+      const emitter = new EventEmitter<TestEvents>();
+
+      // Should not throw
+      expect(() => emitter.emit('update', { value: 42 })).not.toThrow();
+    });
+
+    it('returns this for chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const result = emitter.emit('update', { value: 42 });
+
+      expect(result).toBe(emitter);
+    });
+  });
+
+  describe('once()', () => {
+    it('fires callback only once', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.once('update', callback);
+      emitter.emit('update', { value: 1 });
+      emitter.emit('update', { value: 2 });
+      emitter.emit('update', { value: 3 });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({ value: 1 });
+    });
+
+    it('works with undefined payload events', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter.once('destroy', callback);
+      emitter.emit('destroy');
+      emitter.emit('destroy');
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns this for chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const result = emitter.once('update', vi.fn());
+
+      expect(result).toBe(emitter);
+    });
+  });
+
+  describe('removeAllListeners()', () => {
+    it('removes all listeners for a specific event', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const updateCallback = vi.fn();
+      const changeCallback = vi.fn();
+
+      emitter.on('update', updateCallback);
+      emitter.on('change', changeCallback);
+      emitter.removeAllListeners('update');
+
+      emitter.emit('update', { value: 42 });
+      emitter.emit('change', { oldValue: 'a', newValue: 'b' });
+
+      expect(updateCallback).not.toHaveBeenCalled();
+      expect(changeCallback).toHaveBeenCalled();
+    });
+
+    it('removes all listeners for all events when no argument', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const updateCallback = vi.fn();
+      const changeCallback = vi.fn();
+
+      emitter.on('update', updateCallback);
+      emitter.on('change', changeCallback);
+      emitter.removeAllListeners();
+
+      emitter.emit('update', { value: 42 });
+      emitter.emit('change', { oldValue: 'a', newValue: 'b' });
+
+      expect(updateCallback).not.toHaveBeenCalled();
+      expect(changeCallback).not.toHaveBeenCalled();
+    });
+
+    it('returns this for chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const result = emitter.removeAllListeners();
+
+      expect(result).toBe(emitter);
+    });
+  });
+
+  describe('chaining', () => {
+    it('supports full method chaining', () => {
+      const emitter = new EventEmitter<TestEvents>();
+      const callback = vi.fn();
+
+      emitter
+        .on('update', callback)
+        .on('change', vi.fn())
+        .emit('update', { value: 100 })
+        .off('change', vi.fn())
+        .removeAllListeners('change');
+
+      expect(callback).toHaveBeenCalledWith({ value: 100 });
+    });
+  });
+});

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -1,0 +1,85 @@
+/**
+ * Callback type for event handlers
+ * - Events with payload: (data: T) => void
+ * - Events without payload (void/undefined): () => void
+ */
+type EventCallback<T> = T extends void | undefined ? () => void : (data: T) => void;
+
+/**
+ * Generic, type-safe event emitter
+ *
+ * @example
+ * ```typescript
+ * interface MyEvents {
+ *   update: { value: number };
+ *   destroy: undefined;
+ * }
+ *
+ * const emitter = new EventEmitter<MyEvents>();
+ * emitter.on('update', ({ value }) => console.log(value));
+ * emitter.on('destroy', () => console.log('destroyed'));
+ * ```
+ */
+export class EventEmitter<Events extends Record<string, unknown>> {
+  private callbacks: Map<keyof Events, Set<EventCallback<unknown>>> = new Map();
+
+  /**
+   * Register an event listener
+   */
+  on<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
+    const listeners = this.callbacks.get(event);
+
+    if (listeners) {
+      listeners.add(callback as EventCallback<unknown>);
+    } else {
+      this.callbacks.set(event, new Set([callback as EventCallback<unknown>]));
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove an event listener
+   */
+  off<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
+    const listeners = this.callbacks.get(event);
+
+    if (listeners) {
+      listeners.delete(callback as EventCallback<unknown>);
+
+      // Clean up empty sets
+      if (listeners.size === 0) {
+        this.callbacks.delete(event);
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Emit an event to all registered listeners
+   */
+  emit<E extends keyof Events>(
+    event: E,
+    ...args: Events[E] extends void | undefined ? [] : [Events[E]]
+  ): this {
+    // TODO: Implement in step 1.2.3
+    return this;
+  }
+
+  /**
+   * Register an event listener that fires only once
+   */
+  once<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
+    // TODO: Implement in step 1.2.4
+    return this;
+  }
+
+  /**
+   * Remove all listeners for a specific event, or all events if no event specified
+   */
+  removeAllListeners(event?: keyof Events): this {
+    // TODO: Implement in step 1.2.4
+    return this;
+  }
+}

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -3,7 +3,7 @@
  * - Events with payload: (data: T) => void
  * - Events without payload (void/undefined): () => void
  */
-type EventCallback<T> = T extends void | undefined ? () => void : (data: T) => void;
+type EventCallback<T> = T extends undefined ? () => void : (data: T) => void;
 
 /**
  * Generic, type-safe event emitter
@@ -21,7 +21,7 @@ type EventCallback<T> = T extends void | undefined ? () => void : (data: T) => v
  * ```
  */
 export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Record<string, never>> {
-  private callbacks: Map<keyof Events, Set<EventCallback<unknown>>> = new Map();
+  private callbacks = new Map<keyof Events, Set<EventCallback<unknown>>>();
 
   /**
    * Register an event listener
@@ -61,7 +61,7 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
    */
   emit<E extends keyof Events>(
     event: E,
-    ...args: Events[E] extends void | undefined ? [] : [Events[E]]
+    ...args: Events[E] extends undefined ? [] : [Events[E]]
   ): this {
     const listeners = this.callbacks.get(event);
 
@@ -83,7 +83,7 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
    */
   once<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
     const onceWrapper = ((...args: unknown[]) => {
-      this.off(event, onceWrapper as EventCallback<Events[E]>);
+      this.off(event, onceWrapper);
 
       if (args.length > 0) {
         (callback as (data: unknown) => void)(args[0]);

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -1,7 +1,7 @@
 /**
  * Callback type for event handlers
  * - Events with payload: (data: T) => void
- * - Events without payload (void/undefined): () => void
+ * - Events without payload (undefined): () => void
  */
 type EventCallback<T> = T extends undefined ? () => void : (data: T) => void;
 
@@ -21,7 +21,8 @@ type EventCallback<T> = T extends undefined ? () => void : (data: T) => void;
  * ```
  */
 export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Record<string, never>> {
-  private callbacks = new Map<keyof Events, Set<EventCallback<unknown>>>();
+  // Protected so Editor subclass can access if needed
+  protected callbacks = new Map<keyof Events, Set<EventCallback<unknown>>>();
 
   /**
    * Register an event listener
@@ -39,16 +40,22 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
   }
 
   /**
-   * Remove an event listener
+   * Remove an event listener, or all listeners for an event if no callback specified
    */
-  off<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
+  off<E extends keyof Events>(event: E, callback?: EventCallback<Events[E]>): this {
     const listeners = this.callbacks.get(event);
 
     if (listeners) {
-      listeners.delete(callback as EventCallback<unknown>);
+      if (callback) {
+        // Remove specific callback
+        listeners.delete(callback as EventCallback<unknown>);
 
-      // Clean up empty sets
-      if (listeners.size === 0) {
+        // Clean up empty sets
+        if (listeners.size === 0) {
+          this.callbacks.delete(event);
+        }
+      } else {
+        // Remove all listeners for this event (Tiptap compatibility)
         this.callbacks.delete(event);
       }
     }
@@ -58,6 +65,7 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
 
   /**
    * Emit an event to all registered listeners
+   * Uses .call(this) to preserve context for callbacks
    */
   emit<E extends keyof Events>(
     event: E,
@@ -68,9 +76,9 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
     if (listeners) {
       listeners.forEach((callback) => {
         if (args.length > 0) {
-          (callback as (data: unknown) => void)(args[0]);
+          (callback as (data: unknown) => void).call(this, args[0]);
         } else {
-          (callback as () => void)();
+          (callback as () => void).call(this);
         }
       });
     }
@@ -86,9 +94,9 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
       this.off(event, onceWrapper);
 
       if (args.length > 0) {
-        (callback as (data: unknown) => void)(args[0]);
+        (callback as (data: unknown) => void).call(this, args[0]);
       } else {
-        (callback as () => void)();
+        (callback as () => void).call(this);
       }
     }) as EventCallback<Events[E]>;
 
@@ -106,5 +114,19 @@ export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Reco
     }
 
     return this;
+  }
+
+  /**
+   * Get the number of listeners for a specific event
+   */
+  listenerCount(event: keyof Events): number {
+    return this.callbacks.get(event)?.size ?? 0;
+  }
+
+  /**
+   * Get all event names that have listeners
+   */
+  eventNames(): (keyof Events)[] {
+    return Array.from(this.callbacks.keys());
   }
 }

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -63,7 +63,18 @@ export class EventEmitter<Events extends Record<string, unknown>> {
     event: E,
     ...args: Events[E] extends void | undefined ? [] : [Events[E]]
   ): this {
-    // TODO: Implement in step 1.2.3
+    const listeners = this.callbacks.get(event);
+
+    if (listeners) {
+      listeners.forEach((callback) => {
+        if (args.length > 0) {
+          (callback as (data: unknown) => void)(args[0]);
+        } else {
+          (callback as () => void)();
+        }
+      });
+    }
+
     return this;
   }
 
@@ -71,15 +82,29 @@ export class EventEmitter<Events extends Record<string, unknown>> {
    * Register an event listener that fires only once
    */
   once<E extends keyof Events>(event: E, callback: EventCallback<Events[E]>): this {
-    // TODO: Implement in step 1.2.4
-    return this;
+    const onceWrapper = ((...args: unknown[]) => {
+      this.off(event, onceWrapper as EventCallback<Events[E]>);
+
+      if (args.length > 0) {
+        (callback as (data: unknown) => void)(args[0]);
+      } else {
+        (callback as () => void)();
+      }
+    }) as EventCallback<Events[E]>;
+
+    return this.on(event, onceWrapper);
   }
 
   /**
    * Remove all listeners for a specific event, or all events if no event specified
    */
   removeAllListeners(event?: keyof Events): this {
-    // TODO: Implement in step 1.2.4
+    if (event !== undefined) {
+      this.callbacks.delete(event);
+    } else {
+      this.callbacks.clear();
+    }
+
     return this;
   }
 }

--- a/packages/core/src/EventEmitter.ts
+++ b/packages/core/src/EventEmitter.ts
@@ -20,7 +20,7 @@ type EventCallback<T> = T extends void | undefined ? () => void : (data: T) => v
  * emitter.on('destroy', () => console.log('destroyed'));
  * ```
  */
-export class EventEmitter<Events extends Record<string, unknown>> {
+export class EventEmitter<Events extends { [K in keyof Events]: unknown } = Record<string, never>> {
   private callbacks: Map<keyof Events, Set<EventCallback<unknown>>> = new Map();
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,9 @@ export type {
   KeyboardShortcutCommand,
 } from './types/index.js';
 
+// === Core classes ===
+export { EventEmitter } from './EventEmitter.js';
+
 // Editor class will be implemented here
 // export { Editor } from './Editor';
 


### PR DESCRIPTION
## Summary
- Add generic, type-safe `EventEmitter` class for `@domternal/core`
- Implement pub/sub pattern for editor event system
- Unit tests with full coverage

## Features
- Type-safe events with conditional payload types
- Flexible `off()` - remove specific or all listeners
- Utility methods: `listenerCount`, `eventNames`
- Method chaining (fluent API)