### PR TITLE
feat(core): implement Editor class with CommandManager

### DIFF
--- a/packages/core/__tests__/helpers/createTestEditor.ts
+++ b/packages/core/__tests__/helpers/createTestEditor.ts
@@ -8,10 +8,8 @@
  */
 import type { Schema } from 'prosemirror-model';
 import type { EditorOptions } from '../../src/types/index.js';
+import { Editor } from '../../src/Editor.js';
 import { testSchema, emptyDoc, simpleDoc, boldDoc } from './testSchema.js';
-
-// Editor import will be added when Editor class is implemented
-// import { Editor } from '../../src/Editor.js';
 
 /**
  * Options for createTestEditor factory
@@ -44,21 +42,13 @@ export interface CreateTestEditorOptions
  * });
  * ```
  */
-export function createTestEditor(
-  options: CreateTestEditorOptions = {}
-): unknown {
-  // TODO: Implement when Editor class is available
-  // const { schema = testSchema, ...editorOptions } = options;
-  //
-  // return new Editor({
-  //   schema,
-  //   ...editorOptions,
-  // });
+export function createTestEditor(options: CreateTestEditorOptions = {}): Editor {
+  const { schema = testSchema, ...editorOptions } = options;
 
-  throw new Error(
-    'createTestEditor: Editor class not yet implemented. ' +
-      'This helper will be functional after Phase E.'
-  );
+  return new Editor({
+    schema,
+    ...editorOptions,
+  });
 }
 
 /**
@@ -66,7 +56,7 @@ export function createTestEditor(
  */
 export function createEmptyEditor(
   options: Omit<CreateTestEditorOptions, 'content'> = {}
-): unknown {
+): Editor {
   return createTestEditor({
     ...options,
     content: emptyDoc,
@@ -78,7 +68,7 @@ export function createEmptyEditor(
  */
 export function createEditorWithContent(
   options: Omit<CreateTestEditorOptions, 'content'> = {}
-): unknown {
+): Editor {
   return createTestEditor({
     ...options,
     content: simpleDoc,
@@ -87,3 +77,6 @@ export function createEditorWithContent(
 
 // Re-export test data for convenience
 export { testSchema, emptyDoc, simpleDoc, boldDoc } from './testSchema.js';
+
+// Re-export Editor for convenience
+export { Editor } from '../../src/Editor.js';

--- a/packages/core/__tests__/helpers/createTestEditor.ts
+++ b/packages/core/__tests__/helpers/createTestEditor.ts
@@ -1,0 +1,89 @@
+/**
+ * Test factory for creating Editor instances
+ *
+ * Provides convenient defaults for testing:
+ * - Uses testSchema by default
+ * - Creates detached div element (no DOM mounting needed)
+ * - Sensible default options
+ */
+import type { Schema } from 'prosemirror-model';
+import type { EditorOptions } from '../../src/types/index.js';
+import { testSchema, emptyDoc, simpleDoc, boldDoc } from './testSchema.js';
+
+// Editor import will be added when Editor class is implemented
+// import { Editor } from '../../src/Editor.js';
+
+/**
+ * Options for createTestEditor factory
+ */
+export interface CreateTestEditorOptions
+  extends Omit<EditorOptions, 'schema' | 'extensions'> {
+  /**
+   * ProseMirror schema to use
+   * @default testSchema
+   */
+  schema?: Schema;
+}
+
+/**
+ * Creates an Editor instance with test-friendly defaults
+ *
+ * @example
+ * ```ts
+ * // Basic usage - uses testSchema and empty content
+ * const editor = createTestEditor();
+ *
+ * // With specific content
+ * const editor = createTestEditor({
+ *   content: '<p>Hello world</p>',
+ * });
+ *
+ * // With custom schema
+ * const editor = createTestEditor({
+ *   schema: myCustomSchema,
+ * });
+ * ```
+ */
+export function createTestEditor(
+  options: CreateTestEditorOptions = {}
+): unknown {
+  // TODO: Implement when Editor class is available
+  // const { schema = testSchema, ...editorOptions } = options;
+  //
+  // return new Editor({
+  //   schema,
+  //   ...editorOptions,
+  // });
+
+  throw new Error(
+    'createTestEditor: Editor class not yet implemented. ' +
+      'This helper will be functional after Phase E.'
+  );
+}
+
+/**
+ * Creates an Editor with empty content
+ */
+export function createEmptyEditor(
+  options: Omit<CreateTestEditorOptions, 'content'> = {}
+): unknown {
+  return createTestEditor({
+    ...options,
+    content: emptyDoc,
+  });
+}
+
+/**
+ * Creates an Editor with simple text content
+ */
+export function createEditorWithContent(
+  options: Omit<CreateTestEditorOptions, 'content'> = {}
+): unknown {
+  return createTestEditor({
+    ...options,
+    content: simpleDoc,
+  });
+}
+
+// Re-export test data for convenience
+export { testSchema, emptyDoc, simpleDoc, boldDoc } from './testSchema.js';

--- a/packages/core/__tests__/helpers/index.ts
+++ b/packages/core/__tests__/helpers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Test helpers for @domternal/core
+ */
+
+// Schema and test documents
+export {
+  testSchema,
+  emptyDoc,
+  simpleDoc,
+  boldDoc,
+  testHTML,
+} from './testSchema.js';
+
+// Editor factory
+export {
+  createTestEditor,
+  createEmptyEditor,
+  createEditorWithContent,
+  type CreateTestEditorOptions,
+} from './createTestEditor.js';

--- a/packages/core/__tests__/helpers/index.ts
+++ b/packages/core/__tests__/helpers/index.ts
@@ -16,5 +16,6 @@ export {
   createTestEditor,
   createEmptyEditor,
   createEditorWithContent,
+  Editor,
   type CreateTestEditorOptions,
 } from './createTestEditor.js';

--- a/packages/core/__tests__/helpers/testSchema.ts
+++ b/packages/core/__tests__/helpers/testSchema.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal ProseMirror schema for testing
+ *
+ * Contains only essential nodes and marks:
+ * - doc: root node
+ * - paragraph: block node
+ * - text: inline text
+ * - bold: mark for testing mark functionality
+ */
+import { Schema } from 'prosemirror-model';
+
+/**
+ * Minimal test schema with doc, paragraph, text, and bold mark
+ */
+export const testSchema = new Schema({
+  nodes: {
+    doc: {
+      content: 'block+',
+    },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      parseDOM: [{ tag: 'p' }],
+      toDOM() {
+        return ['p', 0];
+      },
+    },
+    text: {
+      group: 'inline',
+    },
+  },
+  marks: {
+    bold: {
+      parseDOM: [
+        { tag: 'strong' },
+        { tag: 'b' },
+        {
+          style: 'font-weight',
+          getAttrs: (value) =>
+            /^(bold|[5-9]\d{2,})$/.test(value as string) && null,
+        },
+      ],
+      toDOM() {
+        return ['strong', 0];
+      },
+    },
+  },
+});
+
+/**
+ * Empty document for testing
+ */
+export const emptyDoc = {
+  type: 'doc',
+  content: [{ type: 'paragraph' }],
+};
+
+/**
+ * Simple document with text for testing
+ */
+export const simpleDoc = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello world' }],
+    },
+  ],
+};
+
+/**
+ * Document with bold text for testing marks
+ */
+export const boldDoc = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: 'Hello ' },
+        {
+          type: 'text',
+          text: 'bold',
+          marks: [{ type: 'bold' }],
+        },
+        { type: 'text', text: ' world' },
+      ],
+    },
+  ],
+};
+
+/**
+ * HTML content equivalents for testing HTML parsing
+ */
+export const testHTML = {
+  empty: '<p></p>',
+  simple: '<p>Hello world</p>',
+  bold: '<p>Hello <strong>bold</strong> world</p>',
+  multiParagraph: '<p>First paragraph</p><p>Second paragraph</p>',
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "prosemirror-view": "^1.41.5"
   },
   "devDependencies": {
+    "jsdom": "^27.4.0",
     "tsup": "^8.5.1",
     "typescript": "~5.9.3"
   },

--- a/packages/core/src/CommandManager.test.ts
+++ b/packages/core/src/CommandManager.test.ts
@@ -19,8 +19,16 @@ const testSchema = new Schema({
   },
 });
 
+// Mock editor interface for testing
+interface MockEditor {
+  view: EditorView;
+  isDestroyed: boolean;
+  emit: () => void;
+  cleanup: () => void;
+}
+
 // Create mock editor with real ProseMirror view
-function createMockEditor(content?: string) {
+function createMockEditor(content?: string): MockEditor {
   const element = document.createElement('div');
   document.body.appendChild(element);
 
@@ -36,7 +44,9 @@ function createMockEditor(content?: string) {
   return {
     view,
     isDestroyed: false,
-    emit: () => {},
+    emit: (): void => {
+      // No-op for tests
+    },
     cleanup: () => {
       view.destroy();
       element.remove();

--- a/packages/core/src/CommandManager.test.ts
+++ b/packages/core/src/CommandManager.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { CommandManager } from './CommandManager.js';
+
+// Test schema
+const testSchema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: {
+      content: 'inline*',
+      toDOM() {
+        return ['p', 0];
+      },
+      parseDOM: [{ tag: 'p' }],
+    },
+    text: { group: 'inline' },
+  },
+});
+
+// Create mock editor with real ProseMirror view
+function createMockEditor(content?: string) {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+
+  const doc = content
+    ? testSchema.node('doc', null, [
+        testSchema.node('paragraph', null, [testSchema.text(content)]),
+      ])
+    : testSchema.node('doc', null, [testSchema.node('paragraph')]);
+
+  const state = EditorState.create({ schema: testSchema, doc });
+  const view = new EditorView(element, { state });
+
+  return {
+    view,
+    isDestroyed: false,
+    emit: () => {},
+    cleanup: () => {
+      view.destroy();
+      element.remove();
+    },
+  };
+}
+
+describe('CommandManager', () => {
+  let mockEditor: ReturnType<typeof createMockEditor>;
+  let manager: CommandManager;
+
+  beforeEach(() => {
+    mockEditor = createMockEditor('Hello world');
+    manager = new CommandManager(mockEditor);
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('focus', () => {
+    it('returns true when focusing connected editor', () => {
+      const result = manager.focus();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.focus();
+      expect(result).toBe(false);
+    });
+
+    it('returns false when view is not connected to DOM', () => {
+      mockEditor.view.dom.remove();
+      const result = manager.focus();
+      expect(result).toBe(false);
+    });
+
+    it('focuses at start position', () => {
+      manager.focus('start');
+      const { from } = mockEditor.view.state.selection;
+      expect(from).toBe(1);
+    });
+
+    it('focuses at end position', () => {
+      manager.focus('end');
+      const { from } = mockEditor.view.state.selection;
+      // End position is doc.content.size - 1
+      expect(from).toBeGreaterThan(1);
+    });
+
+    it('focuses with true (same as end)', () => {
+      manager.focus(true);
+      const { from } = mockEditor.view.state.selection;
+      expect(from).toBeGreaterThan(1);
+    });
+
+    it('selects all with "all" position', () => {
+      manager.focus('all');
+      const { from, to } = mockEditor.view.state.selection;
+      expect(from).toBe(0);
+      expect(to).toBe(mockEditor.view.state.doc.content.size);
+    });
+
+    it('focuses at numeric position', () => {
+      manager.focus(3);
+      const { from } = mockEditor.view.state.selection;
+      expect(from).toBe(3);
+    });
+  });
+
+  describe('blur', () => {
+    it('returns true when blurring', () => {
+      manager.focus();
+      const result = manager.blur();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.blur();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setContent', () => {
+    it('sets content from HTML string', () => {
+      const result = manager.setContent('<p>New content</p>');
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toBe('New content');
+    });
+
+    it('sets content from JSON object', () => {
+      const result = manager.setContent({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'JSON content' }],
+          },
+        ],
+      });
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toBe('JSON content');
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.setContent('<p>Test</p>');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearContent', () => {
+    it('clears the editor content', () => {
+      const result = manager.clearContent();
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toBe('');
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.clearContent();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('insertText', () => {
+    it('inserts text at current selection', () => {
+      manager.focus('start');
+      const result = manager.insertText('Inserted ');
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toContain('Inserted');
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.insertText('Test');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('deleteSelection', () => {
+    it('deletes selected text', () => {
+      manager.focus('all');
+      const result = manager.deleteSelection();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when selection is empty', () => {
+      manager.focus('start');
+      const result = manager.deleteSelection();
+      expect(result).toBe(false);
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.deleteSelection();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectAll', () => {
+    it('selects all content', () => {
+      const result = manager.selectAll();
+      expect(result).toBe(true);
+
+      const { from, to } = mockEditor.view.state.selection;
+      expect(from).toBe(0);
+      expect(to).toBe(mockEditor.view.state.doc.content.size);
+    });
+
+    it('returns false when editor is destroyed', () => {
+      mockEditor.isDestroyed = true;
+      const result = manager.selectAll();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('chain', () => {
+    it('throws error in Step 1.3', () => {
+      expect(() => manager.chain()).toThrow('chain() is not available in Step 1.3');
+    });
+  });
+
+  describe('can', () => {
+    it('throws error in Step 1.3', () => {
+      expect(() => manager.can()).toThrow('can() is not available in Step 1.3');
+    });
+  });
+});

--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -1,0 +1,325 @@
+/**
+ * CommandManager - Manages editor commands
+ *
+ * Step 1.3: Minimal version with 7 essential commands
+ * Step 2: Will be expanded with chain(), can(), and dynamic commands from extensions
+ */
+import { TextSelection, AllSelection } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+import type { FocusPosition, Content } from './types/index.js';
+import { createDocument } from './helpers/index.js';
+
+/**
+ * Options for setContent command
+ */
+export interface SetContentOptions {
+  /**
+   * Emit update event after setting content
+   * @default true
+   */
+  emitUpdate?: boolean;
+
+  /**
+   * Parse options for HTML content
+   */
+  parseOptions?: Record<string, unknown>;
+}
+
+/**
+ * Options for clearContent command
+ */
+export interface ClearContentOptions {
+  /**
+   * Emit update event after clearing content
+   * @default true
+   */
+  emitUpdate?: boolean;
+}
+
+/**
+ * Editor interface for CommandManager
+ * Forward declaration to avoid circular dependency
+ */
+export interface CommandManagerEditor {
+  view: EditorView;
+  readonly isDestroyed: boolean;
+  emit(event: string, props?: unknown): void;
+}
+
+/**
+ * Resolves focus position to a numeric position in the document
+ */
+function resolveFocusPosition(
+  view: EditorView,
+  position: FocusPosition
+): number | null {
+  const { doc } = view.state;
+
+  if (position === null || position === false) {
+    return null;
+  }
+
+  if (position === true || position === 'end') {
+    // End of document
+    return doc.content.size - 1;
+  }
+
+  if (position === 'start') {
+    // Start of document (after opening tag of first node)
+    return 1;
+  }
+
+  if (position === 'all') {
+    // Select all - handled separately
+    return null;
+  }
+
+  if (typeof position === 'number') {
+    // Clamp to valid range
+    return Math.max(0, Math.min(position, doc.content.size));
+  }
+
+  return null;
+}
+
+/**
+ * Manages editor commands
+ *
+ * In Step 1.3, provides 7 essential commands:
+ * - focus, blur, setContent, clearContent, insertText, deleteSelection, selectAll
+ *
+ * In Step 2, will be expanded with:
+ * - chain() for chainable commands
+ * - can() for checking command availability
+ * - Dynamic commands from extensions
+ */
+export class CommandManager {
+  private editor: CommandManagerEditor;
+
+  constructor(editor: CommandManagerEditor) {
+    this.editor = editor;
+  }
+
+  /**
+   * Focuses the editor at the specified position
+   *
+   * @param position - Where to place the cursor
+   *   - true/'end': End of document
+   *   - 'start': Start of document
+   *   - 'all': Select all content
+   *   - number: Specific position
+   *   - null/false: Just focus without changing selection
+   * @returns true if focus was successful
+   */
+  focus(position: FocusPosition = null): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { view } = this.editor;
+
+    // Check if view is attached to DOM
+    if (!view.dom.isConnected) {
+      // Detached view - can't focus
+      return false;
+    }
+
+    // Focus the editor
+    view.focus();
+
+    // Handle 'all' position - select all content
+    if (position === 'all') {
+      const { tr } = view.state;
+      const selection = new AllSelection(view.state.doc);
+      view.dispatch(tr.setSelection(selection));
+      return true;
+    }
+
+    // Resolve position to cursor location
+    const resolvedPos = resolveFocusPosition(view, position);
+
+    if (resolvedPos !== null) {
+      const { tr, doc } = view.state;
+      const $pos = doc.resolve(resolvedPos);
+      const selection = TextSelection.near($pos);
+      view.dispatch(tr.setSelection(selection));
+    }
+
+    return true;
+  }
+
+  /**
+   * Removes focus from the editor
+   *
+   * @returns true if blur was successful
+   */
+  blur(): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { view } = this.editor;
+    const element = view.dom as HTMLElement;
+
+    element.blur();
+
+    return true;
+  }
+
+  /**
+   * Sets the editor content
+   *
+   * @param content - JSON or HTML content
+   * @param options - Options for setting content
+   * @returns true if content was set successfully
+   */
+  setContent(content: Content, options: SetContentOptions = {}): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { emitUpdate = true, parseOptions } = options;
+    const { view } = this.editor;
+    const { schema } = view.state;
+
+    // Parse content into document
+    const doc = createDocument(content, schema, { parseOptions });
+
+    // Create transaction that replaces entire document
+    const { tr } = view.state;
+    tr.replaceWith(0, view.state.doc.content.size, doc.content);
+
+    // Mark transaction to potentially skip update event
+    if (!emitUpdate) {
+      tr.setMeta('addToHistory', false);
+      tr.setMeta('skipUpdate', true);
+    }
+
+    view.dispatch(tr);
+
+    return true;
+  }
+
+  /**
+   * Clears the editor content to empty state
+   *
+   * @param options - Options for clearing content
+   * @returns true if content was cleared successfully
+   */
+  clearContent(options: ClearContentOptions = {}): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { emitUpdate = true } = options;
+    const { view } = this.editor;
+    const { schema } = view.state;
+
+    // Create empty document
+    const doc = createDocument(null, schema);
+
+    // Create transaction that replaces entire document
+    const { tr } = view.state;
+    tr.replaceWith(0, view.state.doc.content.size, doc.content);
+
+    if (!emitUpdate) {
+      tr.setMeta('addToHistory', false);
+      tr.setMeta('skipUpdate', true);
+    }
+
+    view.dispatch(tr);
+
+    return true;
+  }
+
+  /**
+   * Inserts text at the current selection
+   *
+   * @param text - Text to insert
+   * @returns true if text was inserted successfully
+   */
+  insertText(text: string): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { view } = this.editor;
+    const { tr, selection } = view.state;
+
+    // Insert text at current selection
+    tr.insertText(text, selection.from, selection.to);
+    view.dispatch(tr);
+
+    return true;
+  }
+
+  /**
+   * Deletes the current selection
+   *
+   * @returns true if selection was deleted
+   */
+  deleteSelection(): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { view } = this.editor;
+    const { tr, selection } = view.state;
+
+    // Only delete if there's a selection range
+    if (selection.empty) {
+      return false;
+    }
+
+    tr.deleteSelection();
+    view.dispatch(tr);
+
+    return true;
+  }
+
+  /**
+   * Selects all content in the editor
+   *
+   * @returns true if selection was successful
+   */
+  selectAll(): boolean {
+    if (this.editor.isDestroyed) {
+      return false;
+    }
+
+    const { view } = this.editor;
+    const { tr } = view.state;
+
+    const selection = new AllSelection(view.state.doc);
+    tr.setSelection(selection);
+    view.dispatch(tr);
+
+    return true;
+  }
+
+  /**
+   * Creates a chainable command builder
+   *
+   * Step 1.3: Throws error - not yet implemented
+   * Step 2: Will return ChainBuilder for chainable commands
+   */
+  chain(): never {
+    throw new Error(
+      'chain() is not available in Step 1.3. ' +
+        'Chainable commands will be implemented in Step 2 with the extension system.'
+    );
+  }
+
+  /**
+   * Creates a command availability checker
+   *
+   * Step 1.3: Throws error - not yet implemented
+   * Step 2: Will return CanChecker for dry-run command checks
+   */
+  can(): never {
+    throw new Error(
+      'can() is not available in Step 1.3. ' +
+        'Command availability checks will be implemented in Step 2 with the extension system.'
+    );
+  }
+}

--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -159,7 +159,7 @@ export class CommandManager {
     }
 
     const { view } = this.editor;
-    const element = view.dom as HTMLElement;
+    const element = view.dom;
 
     element.blur();
 

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { Editor } from './Editor.js';
+
+// Test schema
+const testSchema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: {
+      content: 'inline*',
+      toDOM() {
+        return ['p', 0];
+      },
+      parseDOM: [{ tag: 'p' }],
+    },
+    text: { group: 'inline' },
+  },
+});
+
+describe('Editor', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    if (editor && !editor.isDestroyed) {
+      editor.destroy();
+    }
+  });
+
+  describe('constructor', () => {
+    it('creates editor with schema', () => {
+      editor = new Editor({ schema: testSchema });
+
+      expect(editor).toBeInstanceOf(Editor);
+      expect(editor.schema).toBe(testSchema);
+    });
+
+    it('throws error without schema', () => {
+      expect(() => new Editor({} as any)).toThrow('Editor requires a schema');
+    });
+
+    it('creates editor with content', () => {
+      editor = new Editor({
+        schema: testSchema,
+        content: '<p>Hello world</p>',
+      });
+
+      expect(editor.getText()).toBe('Hello world');
+    });
+
+    it('creates editor with JSON content', () => {
+      editor = new Editor({
+        schema: testSchema,
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'JSON content' }],
+            },
+          ],
+        },
+      });
+
+      expect(editor.getText()).toBe('JSON content');
+    });
+
+    it('creates editor with element', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      editor = new Editor({
+        schema: testSchema,
+        element,
+      });
+
+      expect(editor.view.dom.parentElement).toBe(element);
+      element.remove();
+    });
+
+    it('creates detached editor without element', () => {
+      editor = new Editor({ schema: testSchema });
+
+      expect(editor.view.dom).toBeDefined();
+    });
+
+    it('sets editable to true by default', () => {
+      editor = new Editor({ schema: testSchema });
+
+      expect(editor.isEditable).toBe(true);
+    });
+
+    it('respects editable option', () => {
+      editor = new Editor({
+        schema: testSchema,
+        editable: false,
+      });
+
+      expect(editor.isEditable).toBe(false);
+    });
+  });
+
+  describe('getters', () => {
+    beforeEach(() => {
+      editor = new Editor({
+        schema: testSchema,
+        content: '<p>Test content</p>',
+      });
+    });
+
+    it('state returns EditorState', () => {
+      expect(editor.state).toBeDefined();
+      expect(editor.state.doc).toBeDefined();
+    });
+
+    it('schema returns the schema', () => {
+      expect(editor.schema).toBe(testSchema);
+    });
+
+    it('isEditable returns editable state', () => {
+      expect(editor.isEditable).toBe(true);
+    });
+
+    it('isEmpty returns false for content', () => {
+      expect(editor.isEmpty).toBe(false);
+    });
+
+    it('isEmpty returns true for empty content', () => {
+      editor.clearContent();
+      expect(editor.isEmpty).toBe(true);
+    });
+
+    it('isDestroyed returns false initially', () => {
+      expect(editor.isDestroyed).toBe(false);
+    });
+
+    it('isDestroyed returns true after destroy', () => {
+      editor.destroy();
+      expect(editor.isDestroyed).toBe(true);
+    });
+
+    it('commands returns CommandManager', () => {
+      expect(editor.commands).toBeDefined();
+      expect(typeof editor.commands.focus).toBe('function');
+    });
+  });
+
+  describe('content methods', () => {
+    beforeEach(() => {
+      editor = new Editor({
+        schema: testSchema,
+        content: '<p>Initial content</p>',
+      });
+    });
+
+    describe('getJSON', () => {
+      it('returns document as JSON', () => {
+        const json = editor.getJSON();
+
+        expect(json.type).toBe('doc');
+        expect(json.content).toBeDefined();
+      });
+    });
+
+    describe('getHTML', () => {
+      it('returns document as HTML', () => {
+        const html = editor.getHTML();
+
+        expect(html).toContain('<p>');
+        expect(html).toContain('Initial content');
+      });
+    });
+
+    describe('getText', () => {
+      it('returns plain text', () => {
+        const text = editor.getText();
+
+        expect(text).toBe('Initial content');
+      });
+
+      it('uses custom block separator', () => {
+        editor.setContent('<p>Line 1</p><p>Line 2</p>');
+        const text = editor.getText({ blockSeparator: ' | ' });
+
+        expect(text).toBe('Line 1 | Line 2');
+      });
+    });
+
+    describe('setContent', () => {
+      it('sets content and returns this', () => {
+        const result = editor.setContent('<p>New content</p>');
+
+        expect(result).toBe(editor);
+        expect(editor.getText()).toBe('New content');
+      });
+    });
+
+    describe('clearContent', () => {
+      it('clears content and returns this', () => {
+        const result = editor.clearContent();
+
+        expect(result).toBe(editor);
+        expect(editor.isEmpty).toBe(true);
+      });
+    });
+  });
+
+  describe('lifecycle methods', () => {
+    beforeEach(() => {
+      editor = new Editor({ schema: testSchema });
+    });
+
+    describe('setEditable', () => {
+      it('sets editable state and returns this', () => {
+        const result = editor.setEditable(false);
+
+        expect(result).toBe(editor);
+        expect(editor.isEditable).toBe(false);
+      });
+
+      it('can toggle editable state', () => {
+        editor.setEditable(false);
+        expect(editor.isEditable).toBe(false);
+
+        editor.setEditable(true);
+        expect(editor.isEditable).toBe(true);
+      });
+    });
+
+    describe('focus', () => {
+      it('returns this for chaining', () => {
+        const element = document.createElement('div');
+        document.body.appendChild(element);
+
+        const ed = new Editor({ schema: testSchema, element });
+        const result = ed.focus();
+
+        expect(result).toBe(ed);
+        ed.destroy();
+        element.remove();
+      });
+    });
+
+    describe('blur', () => {
+      it('returns this for chaining', () => {
+        const result = editor.blur();
+
+        expect(result).toBe(editor);
+      });
+    });
+
+    describe('destroy', () => {
+      it('destroys the editor', () => {
+        editor.destroy();
+
+        expect(editor.isDestroyed).toBe(true);
+      });
+
+      it('can be called multiple times safely', () => {
+        editor.destroy();
+        expect(() => editor.destroy()).not.toThrow();
+      });
+    });
+  });
+
+  describe('events', () => {
+    it('emits create event', () => {
+      const onCreate = vi.fn();
+
+      editor = new Editor({
+        schema: testSchema,
+        onCreate,
+      });
+
+      expect(onCreate).toHaveBeenCalledTimes(1);
+      expect(onCreate).toHaveBeenCalledWith({ editor });
+    });
+
+    it('emits beforeCreate event', () => {
+      const onBeforeCreate = vi.fn();
+
+      editor = new Editor({
+        schema: testSchema,
+        onBeforeCreate,
+      });
+
+      expect(onBeforeCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits destroy event', () => {
+      const onDestroy = vi.fn();
+
+      editor = new Editor({
+        schema: testSchema,
+        onDestroy,
+      });
+
+      editor.destroy();
+
+      expect(onDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits update event on content change', () => {
+      const onUpdate = vi.fn();
+
+      editor = new Editor({
+        schema: testSchema,
+        onUpdate,
+      });
+
+      editor.setContent('<p>New content</p>');
+
+      expect(onUpdate).toHaveBeenCalled();
+    });
+
+    it('emits transaction event', () => {
+      const onTransaction = vi.fn();
+
+      editor = new Editor({
+        schema: testSchema,
+        onTransaction,
+      });
+
+      editor.setContent('<p>New content</p>');
+
+      expect(onTransaction).toHaveBeenCalled();
+    });
+
+    it('supports addEventListener style', () => {
+      editor = new Editor({ schema: testSchema });
+
+      const handler = vi.fn();
+      editor.on('update', handler);
+
+      editor.setContent('<p>New content</p>');
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('supports removeEventListener style', () => {
+      editor = new Editor({ schema: testSchema });
+
+      const handler = vi.fn();
+      editor.on('update', handler);
+      editor.off('update', handler);
+
+      editor.setContent('<p>New content</p>');
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('view', () => {
+    it('exposes ProseMirror view', () => {
+      editor = new Editor({ schema: testSchema });
+
+      expect(editor.view).toBeDefined();
+      expect(editor.view.dom).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Schema } from 'prosemirror-model';
 import { Editor } from './Editor.js';
+import type { EditorOptions } from './types/index.js';
 
 // Test schema
 const testSchema = new Schema({
@@ -21,7 +22,7 @@ describe('Editor', () => {
   let editor: Editor;
 
   afterEach(() => {
-    if (editor && !editor.isDestroyed) {
+    if (!editor.isDestroyed) {
       editor.destroy();
     }
   });
@@ -35,7 +36,10 @@ describe('Editor', () => {
     });
 
     it('throws error without schema', () => {
-      expect(() => new Editor({} as any)).toThrow('Editor requires a schema');
+      const invalidOptions = {} as Omit<EditorOptions, 'schema'>;
+      expect(() => new Editor(invalidOptions)).toThrow(
+        'Editor requires a schema'
+      );
     });
 
     it('creates editor with content', () => {
@@ -156,8 +160,8 @@ describe('Editor', () => {
       it('returns document as JSON', () => {
         const json = editor.getJSON();
 
-        expect(json.type).toBe('doc');
-        expect(json.content).toBeDefined();
+        expect(json['type']).toBe('doc');
+        expect(json['content']).toBeDefined();
       });
     });
 
@@ -257,7 +261,7 @@ describe('Editor', () => {
 
       it('can be called multiple times safely', () => {
         editor.destroy();
-        expect(() => editor.destroy()).not.toThrow();
+        expect(() => { editor.destroy(); }).not.toThrow();
       });
     });
   });

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -1,0 +1,400 @@
+/**
+ * Editor - Main editor class wrapping ProseMirror
+ *
+ * Step 1.3: Basic editor with schema-based initialization
+ * Step 2: Will support extensions for schema building
+ */
+import { EditorState, Transaction } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { DOMSerializer } from 'prosemirror-model';
+import type { Schema, Node as PMNode } from 'prosemirror-model';
+
+import { EventEmitter } from './EventEmitter.js';
+import { ExtensionManager } from './ExtensionManager.js';
+import { CommandManager, type SetContentOptions } from './CommandManager.js';
+import { createDocument, isDocumentEmpty } from './helpers/index.js';
+import type {
+  EditorOptions,
+  EditorEvents,
+  Content,
+  FocusPosition,
+} from './types/index.js';
+
+/**
+ * Main editor class
+ *
+ * Wraps ProseMirror's EditorView and EditorState with a cleaner API.
+ *
+ * @example
+ * ```ts
+ * import { Editor } from '@domternal/core';
+ * import { Schema } from 'prosemirror-model';
+ *
+ * const schema = new Schema({
+ *   nodes: { doc: { content: 'paragraph+' }, paragraph: { content: 'text*' }, text: {} }
+ * });
+ *
+ * const editor = new Editor({
+ *   schema,
+ *   element: document.getElementById('editor'),
+ *   content: '<p>Hello world</p>',
+ * });
+ *
+ * // Get content
+ * const json = editor.getJSON();
+ * const html = editor.getHTML();
+ *
+ * // Set content
+ * editor.commands.setContent('<p>New content</p>');
+ *
+ * // Cleanup
+ * editor.destroy();
+ * ```
+ */
+export class Editor extends EventEmitter<EditorEvents> {
+  /**
+   * Editor configuration options
+   */
+  private options: EditorOptions;
+
+  /**
+   * Manages extensions and schema
+   */
+  private extensionManager!: ExtensionManager;
+
+  /**
+   * Manages commands
+   */
+  private commandManager!: CommandManager;
+
+  /**
+   * ProseMirror EditorView instance
+   */
+  public view!: EditorView;
+
+  /**
+   * Whether the editor has been destroyed
+   */
+  private _isDestroyed = false;
+
+  /**
+   * Creates a new Editor instance
+   *
+   * @param options - Editor configuration
+   * @throws Error if running in SSR environment (no window)
+   * @throws Error if schema is not provided
+   */
+  constructor(options: EditorOptions) {
+    super();
+
+    // SSR Guard - Editor requires browser environment
+    if (typeof window === 'undefined') {
+      throw new Error(
+        'Editor requires a browser environment. ' +
+          'For server-side rendering, use generateHTML() and generateJSON() helpers instead.'
+      );
+    }
+
+    // Validate required options for Step 1.3
+    if (!options.schema) {
+      throw new Error(
+        'Editor requires a schema in Step 1.3. ' +
+          'In Step 2, you can provide extensions instead and the schema will be built automatically.'
+      );
+    }
+
+    this.options = {
+      editable: true,
+      ...options,
+    };
+
+    this.createEditor();
+  }
+
+  // === Getters ===
+
+  /**
+   * Gets the current EditorState
+   */
+  get state(): EditorState {
+    return this.view.state;
+  }
+
+  /**
+   * Gets the ProseMirror schema
+   */
+  get schema(): Schema {
+    return this.extensionManager.schema;
+  }
+
+  /**
+   * Checks if the editor is editable
+   */
+  get isEditable(): boolean {
+    return this.view.editable;
+  }
+
+  /**
+   * Checks if the editor content is empty
+   */
+  get isEmpty(): boolean {
+    return isDocumentEmpty(this.state.doc);
+  }
+
+  /**
+   * Checks if the editor has focus
+   */
+  get isFocused(): boolean {
+    return this.view.hasFocus();
+  }
+
+  /**
+   * Checks if the editor has been destroyed
+   */
+  get isDestroyed(): boolean {
+    return this._isDestroyed;
+  }
+
+  /**
+   * Gets the command manager for executing commands
+   */
+  get commands(): CommandManager {
+    return this.commandManager;
+  }
+
+  // === Content Methods ===
+
+  /**
+   * Gets the document content as JSON
+   */
+  getJSON(): Record<string, unknown> {
+    return this.state.doc.toJSON() as Record<string, unknown>;
+  }
+
+  /**
+   * Gets the document content as HTML string
+   */
+  getHTML(): string {
+    const fragment = DOMSerializer.fromSchema(this.schema).serializeFragment(
+      this.state.doc.content
+    );
+
+    const div = document.createElement('div');
+    div.appendChild(fragment);
+
+    return div.innerHTML;
+  }
+
+  /**
+   * Gets the document content as plain text
+   *
+   * @param options - Options for text extraction
+   * @param options.blockSeparator - String to insert between blocks (default: '\n\n')
+   */
+  getText(options: { blockSeparator?: string } = {}): string {
+    const { blockSeparator = '\n\n' } = options;
+    return this.state.doc.textBetween(
+      0,
+      this.state.doc.content.size,
+      blockSeparator
+    );
+  }
+
+  /**
+   * Sets the editor content
+   *
+   * @param content - JSON or HTML content
+   * @param emitUpdate - Whether to emit update event (default: true)
+   */
+  setContent(content: Content, emitUpdate = true): this {
+    this.commandManager.setContent(content, { emitUpdate });
+    return this;
+  }
+
+  /**
+   * Clears the editor content
+   *
+   * @param emitUpdate - Whether to emit update event (default: true)
+   */
+  clearContent(emitUpdate = true): this {
+    this.commandManager.clearContent({ emitUpdate });
+    return this;
+  }
+
+  // === Lifecycle Methods ===
+
+  /**
+   * Sets whether the editor is editable
+   *
+   * @param editable - Whether the editor should be editable
+   */
+  setEditable(editable: boolean): this {
+    this.options.editable = editable;
+
+    // ProseMirror rechecks editable on each transaction
+    // Dispatch empty transaction to trigger re-evaluation
+    this.view.dispatch(this.state.tr);
+
+    return this;
+  }
+
+  /**
+   * Focuses the editor
+   *
+   * @param position - Where to place cursor (default: null = just focus)
+   */
+  focus(position: FocusPosition = null): this {
+    this.commandManager.focus(position);
+    return this;
+  }
+
+  /**
+   * Removes focus from the editor
+   */
+  blur(): this {
+    this.commandManager.blur();
+    return this;
+  }
+
+  /**
+   * Destroys the editor and cleans up resources
+   *
+   * After calling destroy(), the editor instance should not be used.
+   */
+  destroy(): void {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this.emit('destroy');
+    this.options.onDestroy?.();
+
+    // Destroy ProseMirror view
+    this.view.destroy();
+
+    // Destroy managers
+    this.extensionManager.destroy();
+
+    // Clear all event listeners
+    this.removeAllListeners();
+
+    this._isDestroyed = true;
+  }
+
+  // === Private Methods ===
+
+  /**
+   * Creates the editor instance
+   */
+  private createEditor(): void {
+    // 1. Emit beforeCreate - extensions can modify options in Step 2
+    this.emit('beforeCreate', { editor: this });
+    this.options.onBeforeCreate?.({ editor: this });
+
+    // 2. Initialize ExtensionManager with schema
+    this.extensionManager = new ExtensionManager(this.options.schema!, this);
+    this.extensionManager.validateSchema();
+
+    // 3. Create initial document from content
+    const doc = createDocument(
+      this.options.content ?? null,
+      this.extensionManager.schema
+    );
+
+    // 4. Get plugins from extensions (empty in Step 1.3)
+    const plugins = this.extensionManager.plugins;
+
+    // 5. Create EditorState
+    const state = EditorState.create({
+      schema: this.extensionManager.schema,
+      doc,
+      plugins,
+    });
+
+    // 6. Resolve element - use provided or create detached div
+    const element = this.options.element ?? document.createElement('div');
+
+    // 7. Create EditorView
+    this.view = new EditorView(element, {
+      state,
+      dispatchTransaction: this.dispatchTransaction.bind(this),
+      editable: () => this.options.editable ?? true,
+      // Handle focus/blur events
+      handleDOMEvents: {
+        focus: (view, event) => {
+          this.emit('focus', { editor: this, event: event as FocusEvent });
+          this.options.onFocus?.({ editor: this, event: event as FocusEvent });
+          return false;
+        },
+        blur: (view, event) => {
+          this.emit('blur', { editor: this, event: event as FocusEvent });
+          this.options.onBlur?.({ editor: this, event: event as FocusEvent });
+          return false;
+        },
+      },
+    });
+
+    // 8. Emit mount event - view is now attached to DOM element
+    this.emit('mount', { editor: this, view: this.view });
+    this.options.onMount?.({ editor: this, view: this.view });
+
+    // 9. Initialize CommandManager
+    this.commandManager = new CommandManager(this);
+
+    // 10. Handle autofocus
+    if (this.options.autofocus) {
+      // Use setTimeout to ensure DOM is ready
+      setTimeout(() => {
+        this.commandManager.focus(this.options.autofocus!);
+      }, 0);
+    }
+
+    // 11. Emit create event
+    this.emit('create', { editor: this });
+    this.options.onCreate?.({ editor: this });
+  }
+
+  /**
+   * Handles ProseMirror transactions
+   */
+  private dispatchTransaction(transaction: Transaction): void {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    // 1. Apply transaction to state
+    const newState = this.view.state.apply(transaction);
+
+    // 2. Update view
+    this.view.updateState(newState);
+
+    // 3. Emit transaction event (fires for EVERY transaction)
+    this.emit('transaction', { editor: this, transaction });
+    this.options.onTransaction?.({ editor: this, transaction });
+
+    // 4. Check if we should skip update event
+    const skipUpdate = transaction.getMeta('skipUpdate');
+
+    // 5. Emit selectionUpdate if selection changed (without doc change)
+    if (!transaction.docChanged && transaction.selectionSet) {
+      this.emit('selectionUpdate', { editor: this, transaction });
+      this.options.onSelectionUpdate?.({ editor: this, transaction });
+    }
+
+    // 6. Emit update if document changed
+    if (transaction.docChanged && !skipUpdate) {
+      this.emit('update', { editor: this, transaction });
+      this.options.onUpdate?.({ editor: this, transaction });
+    }
+  }
+
+  /**
+   * Emit method - needed for CommandManager interface
+   */
+  emit<E extends keyof EditorEvents>(
+    event: E,
+    ...args: EditorEvents[E] extends undefined ? [] : [EditorEvents[E]]
+  ): this {
+    return super.emit(event, ...args);
+  }
+}

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -7,11 +7,11 @@
 import { EditorState, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { DOMSerializer } from 'prosemirror-model';
-import type { Schema, Node as PMNode } from 'prosemirror-model';
+import type { Schema } from 'prosemirror-model';
 
 import { EventEmitter } from './EventEmitter.js';
 import { ExtensionManager } from './ExtensionManager.js';
-import { CommandManager, type SetContentOptions } from './CommandManager.js';
+import { CommandManager } from './CommandManager.js';
 import { createDocument, isDocumentEmpty } from './helpers/index.js';
 import type {
   EditorOptions,
@@ -321,12 +321,12 @@ export class Editor extends EventEmitter<EditorEvents> {
       editable: () => this.options.editable ?? true,
       // Handle focus/blur events
       handleDOMEvents: {
-        focus: (view, event) => {
+        focus: (_view, event) => {
           this.emit('focus', { editor: this, event: event as FocusEvent });
           this.options.onFocus?.({ editor: this, event: event as FocusEvent });
           return false;
         },
-        blur: (view, event) => {
+        blur: (_view, event) => {
           this.emit('blur', { editor: this, event: event as FocusEvent });
           this.options.onBlur?.({ editor: this, event: event as FocusEvent });
           return false;
@@ -391,7 +391,7 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Emit method - needed for CommandManager interface
    */
-  emit<E extends keyof EditorEvents>(
+  override emit<E extends keyof EditorEvents>(
     event: E,
     ...args: EditorEvents[E] extends undefined ? [] : [EditorEvents[E]]
   ): this {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -4,7 +4,8 @@
  * Step 1.3: Basic editor with schema-based initialization
  * Step 2: Will support extensions for schema building
  */
-import { EditorState, Transaction } from 'prosemirror-state';
+import type { Transaction } from 'prosemirror-state';
+import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { DOMSerializer } from 'prosemirror-model';
 import type { Schema } from 'prosemirror-model';
@@ -291,7 +292,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.emit('beforeCreate', { editor: this });
     this.options.onBeforeCreate?.({ editor: this });
 
-    // 2. Initialize ExtensionManager with schema
+    // 2. Initialize ExtensionManager with schema (validated in constructor)
     this.extensionManager = new ExtensionManager(this.options.schema!, this);
     this.extensionManager.validateSchema();
 
@@ -322,13 +323,13 @@ export class Editor extends EventEmitter<EditorEvents> {
       // Handle focus/blur events
       handleDOMEvents: {
         focus: (_view, event) => {
-          this.emit('focus', { editor: this, event: event as FocusEvent });
-          this.options.onFocus?.({ editor: this, event: event as FocusEvent });
+          this.emit('focus', { editor: this, event: event });
+          this.options.onFocus?.({ editor: this, event: event });
           return false;
         },
         blur: (_view, event) => {
-          this.emit('blur', { editor: this, event: event as FocusEvent });
-          this.options.onBlur?.({ editor: this, event: event as FocusEvent });
+          this.emit('blur', { editor: this, event: event });
+          this.options.onBlur?.({ editor: this, event: event });
           return false;
         },
       },
@@ -345,7 +346,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     if (this.options.autofocus) {
       // Use setTimeout to ensure DOM is ready
       setTimeout(() => {
-        this.commandManager.focus(this.options.autofocus!);
+        this.commandManager.focus(this.options.autofocus);
       }, 0);
     }
 
@@ -373,7 +374,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.options.onTransaction?.({ editor: this, transaction });
 
     // 4. Check if we should skip update event
-    const skipUpdate = transaction.getMeta('skipUpdate');
+    const skipUpdate = transaction.getMeta('skipUpdate') as boolean | undefined;
 
     // 5. Emit selectionUpdate if selection changed (without doc change)
     if (!transaction.docChanged && transaction.selectionSet) {

--- a/packages/core/src/ExtensionManager.test.ts
+++ b/packages/core/src/ExtensionManager.test.ts
@@ -71,7 +71,7 @@ describe('ExtensionManager', () => {
     it('does not throw for valid schema', () => {
       const manager = new ExtensionManager(validSchema, mockEditor);
 
-      expect(() => manager.validateSchema()).not.toThrow();
+      expect(() => { manager.validateSchema(); }).not.toThrow();
     });
 
     it('throws error for schema without doc node', () => {
@@ -79,7 +79,7 @@ describe('ExtensionManager', () => {
         schema: schemaWithoutDoc,
       });
 
-      expect(() => manager.validateSchema()).toThrow(
+      expect(() => { manager.validateSchema(); }).toThrow(
         'Invalid schema: missing required "doc" node'
       );
     });
@@ -91,7 +91,7 @@ describe('ExtensionManager', () => {
       const manager = new ExtensionManager(validSchema, mockEditor);
       manager.destroy();
 
-      expect(() => manager.validateSchema()).toThrow(
+      expect(() => { manager.validateSchema(); }).toThrow(
         'ExtensionManager has been destroyed'
       );
     });
@@ -101,14 +101,14 @@ describe('ExtensionManager', () => {
     it('can be called without error', () => {
       const manager = new ExtensionManager(validSchema, mockEditor);
 
-      expect(() => manager.destroy()).not.toThrow();
+      expect(() => { manager.destroy(); }).not.toThrow();
     });
 
     it('can be called multiple times safely', () => {
       const manager = new ExtensionManager(validSchema, mockEditor);
 
       manager.destroy();
-      expect(() => manager.destroy()).not.toThrow();
+      expect(() => { manager.destroy(); }).not.toThrow();
     });
   });
 });

--- a/packages/core/src/ExtensionManager.test.ts
+++ b/packages/core/src/ExtensionManager.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { ExtensionManager } from './ExtensionManager.js';
+
+// Valid test schema with required nodes
+const validSchema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+    },
+    text: { group: 'inline' },
+  },
+});
+
+// Invalid schema missing 'doc' node
+const schemaWithoutDoc = new Schema({
+  nodes: {
+    paragraph: {
+      content: 'inline*',
+      toDOM() {
+        return ['p', 0];
+      },
+    },
+    text: { group: 'inline' },
+  },
+  topNode: 'paragraph',
+});
+
+// Note: ProseMirror enforces 'text' node at schema creation time,
+// so we can't create a schema without it for testing.
+// The validateSchema check for 'text' is a defensive measure.
+
+// Mock editor for testing
+const mockEditor = {
+  schema: validSchema,
+};
+
+describe('ExtensionManager', () => {
+  describe('constructor', () => {
+    it('creates instance with schema and editor', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      expect(manager).toBeInstanceOf(ExtensionManager);
+      expect(manager.schema).toBe(validSchema);
+    });
+  });
+
+  describe('schema', () => {
+    it('returns the schema passed to constructor', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      expect(manager.schema).toBe(validSchema);
+      expect(manager.schema.nodes['doc']).toBeDefined();
+      expect(manager.schema.nodes['paragraph']).toBeDefined();
+      expect(manager.schema.nodes['text']).toBeDefined();
+    });
+  });
+
+  describe('plugins', () => {
+    it('returns empty array in Step 1.3 (no extensions)', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      expect(manager.plugins).toEqual([]);
+      expect(Array.isArray(manager.plugins)).toBe(true);
+    });
+  });
+
+  describe('validateSchema', () => {
+    it('does not throw for valid schema', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      expect(() => manager.validateSchema()).not.toThrow();
+    });
+
+    it('throws error for schema without doc node', () => {
+      const manager = new ExtensionManager(schemaWithoutDoc, {
+        schema: schemaWithoutDoc,
+      });
+
+      expect(() => manager.validateSchema()).toThrow(
+        'Invalid schema: missing required "doc" node'
+      );
+    });
+
+    // Note: Can't test missing 'text' node because ProseMirror
+    // enforces it at schema creation time (throws RangeError)
+
+    it('throws error after destroy', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+      manager.destroy();
+
+      expect(() => manager.validateSchema()).toThrow(
+        'ExtensionManager has been destroyed'
+      );
+    });
+  });
+
+  describe('destroy', () => {
+    it('can be called without error', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      expect(() => manager.destroy()).not.toThrow();
+    });
+
+    it('can be called multiple times safely', () => {
+      const manager = new ExtensionManager(validSchema, mockEditor);
+
+      manager.destroy();
+      expect(() => manager.destroy()).not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -1,0 +1,118 @@
+/**
+ * ExtensionManager - Manages extensions and schema
+ *
+ * Step 1.3: Minimal version that holds schema
+ * Step 2: Will be expanded with full extension lifecycle
+ */
+import type { Schema, Node as PMNode } from 'prosemirror-model';
+import type { Plugin } from 'prosemirror-state';
+
+/**
+ * Editor interface for ExtensionManager
+ * Forward declaration to avoid circular dependency
+ */
+export interface ExtensionManagerEditor {
+  readonly schema: Schema;
+}
+
+/**
+ * Manages editor extensions and schema
+ *
+ * In Step 1.3, this is a minimal implementation that:
+ * - Holds the schema passed to the Editor
+ * - Returns empty plugins array (no extensions yet)
+ *
+ * In Step 2, this will be expanded to:
+ * - Build schema from extensions
+ * - Collect plugins from extensions
+ * - Handle extension lifecycle
+ * - Detect schema conflicts (AD-7)
+ */
+export class ExtensionManager {
+  /**
+   * ProseMirror schema for the editor
+   */
+  private readonly _schema: Schema;
+
+  /**
+   * Reference to the editor instance
+   */
+  private readonly editor: ExtensionManagerEditor;
+
+  /**
+   * Whether the manager has been destroyed
+   */
+  private isDestroyed = false;
+
+  /**
+   * Creates a new ExtensionManager
+   *
+   * @param schema - ProseMirror schema to use
+   * @param editor - Editor instance (for future extension access)
+   */
+  constructor(schema: Schema, editor: ExtensionManagerEditor) {
+    this._schema = schema;
+    this.editor = editor;
+  }
+
+  /**
+   * Gets the ProseMirror schema
+   */
+  get schema(): Schema {
+    return this._schema;
+  }
+
+  /**
+   * Gets plugins from all extensions
+   *
+   * Step 1.3: Returns empty array (no extensions)
+   * Step 2: Will collect plugins from extensions
+   */
+  get plugins(): Plugin[] {
+    // Step 1.3: No extensions, no plugins
+    return [];
+  }
+
+  /**
+   * Validates that the schema has required nodes
+   *
+   * @throws Error if schema is missing 'doc' or 'text' nodes
+   */
+  validateSchema(): void {
+    if (this.isDestroyed) {
+      throw new Error('ExtensionManager has been destroyed');
+    }
+
+    const { nodes } = this._schema.spec;
+
+    if (!nodes.get('doc')) {
+      throw new Error(
+        'Invalid schema: missing required "doc" node. ' +
+          'The schema must define a "doc" node as the document root.'
+      );
+    }
+
+    if (!nodes.get('text')) {
+      throw new Error(
+        'Invalid schema: missing required "text" node. ' +
+          'The schema must define a "text" node for inline text content.'
+      );
+    }
+  }
+
+  /**
+   * Cleans up the extension manager
+   *
+   * Step 1.3: Basic cleanup
+   * Step 2: Will call destroy on all extensions
+   */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.isDestroyed = true;
+
+    // Step 2: Will iterate extensions and call onDestroy hooks
+  }
+}

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -4,7 +4,7 @@
  * Step 1.3: Minimal version that holds schema
  * Step 2: Will be expanded with full extension lifecycle
  */
-import type { Schema, Node as PMNode } from 'prosemirror-model';
+import type { Schema } from 'prosemirror-model';
 import type { Plugin } from 'prosemirror-state';
 
 /**
@@ -37,7 +37,7 @@ export class ExtensionManager {
   /**
    * Reference to the editor instance
    */
-  private readonly editor: ExtensionManagerEditor;
+  readonly editor: ExtensionManagerEditor;
 
   /**
    * Whether the manager has been destroyed

--- a/packages/core/src/helpers/createDocument.test.ts
+++ b/packages/core/src/helpers/createDocument.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { createDocument } from './createDocument.js';
+
+// Minimal test schema
+const testSchema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      parseDOM: [{ tag: 'p' }],
+      toDOM() {
+        return ['p', 0];
+      },
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    bold: {
+      parseDOM: [{ tag: 'strong' }, { tag: 'b' }],
+      toDOM() {
+        return ['strong', 0];
+      },
+    },
+  },
+});
+
+describe('createDocument', () => {
+  describe('null/undefined content', () => {
+    it('creates empty document for null content', () => {
+      const doc = createDocument(null, testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.childCount).toBe(1);
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+      expect(doc.firstChild?.childCount).toBe(0);
+    });
+
+    it('creates empty document for undefined content', () => {
+      const doc = createDocument(undefined, testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.childCount).toBe(1);
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+  });
+
+  describe('JSON content', () => {
+    it('parses JSON content with type property', () => {
+      const json = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello world' }],
+          },
+        ],
+      };
+
+      const doc = createDocument(json, testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.childCount).toBe(1);
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+      expect(doc.textContent).toBe('Hello world');
+    });
+
+    it('parses JSON content with marks', () => {
+      const json = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'Hello ' },
+              { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+            ],
+          },
+        ],
+      };
+
+      const doc = createDocument(json, testSchema);
+
+      expect(doc.textContent).toBe('Hello bold');
+      // Check that the second text node has bold mark
+      const paragraph = doc.firstChild!;
+      const boldText = paragraph.child(1);
+      expect(boldText.marks.length).toBe(1);
+      expect(boldText.marks[0].type.name).toBe('bold');
+    });
+
+    it('parses empty doc JSON', () => {
+      const json = {
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      };
+
+      const doc = createDocument(json, testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.childCount).toBe(1);
+    });
+  });
+
+  describe('HTML content', () => {
+    it('parses simple HTML paragraph', () => {
+      const doc = createDocument('<p>Hello world</p>', testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.textContent).toBe('Hello world');
+    });
+
+    it('parses HTML with marks', () => {
+      const doc = createDocument('<p>Hello <strong>bold</strong></p>', testSchema);
+
+      expect(doc.textContent).toBe('Hello bold');
+    });
+
+    it('parses multiple paragraphs', () => {
+      const doc = createDocument(
+        '<p>First</p><p>Second</p>',
+        testSchema
+      );
+
+      expect(doc.childCount).toBe(2);
+      expect(doc.child(0).textContent).toBe('First');
+      expect(doc.child(1).textContent).toBe('Second');
+    });
+
+    it('handles HTML with whitespace', () => {
+      const doc = createDocument('  <p>Hello</p>  ', testSchema);
+
+      expect(doc.textContent).toBe('Hello');
+    });
+
+    it('handles empty paragraph HTML', () => {
+      const doc = createDocument('<p></p>', testSchema);
+
+      expect(doc.type.name).toBe('doc');
+      expect(doc.childCount).toBe(1);
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+  });
+
+  describe('invalid content', () => {
+    it('throws error for plain text (no HTML tags)', () => {
+      expect(() => {
+        createDocument('Hello world', testSchema);
+      }).toThrow('Invalid content format: plain text is not supported');
+    });
+
+    it('throws error for empty string', () => {
+      expect(() => {
+        createDocument('', testSchema);
+      }).toThrow('Invalid content format: plain text is not supported');
+    });
+
+    it('throws error for whitespace-only string', () => {
+      expect(() => {
+        createDocument('   ', testSchema);
+      }).toThrow('Invalid content format: plain text is not supported');
+    });
+
+    it('throws error for object without type property', () => {
+      expect(() => {
+        createDocument({ content: [] } as never, testSchema);
+      }).toThrow('Invalid content format');
+    });
+
+    it('throws error for array content', () => {
+      expect(() => {
+        createDocument([] as never, testSchema);
+      }).toThrow('Invalid content format');
+    });
+
+    it('throws error for number content', () => {
+      expect(() => {
+        createDocument(123 as never, testSchema);
+      }).toThrow('Invalid content format');
+    });
+  });
+});

--- a/packages/core/src/helpers/createDocument.test.ts
+++ b/packages/core/src/helpers/createDocument.test.ts
@@ -84,7 +84,8 @@ describe('createDocument', () => {
 
       expect(doc.textContent).toBe('Hello bold');
       // Check that the second text node has bold mark
-      const paragraph = doc.firstChild!;
+      const paragraph = doc.firstChild;
+      if (!paragraph) throw new Error('Expected paragraph');
       const boldText = paragraph.child(1);
       expect(boldText.marks.length).toBe(1);
       expect(boldText.marks[0].type.name).toBe('bold');

--- a/packages/core/src/helpers/createDocument.test.ts
+++ b/packages/core/src/helpers/createDocument.test.ts
@@ -88,7 +88,7 @@ describe('createDocument', () => {
       if (!paragraph) throw new Error('Expected paragraph');
       const boldText = paragraph.child(1);
       expect(boldText.marks.length).toBe(1);
-      expect(boldText.marks[0].type.name).toBe('bold');
+      expect(boldText.marks[0]?.type.name).toBe('bold');
     });
 
     it('parses empty doc JSON', () => {

--- a/packages/core/src/helpers/createDocument.ts
+++ b/packages/core/src/helpers/createDocument.ts
@@ -1,0 +1,138 @@
+/**
+ * Create a ProseMirror document from content
+ *
+ * Supports JSON and HTML content formats (AD-11).
+ * Plain text is NOT supported - use HTML or JSON explicitly.
+ */
+import { Node as PMNode, Schema, DOMParser } from 'prosemirror-model';
+import type { Content, JSONContent } from '../types/index.js';
+
+/**
+ * Options for createDocument
+ */
+export interface CreateDocumentOptions {
+  /**
+   * Parse options passed to DOMParser
+   */
+  parseOptions?: Parameters<DOMParser['parse']>[1];
+}
+
+/**
+ * Checks if content is a JSON object (has 'type' property)
+ */
+function isJSONContent(content: unknown): content is JSONContent {
+  return (
+    typeof content === 'object' &&
+    content !== null &&
+    'type' in content &&
+    typeof (content as JSONContent).type === 'string'
+  );
+}
+
+/**
+ * Checks if content is an HTML string (starts with '<')
+ */
+function isHTMLContent(content: unknown): content is string {
+  return typeof content === 'string' && content.trim().startsWith('<');
+}
+
+/**
+ * Creates an empty document with a single empty paragraph
+ */
+function createEmptyDocument(schema: Schema): PMNode {
+  const paragraphType = schema.nodes.paragraph;
+
+  if (paragraphType) {
+    return schema.node('doc', null, [paragraphType.create()]);
+  }
+
+  // Fallback: create doc with whatever the first block type is
+  const docSpec = schema.nodes.doc.spec;
+  const content = docSpec.content || '';
+
+  // Try to find the first allowed node type
+  for (const [name, nodeType] of Object.entries(schema.nodes)) {
+    if (name !== 'doc' && name !== 'text' && nodeType.isBlock) {
+      return schema.node('doc', null, [nodeType.create()]);
+    }
+  }
+
+  // Last resort: empty doc (might be invalid for some schemas)
+  return schema.node('doc', null, []);
+}
+
+/**
+ * Parses HTML string into a ProseMirror document
+ */
+function parseHTMLContent(
+  html: string,
+  schema: Schema,
+  options?: CreateDocumentOptions
+): PMNode {
+  // Create a temporary DOM element to parse the HTML
+  const element = document.createElement('div');
+  element.innerHTML = html;
+
+  const parser = DOMParser.fromSchema(schema);
+  return parser.parse(element, options?.parseOptions);
+}
+
+/**
+ * Creates a ProseMirror document from content
+ *
+ * @param content - JSON content object, HTML string, or null/undefined
+ * @param schema - ProseMirror schema to use
+ * @param options - Optional parse options
+ * @returns ProseMirror Node (document)
+ *
+ * @throws Error if content format is invalid (plain text without HTML tags)
+ *
+ * @example
+ * ```ts
+ * // JSON content
+ * const doc = createDocument(
+ *   { type: 'doc', content: [{ type: 'paragraph' }] },
+ *   schema
+ * );
+ *
+ * // HTML content
+ * const doc = createDocument('<p>Hello world</p>', schema);
+ *
+ * // Empty document
+ * const doc = createDocument(null, schema);
+ * ```
+ */
+export function createDocument(
+  content: Content | null | undefined,
+  schema: Schema,
+  options?: CreateDocumentOptions
+): PMNode {
+  // Handle null/undefined - create empty document
+  if (content === null || content === undefined) {
+    return createEmptyDocument(schema);
+  }
+
+  // Handle JSON content
+  if (isJSONContent(content)) {
+    return PMNode.fromJSON(schema, content);
+  }
+
+  // Handle HTML string
+  if (isHTMLContent(content)) {
+    return parseHTMLContent(content, schema, options);
+  }
+
+  // Handle plain text string (not allowed per AD-11)
+  if (typeof content === 'string') {
+    throw new Error(
+      'Invalid content format: plain text is not supported. ' +
+        'Use HTML string (e.g., "<p>Hello</p>") or JSON content object instead.'
+    );
+  }
+
+  // Unknown content type
+  throw new Error(
+    `Invalid content format: expected JSON object with 'type' property or HTML string, ` +
+      `got ${typeof content}`
+  );
+}

--- a/packages/core/src/helpers/createDocument.ts
+++ b/packages/core/src/helpers/createDocument.ts
@@ -40,16 +40,13 @@ function isHTMLContent(content: unknown): content is string {
  * Creates an empty document with a single empty paragraph
  */
 function createEmptyDocument(schema: Schema): PMNode {
-  const paragraphType = schema.nodes.paragraph;
+  const paragraphType = schema.nodes['paragraph'];
 
   if (paragraphType) {
     return schema.node('doc', null, [paragraphType.create()]);
   }
 
   // Fallback: create doc with whatever the first block type is
-  const docSpec = schema.nodes.doc.spec;
-  const content = docSpec.content || '';
-
   // Try to find the first allowed node type
   for (const [name, nodeType] of Object.entries(schema.nodes)) {
     if (name !== 'doc' && name !== 'text' && nodeType.isBlock) {

--- a/packages/core/src/helpers/createDocument.ts
+++ b/packages/core/src/helpers/createDocument.ts
@@ -4,7 +4,8 @@
  * Supports JSON and HTML content formats (AD-11).
  * Plain text is NOT supported - use HTML or JSON explicitly.
  */
-import { Node as PMNode, Schema, DOMParser } from 'prosemirror-model';
+import type { Schema} from 'prosemirror-model';
+import { Node as PMNode, DOMParser } from 'prosemirror-model';
 import type { Content, JSONContent } from '../types/index.js';
 
 /**

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Helper utilities for @domternal/core
+ */
+
+export { createDocument, type CreateDocumentOptions } from './createDocument.js';
+export {
+  isNodeEmpty,
+  isDocumentEmpty,
+  type IsNodeEmptyOptions,
+} from './isNodeEmpty.js';

--- a/packages/core/src/helpers/isNodeEmpty.test.ts
+++ b/packages/core/src/helpers/isNodeEmpty.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { Schema, Node as PMNode } from 'prosemirror-model';
+import { isNodeEmpty, isDocumentEmpty } from './isNodeEmpty.js';
+
+// Test schema with various node types
+const testSchema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+    },
+    heading: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { level: { default: 1 } },
+    },
+    hardBreak: {
+      group: 'inline',
+      inline: true,
+      selectable: false,
+    },
+    image: {
+      group: 'inline',
+      inline: true,
+      attrs: { src: {} },
+    },
+    horizontalRule: {
+      group: 'block',
+    },
+    text: { group: 'inline' },
+  },
+});
+
+// Helper to create nodes from JSON
+function createNode(json: Record<string, unknown>): PMNode {
+  return PMNode.fromJSON(testSchema, json);
+}
+
+describe('isNodeEmpty', () => {
+  describe('text nodes', () => {
+    // Note: ProseMirror doesn't allow creating empty text nodes (throws RangeError)
+    // So we only test non-empty text nodes
+
+    it('returns false for text node with content', () => {
+      const node = testSchema.text('Hello');
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+
+    it('returns false for text node with whitespace', () => {
+      const node = testSchema.text('   ');
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+  });
+
+  describe('paragraph nodes', () => {
+    it('returns true for empty paragraph', () => {
+      const node = createNode({ type: 'paragraph' });
+      expect(isNodeEmpty(node)).toBe(true);
+    });
+
+    it('returns false for paragraph with text', () => {
+      const node = createNode({
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello' }],
+      });
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+
+    it('returns true for paragraph with only hardBreak (ignoreHardBreaks: true)', () => {
+      const node = createNode({
+        type: 'paragraph',
+        content: [{ type: 'hardBreak' }],
+      });
+      expect(isNodeEmpty(node, { ignoreHardBreaks: true })).toBe(true);
+    });
+
+    it('returns false for paragraph with only hardBreak (ignoreHardBreaks: false)', () => {
+      const node = createNode({
+        type: 'paragraph',
+        content: [{ type: 'hardBreak' }],
+      });
+      expect(isNodeEmpty(node, { ignoreHardBreaks: false })).toBe(false);
+    });
+  });
+
+  describe('document nodes', () => {
+    it('returns true for doc with empty paragraph', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      });
+      expect(isNodeEmpty(node)).toBe(true);
+    });
+
+    it('returns false for doc with text content', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      });
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+
+    it('returns true for doc with multiple empty paragraphs', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [{ type: 'paragraph' }, { type: 'paragraph' }],
+      });
+      expect(isNodeEmpty(node)).toBe(true);
+    });
+
+    it('returns false for doc with one non-empty paragraph', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [
+          { type: 'paragraph' },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      });
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+  });
+
+  describe('leaf nodes', () => {
+    it('returns false for horizontalRule (non-empty leaf)', () => {
+      const node = createNode({ type: 'horizontalRule' });
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+
+    it('returns false for image node', () => {
+      const node = createNode({
+        type: 'image',
+        attrs: { src: 'test.jpg' },
+      });
+      expect(isNodeEmpty(node)).toBe(false);
+    });
+  });
+
+  describe('checkChildren option', () => {
+    it('returns false when checkChildren is false and has children', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      });
+      expect(isNodeEmpty(node, { checkChildren: false })).toBe(false);
+    });
+
+    it('returns true when checkChildren is false and no children', () => {
+      // Create a node that can have no children
+      const node = createNode({ type: 'paragraph' });
+      expect(isNodeEmpty(node, { checkChildren: false })).toBe(true);
+    });
+  });
+
+  describe('default options', () => {
+    it('uses checkChildren: true by default', () => {
+      const node = createNode({
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      });
+      // Default should check children, so empty paragraph = empty doc
+      expect(isNodeEmpty(node)).toBe(true);
+    });
+
+    it('uses ignoreHardBreaks: true by default', () => {
+      const node = createNode({
+        type: 'paragraph',
+        content: [{ type: 'hardBreak' }],
+      });
+      expect(isNodeEmpty(node)).toBe(true);
+    });
+  });
+});
+
+describe('isDocumentEmpty', () => {
+  it('returns true for empty document', () => {
+    const doc = createNode({
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    });
+    expect(isDocumentEmpty(doc)).toBe(true);
+  });
+
+  it('returns false for document with content', () => {
+    const doc = createNode({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+    expect(isDocumentEmpty(doc)).toBe(false);
+  });
+
+  it('returns true for document with only hardBreaks', () => {
+    const doc = createNode({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'hardBreak' }],
+        },
+      ],
+    });
+    expect(isDocumentEmpty(doc)).toBe(true);
+  });
+});

--- a/packages/core/src/helpers/isNodeEmpty.ts
+++ b/packages/core/src/helpers/isNodeEmpty.ts
@@ -1,0 +1,101 @@
+/**
+ * Check if a ProseMirror node is empty
+ */
+import type { Node as PMNode } from 'prosemirror-model';
+
+/**
+ * Options for isNodeEmpty check
+ */
+export interface IsNodeEmptyOptions {
+  /**
+   * Check child nodes recursively
+   * @default true
+   */
+  checkChildren?: boolean;
+
+  /**
+   * Ignore hardBreak nodes when checking emptiness
+   * @default true
+   */
+  ignoreHardBreaks?: boolean;
+}
+
+/**
+ * Checks if a ProseMirror node is considered empty
+ *
+ * A node is considered empty if:
+ * - It has no content (childCount === 0)
+ * - It only contains empty child nodes (when checkChildren is true)
+ * - It only contains hardBreaks (when ignoreHardBreaks is true)
+ *
+ * @param node - ProseMirror node to check
+ * @param options - Options for emptiness check
+ * @returns true if node is empty
+ *
+ * @example
+ * ```ts
+ * // Check if document is empty
+ * const empty = isNodeEmpty(editor.state.doc);
+ *
+ * // Check without recursion
+ * const empty = isNodeEmpty(node, { checkChildren: false });
+ * ```
+ */
+export function isNodeEmpty(
+  node: PMNode,
+  options: IsNodeEmptyOptions = {}
+): boolean {
+  const { checkChildren = true, ignoreHardBreaks = true } = options;
+
+  // Leaf nodes with no content
+  if (node.isLeaf) {
+    // Text node is empty if it has no text
+    if (node.isText) {
+      return !node.text || node.text.length === 0;
+    }
+
+    // HardBreak is considered "empty" if ignoreHardBreaks is true
+    if (ignoreHardBreaks && node.type.name === 'hardBreak') {
+      return true;
+    }
+
+    // Other leaf nodes (like images, horizontal rules) are not empty
+    return false;
+  }
+
+  // No children = empty
+  if (node.childCount === 0) {
+    return true;
+  }
+
+  // If not checking children, has children = not empty
+  if (!checkChildren) {
+    return false;
+  }
+
+  // Check all children recursively
+  let isEmpty = true;
+  node.forEach((child) => {
+    if (!isNodeEmpty(child, options)) {
+      isEmpty = false;
+    }
+  });
+
+  return isEmpty;
+}
+
+/**
+ * Checks if a document node is empty
+ *
+ * Convenience wrapper for isNodeEmpty with document-specific defaults.
+ * A document is empty if it only contains empty paragraphs or no content.
+ *
+ * @param doc - Document node to check
+ * @returns true if document is empty
+ */
+export function isDocumentEmpty(doc: PMNode): boolean {
+  return isNodeEmpty(doc, {
+    checkChildren: true,
+    ignoreHardBreaks: true,
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,11 +46,25 @@ export type {
 
 // === Core classes ===
 export { EventEmitter } from './EventEmitter.js';
+export { Editor } from './Editor.js';
+export { ExtensionManager } from './ExtensionManager.js';
+export {
+  CommandManager,
+  type SetContentOptions,
+  type ClearContentOptions,
+  type CommandManagerEditor,
+} from './CommandManager.js';
 
-// Editor class will be implemented here
-// export { Editor } from './Editor';
+// === Helpers ===
+export {
+  createDocument,
+  isNodeEmpty,
+  isDocumentEmpty,
+  type CreateDocumentOptions,
+  type IsNodeEmptyOptions,
+} from './helpers/index.js';
 
-// Extension system will be implemented here
+// Extension system will be implemented in Step 2
 // export { Extension } from './Extension';
 // export { Node } from './Node';
 // export { Mark } from './Mark';

--- a/packages/core/src/types/EditorEvents.ts
+++ b/packages/core/src/types/EditorEvents.ts
@@ -69,6 +69,7 @@ export interface DropEventProps {
  */
 export interface MountEventProps {
   editor: EditorInstance;
+  view: unknown;
 }
 
 /**

--- a/packages/core/src/types/EditorEvents.ts
+++ b/packages/core/src/types/EditorEvents.ts
@@ -38,8 +38,10 @@ export interface CreateEventProps {
  */
 export interface ContentErrorProps {
   editor: EditorInstance;
+  /** The validation error that occurred */
   error: Error;
-  disableCollaboration: () => void;
+  /** The original content that failed validation */
+  content: unknown;
 }
 
 /**

--- a/packages/core/src/types/EditorOptions.ts
+++ b/packages/core/src/types/EditorOptions.ts
@@ -1,3 +1,4 @@
+import type { Schema } from 'prosemirror-model';
 import type { Content } from './Content.js';
 import type {
   CreateEventProps,
@@ -41,8 +42,18 @@ export type FocusPosition = boolean | 'start' | 'end' | 'all' | number | null;
  */
 export interface EditorOptions {
   /**
+   * ProseMirror Schema for the editor
+   *
+   * Step 1.3: Required (no extensions system yet)
+   * Step 2+: Optional if extensions are provided (schema built from extensions)
+   *
+   * The schema must contain at least 'doc' and 'text' nodes.
+   */
+  schema?: Schema;
+
+  /**
    * HTML element to mount the editor
-   * If not provided, editor runs in "headless" mode
+   * If not provided, creates a detached div (useful for testing/headless mode)
    */
   element?: HTMLElement | null;
 
@@ -195,8 +206,12 @@ export interface EditorOptions {
 
 /**
  * Required options that must be resolved before creating the editor
+ *
+ * Step 1.3: schema is required
+ * Step 2+: schema OR extensions must be provided
  */
 export interface ResolvedEditorOptions extends EditorOptions {
+  schema: Schema;
   extensions: AnyExtension[];
   editable: boolean;
   enableInputRules: boolean;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
     include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 0.5.18
       '@vitest/coverage-v8':
         specifier: ^4.0.17
-        version: 4.0.17(vitest@4.0.17(yaml@2.8.2))
+        version: 4.0.17(vitest@4.0.17(jsdom@27.4.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
@@ -49,7 +49,7 @@ importers:
         version: 8.53.0(eslint@9.39.2)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(yaml@2.8.2)
+        version: 4.0.17(jsdom@27.4.0)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -90,6 +90,9 @@ importers:
         specifier: ^1.41.5
         version: 1.41.5
     devDependencies:
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
@@ -98,6 +101,18 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.1':
+    resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    resolution: {integrity: sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -640,6 +655,38 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.25':
+    resolution: {integrity: sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
@@ -842,6 +889,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.9.0':
+    resolution: {integrity: sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1427,6 +1483,10 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1513,6 +1573,9 @@ packages:
   baseline-browser-mapping@2.9.15:
     resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1629,6 +1692,18 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1637,6 +1712,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1686,6 +1764,10 @@ packages:
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -1902,8 +1984,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1955,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -2004,6 +2101,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2066,6 +2172,10 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2082,6 +2192,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2199,6 +2312,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2347,6 +2463,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2378,6 +2498,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2461,6 +2585,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -2490,9 +2617,24 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.19:
+    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+
+  tldts@7.0.19:
+    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
+    hasBin: true
+
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2657,8 +2799,28 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2680,6 +2842,25 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2710,6 +2891,26 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.1':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -3425,6 +3626,28 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -3561,6 +3784,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.9.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -4042,7 +4267,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(jsdom@27.4.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.17
@@ -4054,7 +4279,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.17(yaml@2.8.2)
+      vitest: 4.0.17(jsdom@27.4.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.17':
     dependencies:
@@ -4113,6 +4338,8 @@ snapshots:
   acorn@8.15.0: {}
 
   address@1.2.2: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -4210,6 +4437,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.15: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bl@4.1.0:
     dependencies:
@@ -4327,9 +4558,28 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.25
+      css-tree: 3.1.0
+      lru-cache: 11.2.4
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -4375,6 +4625,8 @@ snapshots:
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
+
+  entities@6.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4613,7 +4865,27 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.9.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   ieee754@1.2.1: {}
 
@@ -4647,6 +4919,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-interactive@1.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-unicode-supported@0.1.0: {}
 
@@ -4697,6 +4971,34 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.7.6
+      '@exodus/bytes': 1.9.0
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -4741,6 +5043,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  lru-cache@11.2.4: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4760,6 +5064,8 @@ snapshots:
       semver: 7.7.3
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.12.2: {}
 
   mime-db@1.52.0: {}
 
@@ -4949,6 +5255,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5103,6 +5413,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -5154,6 +5466,10 @@ snapshots:
   rope-sequence@1.3.4: {}
 
   safe-buffer@5.2.1: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver@6.3.1: {}
 
@@ -5225,6 +5541,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -5254,7 +5572,21 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.19: {}
+
+  tldts@7.0.19:
+    dependencies:
+      tldts-core: 7.0.19
+
   tmp@0.2.5: {}
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.19
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -5355,7 +5687,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vitest@4.0.17(yaml@2.8.2):
+  vitest@4.0.17(jsdom@27.4.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
       '@vitest/mocker': 4.0.17(vite@7.3.1(yaml@2.8.2))
@@ -5377,6 +5709,8 @@ snapshots:
       tinyrainbow: 3.0.3
       vite: 7.3.1(yaml@2.8.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -5392,9 +5726,24 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
 
   which@2.0.2:
     dependencies:
@@ -5414,6 +5763,12 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
Implement Editor class with CommandManager, ExtensionManager, and content helpers for Step 1.3.

## Features
- Editor class wrapping ProseMirror EditorView
- CommandManager with 7 commands: focus, blur, setContent, clearContent, insertText, deleteSelection, selectAll
- ExtensionManager for schema management (minimal, expanded in Step 2)
- Content helpers: createDocument (JSON/HTML parsing), isNodeEmpty
- Content methods: getJSON(), getHTML(), getText(), setContent(), clearContent()
- Full event system: beforeCreate, create, mount, update, selectionUpdate, transaction, focus, blur, destroy
- Fix ContentErrorProps for AD-8 content validation
- Test coverage ~90%
