### PR TITLE
feat(core): add Extension, Node, and Mark base classes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,12 @@ export default defineConfig(
     },
   },
   {
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+  {
     ignores: [
       '**/dist/**',
       '**/node_modules/**',

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -69,6 +69,11 @@ export class Editor extends EventEmitter<EditorEvents> {
   private commandManager!: CommandManager;
 
   /**
+   * Validated schema (guaranteed non-null after constructor)
+   */
+  private validatedSchema!: Schema;
+
+  /**
    * ProseMirror EditorView instance
    */
   public view!: EditorView;
@@ -108,6 +113,9 @@ export class Editor extends EventEmitter<EditorEvents> {
       editable: true,
       ...options,
     };
+
+    // Store validated schema (guaranteed non-null after check above)
+    this.validatedSchema = options.schema;
 
     this.createEditor();
   }
@@ -293,7 +301,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.options.onBeforeCreate?.({ editor: this });
 
     // 2. Initialize ExtensionManager with schema (validated in constructor)
-    this.extensionManager = new ExtensionManager(this.options.schema!, this);
+    this.extensionManager = new ExtensionManager(this.validatedSchema, this);
     this.extensionManager.validateSchema();
 
     // 3. Create initial document from content

--- a/packages/core/src/Extension.test.ts
+++ b/packages/core/src/Extension.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+import { Extension } from './Extension.js';
+
+describe('Extension', () => {
+  describe('create()', () => {
+    it('creates extension with name', () => {
+      const ext = Extension.create({ name: 'test' });
+
+      expect(ext.name).toBe('test');
+      expect(ext.type).toBe('extension');
+    });
+
+    it('creates extension with default options from addOptions', () => {
+      const ext = Extension.create({
+        name: 'test',
+        addOptions() {
+          return { foo: 'bar', count: 42 };
+        },
+      });
+
+      expect(ext.options).toEqual({ foo: 'bar', count: 42 });
+    });
+
+    it('creates extension with empty options if addOptions not defined', () => {
+      const ext = Extension.create({ name: 'test' });
+
+      expect(ext.options).toEqual({});
+    });
+
+    it('creates extension with storage from addStorage', () => {
+      const ext = Extension.create({
+        name: 'test',
+        addStorage() {
+          return { characters: 0, words: 0 };
+        },
+      });
+
+      expect(ext.storage).toEqual({ characters: 0, words: 0 });
+    });
+
+    it('creates extension with empty storage if addStorage not defined', () => {
+      const ext = Extension.create({ name: 'test' });
+
+      expect(ext.storage).toEqual({});
+    });
+
+    it('stores the original config', () => {
+      const config = {
+        name: 'test',
+        priority: 500,
+        addOptions: () => ({ enabled: true }),
+      };
+      const ext = Extension.create(config);
+
+      expect(ext.config.name).toBe('test');
+      expect(ext.config.priority).toBe(500);
+    });
+
+    it('allows access to this.name in addOptions', () => {
+      const ext = Extension.create({
+        name: 'myExtension',
+        addOptions() {
+          return { extensionName: this.name };
+        },
+      });
+
+      expect(ext.options.extensionName).toBe('myExtension');
+    });
+
+    it('allows access to this.name in addStorage', () => {
+      const ext = Extension.create({
+        name: 'counter',
+        addStorage() {
+          return { name: this.name, count: 0 };
+        },
+      });
+
+      expect(ext.storage.name).toBe('counter');
+    });
+
+    it('initializes editor as null (set later by ExtensionManager)', () => {
+      const ext = Extension.create({ name: 'test' });
+
+      expect(ext.editor).toBeNull();
+    });
+  });
+
+  describe('configure()', () => {
+    it('returns new instance with merged options', () => {
+      const ext = Extension.create({
+        name: 'test',
+        addOptions() {
+          return { a: 1, b: 2, c: 3 };
+        },
+      });
+
+      const configured = ext.configure({ b: 20 });
+
+      expect(configured.options).toEqual({ a: 1, b: 20, c: 3 });
+    });
+
+    it('does not modify original extension', () => {
+      const ext = Extension.create({
+        name: 'test',
+        addOptions() {
+          return { value: 'original' };
+        },
+      });
+
+      ext.configure({ value: 'modified' });
+
+      expect(ext.options.value).toBe('original');
+    });
+
+    it('returns new Extension instance', () => {
+      const ext = Extension.create({ name: 'test' });
+      const configured = ext.configure({});
+
+      expect(configured).toBeInstanceOf(Extension);
+      expect(configured).not.toBe(ext);
+    });
+
+    it('preserves extension name', () => {
+      const ext = Extension.create({ name: 'myExtension' });
+      const configured = ext.configure({});
+
+      expect(configured.name).toBe('myExtension');
+    });
+
+    it('preserves extension type', () => {
+      const ext = Extension.create({ name: 'test' });
+      const configured = ext.configure({});
+
+      expect(configured.type).toBe('extension');
+    });
+
+    it('preserves other config properties', () => {
+      const ext = Extension.create({
+        name: 'test',
+        priority: 500,
+        dependencies: ['other'],
+        addOptions() {
+          return { value: 1 };
+        },
+      });
+
+      const configured = ext.configure({ value: 2 });
+
+      expect(configured.config.priority).toBe(500);
+      expect(configured.config.dependencies).toEqual(['other']);
+    });
+  });
+
+  describe('extend()', () => {
+    it('returns new instance with extended config', () => {
+      const base = Extension.create({
+        name: 'base',
+        addOptions() {
+          return { baseOption: true };
+        },
+      });
+
+      const extended = base.extend({
+        name: 'extended',
+        addOptions() {
+          return { extendedOption: true };
+        },
+      });
+
+      expect(extended.name).toBe('extended');
+      expect(extended.options).toEqual({ extendedOption: true });
+    });
+
+    it('does not modify original extension', () => {
+      const base = Extension.create({ name: 'base' });
+
+      base.extend({ name: 'extended' });
+
+      expect(base.name).toBe('base');
+    });
+
+    it('returns new Extension instance', () => {
+      const base = Extension.create({ name: 'base' });
+      const extended = base.extend({ name: 'extended' });
+
+      expect(extended).toBeInstanceOf(Extension);
+      expect(extended).not.toBe(base);
+    });
+
+    it('inherits config from base when not overridden', () => {
+      const base = Extension.create({
+        name: 'base',
+        priority: 500,
+        dependencies: ['dep1'],
+      });
+
+      const extended = base.extend({
+        name: 'extended',
+      });
+
+      expect(extended.config.priority).toBe(500);
+      expect(extended.config.dependencies).toEqual(['dep1']);
+    });
+
+    it('overrides config when specified', () => {
+      const base = Extension.create({
+        name: 'base',
+        priority: 500,
+      });
+
+      const extended = base.extend({
+        name: 'extended',
+        priority: 900,
+      });
+
+      expect(extended.config.priority).toBe(900);
+    });
+
+    it('sets type to extension', () => {
+      const base = Extension.create({ name: 'base' });
+      const extended = base.extend({ name: 'extended' });
+
+      expect(extended.type).toBe('extension');
+    });
+  });
+
+  describe('storage mutation', () => {
+    it('storage is mutable', () => {
+      const ext = Extension.create({
+        name: 'counter',
+        addStorage() {
+          return { count: 0 };
+        },
+      });
+
+      ext.storage.count = 10;
+
+      expect(ext.storage.count).toBe(10);
+    });
+
+    it('options are readonly (TypeScript enforced)', () => {
+      const ext = Extension.create({
+        name: 'test',
+        addOptions() {
+          return { value: 'initial' };
+        },
+      });
+
+      // This should not compile in TypeScript, but we verify the value exists
+      expect(ext.options.value).toBe('initial');
+    });
+  });
+
+  describe('type safety', () => {
+    it('correctly types options', () => {
+      interface MyOptions {
+        enabled: boolean;
+        maxLength: number;
+      }
+
+      const ext = Extension.create<MyOptions>({
+        name: 'typed',
+        addOptions() {
+          return { enabled: true, maxLength: 100 };
+        },
+      });
+
+      // TypeScript should know these types
+      expect(typeof ext.options.enabled).toBe('boolean');
+      expect(typeof ext.options.maxLength).toBe('number');
+    });
+
+    it('correctly types storage', () => {
+      interface MyStorage {
+        count: number;
+        history: string[];
+      }
+
+      const ext = Extension.create<unknown, MyStorage>({
+        name: 'typed',
+        addStorage() {
+          return { count: 0, history: [] };
+        },
+      });
+
+      ext.storage.count = 5;
+      ext.storage.history.push('action');
+
+      expect(ext.storage.count).toBe(5);
+      expect(ext.storage.history).toEqual(['action']);
+    });
+  });
+});

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -1,0 +1,168 @@
+/**
+ * Extension - Base class for all extensions
+ *
+ * Extensions provide functionality without contributing to the schema.
+ * For schema contributions, use Node (for block/inline nodes) or Mark (for inline formatting).
+ *
+ * Three-tier model:
+ * - Extension (type: 'extension') → Pure functionality (History, Placeholder, etc.)
+ * - Node (type: 'node') → Schema nodes (Paragraph, Heading, etc.)
+ * - Mark (type: 'mark') → Schema marks (Bold, Italic, etc.)
+ *
+ * @example
+ * const History = Extension.create({
+ *   name: 'history',
+ *   addOptions() {
+ *     return { depth: 100 };
+ *   },
+ *   addKeyboardShortcuts() {
+ *     return {
+ *       'Mod-z': () => this.editor.commands.undo(),
+ *       'Mod-Shift-z': () => this.editor.commands.redo(),
+ *     };
+ *   },
+ * });
+ */
+
+import type { ExtensionConfig } from './types/ExtensionConfig.js';
+import { callOrReturn } from './helpers/callOrReturn.js';
+
+/**
+ * Editor interface for Extension
+ * Forward declaration to avoid circular dependency
+ */
+export interface ExtensionEditorInterface {
+  readonly state: unknown;
+  readonly view: unknown;
+  readonly schema: unknown;
+}
+
+/**
+ * Base class for all extensions
+ *
+ * @typeParam Options - Extension options type
+ * @typeParam Storage - Extension storage type
+ */
+export class Extension<Options = unknown, Storage = unknown> {
+  /**
+   * Extension type identifier
+   * Used to distinguish between Extension, Node, and Mark
+   */
+  readonly type = 'extension' as const;
+
+  /**
+   * Unique extension name
+   */
+  readonly name: string;
+
+  /**
+   * Extension options (immutable after creation)
+   */
+  readonly options: Options;
+
+  /**
+   * Extension storage (mutable state)
+   * Accessible via editor.storage[extensionName]
+   */
+  storage: Storage;
+
+  /**
+   * The original configuration object
+   */
+  readonly config: ExtensionConfig<Options, Storage>;
+
+  /**
+   * Editor instance (set by ExtensionManager after creation)
+   * null! indicates it will be set before use
+   */
+  editor: ExtensionEditorInterface = null!;
+
+  /**
+   * Protected constructor - use Extension.create() instead
+   */
+  protected constructor(config: ExtensionConfig<Options, Storage>) {
+    this.config = config;
+    this.name = config.name;
+
+    // Initialize options using addOptions() with `this` context
+    // If addOptions is not defined, default to empty object
+    const defaultOptions = callOrReturn(config.addOptions, this);
+    this.options = (defaultOptions ?? {}) as Options;
+
+    // Initialize storage using addStorage() with `this` context
+    // If addStorage is not defined, default to empty object
+    const defaultStorage = callOrReturn(config.addStorage, this);
+    this.storage = (defaultStorage ?? {}) as Storage;
+  }
+
+  /**
+   * Creates a new extension instance
+   *
+   * @param config - Extension configuration
+   * @returns New extension instance
+   *
+   * @example
+   * const MyExtension = Extension.create({
+   *   name: 'myExtension',
+   *   addOptions() {
+   *     return { enabled: true };
+   *   },
+   * });
+   */
+  static create<O = unknown, S = unknown>(
+    config: ExtensionConfig<O, S>
+  ): Extension<O, S> {
+    return new Extension(config);
+  }
+
+  /**
+   * Creates a new extension with merged options
+   * Original extension is not modified
+   *
+   * @param options - Options to merge with existing options
+   * @returns New extension instance with merged options
+   *
+   * @example
+   * const configured = MyExtension.configure({ enabled: false });
+   */
+  configure(options: Partial<Options>): Extension<Options, Storage> {
+    // Create new config with merged options
+    const newConfig: ExtensionConfig<Options, Storage> = {
+      ...this.config,
+      // Override addOptions to return merged options
+      addOptions: () => ({
+        ...this.options,
+        ...options,
+      }),
+    };
+
+    return new Extension(newConfig);
+  }
+
+  /**
+   * Creates a new extension with extended configuration
+   * Original extension is not modified
+   *
+   * @param extendedConfig - Configuration to extend/override
+   * @returns New extension instance with extended config
+   *
+   * @example
+   * const Extended = MyExtension.extend({
+   *   name: 'extendedExtension',
+   *   addCommands() {
+   *     return { customCommand: () => ({ tr }) => true };
+   *   },
+   * });
+   */
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>
+  ): Extension<ExtendedOptions, ExtendedStorage> {
+    // Merge base config with extended config
+    const newConfig = {
+      ...this.config,
+      ...extendedConfig,
+    } as ExtensionConfig<ExtendedOptions, ExtendedStorage>;
+
+    return new Extension(newConfig);
+  }
+}

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -47,8 +47,9 @@ export class Extension<Options = unknown, Storage = unknown> {
   /**
    * Extension type identifier
    * Used to distinguish between Extension, Node, and Mark
+   * Subclasses override this to 'node' or 'mark'
    */
-  readonly type = 'extension' as const;
+  readonly type: 'extension' | 'node' | 'mark' = 'extension';
 
   /**
    * Unique extension name

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -74,9 +74,9 @@ export class Extension<Options = unknown, Storage = unknown> {
 
   /**
    * Editor instance (set by ExtensionManager after creation)
-   * null! indicates it will be set before use
+   * null until ExtensionManager binds it
    */
-  editor: ExtensionEditorInterface = null!;
+  editor: ExtensionEditorInterface | null = null;
 
   /**
    * Protected constructor - use Extension.create() instead

--- a/packages/core/src/Mark.test.ts
+++ b/packages/core/src/Mark.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Tests for Mark class
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Mark } from './Mark.js';
+
+describe('Mark', () => {
+  describe('create()', () => {
+    it('creates a mark with a name', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      expect(mark.name).toBe('bold');
+    });
+
+    it('sets type to "mark"', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      expect(mark.type).toBe('mark');
+    });
+
+    it('creates mark with default options', () => {
+      interface BoldOptions {
+        HTMLAttributes: Record<string, unknown>;
+      }
+
+      const mark = Mark.create<BoldOptions>({
+        name: 'bold',
+        addOptions() {
+          return {
+            HTMLAttributes: { class: 'bold' },
+          };
+        },
+      });
+
+      expect(mark.options.HTMLAttributes).toEqual({ class: 'bold' });
+    });
+
+    it('creates mark with default storage', () => {
+      interface BoldStorage {
+        count: number;
+      }
+
+      const mark = Mark.create<unknown, BoldStorage>({
+        name: 'bold',
+        addStorage() {
+          return { count: 0 };
+        },
+      });
+
+      expect(mark.storage.count).toBe(0);
+    });
+
+    it('creates mark with empty options if addOptions not provided', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      expect(mark.options).toEqual({});
+    });
+
+    it('creates mark with empty storage if addStorage not provided', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      expect(mark.storage).toEqual({});
+    });
+  });
+
+  describe('configure()', () => {
+    it('creates new mark with merged options', () => {
+      interface BoldOptions {
+        weight: string;
+        color: string;
+      }
+
+      const original = Mark.create<BoldOptions>({
+        name: 'bold',
+        addOptions() {
+          return { weight: 'bold', color: 'black' };
+        },
+      });
+
+      const configured = original.configure({ weight: '700' });
+
+      expect(configured.options.weight).toBe('700');
+      expect(configured.options.color).toBe('black');
+    });
+
+    it('does not modify original mark', () => {
+      interface BoldOptions {
+        weight: string;
+      }
+
+      const original = Mark.create<BoldOptions>({
+        name: 'bold',
+        addOptions() {
+          return { weight: 'bold' };
+        },
+      });
+
+      original.configure({ weight: '700' });
+
+      expect(original.options.weight).toBe('bold');
+    });
+
+    it('returns a Mark instance', () => {
+      const mark = Mark.create({ name: 'bold' });
+      const configured = mark.configure({});
+
+      expect(configured).toBeInstanceOf(Mark);
+    });
+
+    it('preserves mark type after configure', () => {
+      const mark = Mark.create({ name: 'bold' });
+      const configured = mark.configure({});
+
+      expect(configured.type).toBe('mark');
+    });
+  });
+
+  describe('extend()', () => {
+    it('creates new mark with extended config', () => {
+      const base = Mark.create({ name: 'bold' });
+      const extended = base.extend({ name: 'customBold' });
+
+      expect(extended.name).toBe('customBold');
+    });
+
+    it('does not modify original mark', () => {
+      const original = Mark.create({ name: 'bold' });
+      original.extend({ name: 'customBold' });
+
+      expect(original.name).toBe('bold');
+    });
+
+    it('returns a Mark instance', () => {
+      const mark = Mark.create({ name: 'bold' });
+      const extended = mark.extend({ name: 'customBold' });
+
+      expect(extended).toBeInstanceOf(Mark);
+    });
+
+    it('preserves original config when extending', () => {
+      interface BoldOptions {
+        weight: string;
+      }
+
+      const original = Mark.create<BoldOptions>({
+        name: 'bold',
+        addOptions() {
+          return { weight: 'bold' };
+        },
+      });
+
+      const extended = original.extend({ name: 'customBold' });
+
+      expect(extended.options.weight).toBe('bold');
+    });
+
+    it('can extend with new options type', () => {
+      interface BaseOptions {
+        weight: string;
+      }
+
+      interface ExtendedOptions extends BaseOptions {
+        color: string;
+      }
+
+      const base = Mark.create<BaseOptions>({
+        name: 'bold',
+        addOptions() {
+          return { weight: 'bold' };
+        },
+      });
+
+      const extended = base.extend<ExtendedOptions>({
+        addOptions() {
+          return { weight: 'bold', color: 'red' };
+        },
+      });
+
+      expect(extended.options.color).toBe('red');
+    });
+
+    it('preserves type as mark after extend', () => {
+      const base = Mark.create({ name: 'bold' });
+      const extended = base.extend({ name: 'customBold' });
+
+      expect(extended.type).toBe('mark');
+    });
+  });
+
+  describe('markType getter', () => {
+    it('returns null when editor is not set', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      expect(mark.markType).toBeNull();
+    });
+
+    it('returns MarkType from schema when editor is set', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      // Mock editor with schema
+      const mockMarkType = { name: 'bold' };
+      mark.editor = {
+        schema: {
+          marks: {
+            bold: mockMarkType,
+          },
+        },
+      } as never;
+
+      expect(mark.markType).toBe(mockMarkType);
+    });
+
+    it('returns null when mark not in schema', () => {
+      const mark = Mark.create({ name: 'bold' });
+
+      // Mock editor with schema that doesn't have this mark
+      mark.editor = {
+        schema: {
+          marks: {},
+        },
+      } as never;
+
+      expect(mark.markType).toBeNull();
+    });
+  });
+
+  describe('createMarkSpec()', () => {
+    describe('schema properties', () => {
+      it('includes inclusive in spec', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          inclusive: false,
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.inclusive).toBe(false);
+      });
+
+      it('includes excludes in spec', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          excludes: 'italic',
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.excludes).toBe('italic');
+      });
+
+      it('includes group in spec', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          group: 'formatting',
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.group).toBe('formatting');
+      });
+
+      it('includes spanning in spec', () => {
+        const mark = Mark.create({
+          name: 'code',
+          spanning: false,
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.spanning).toBe(false);
+      });
+
+      it('excludes undefined properties from spec', () => {
+        const mark = Mark.create({ name: 'bold' });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.inclusive).toBeUndefined();
+        expect(spec.excludes).toBeUndefined();
+        expect(spec.group).toBeUndefined();
+        expect(spec.spanning).toBeUndefined();
+      });
+    });
+
+    describe('attributes', () => {
+      it('converts addAttributes to spec.attrs', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null },
+            };
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.attrs).toEqual({
+          href: { default: null },
+        });
+      });
+
+      it('includes validate function in attrs', () => {
+        const validateFn = (value: unknown): boolean =>
+          typeof value === 'string' && value.startsWith('http');
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null, validate: validateFn },
+            };
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect((spec.attrs!['href'] as { validate?: unknown }).validate).toBe(
+          validateFn
+        );
+      });
+
+      it('handles multiple attributes', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null },
+              target: { default: '_blank' },
+              rel: { default: 'noopener' },
+            };
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.attrs).toEqual({
+          href: { default: null },
+          target: { default: '_blank' },
+          rel: { default: 'noopener' },
+        });
+      });
+    });
+
+    describe('parseHTML', () => {
+      it('converts parseHTML to parseDOM', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [{ tag: 'strong' }];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.parseDOM).toHaveLength(1);
+        expect((spec.parseDOM![0] as { tag: string }).tag).toBe('strong');
+      });
+
+      it('handles multiple parse rules', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [{ tag: 'strong' }, { tag: 'b' }];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec.parseDOM).toHaveLength(2);
+        expect((spec.parseDOM![0] as { tag: string }).tag).toBe('strong');
+        expect((spec.parseDOM![1] as { tag: string }).tag).toBe('b');
+      });
+
+      it('handles style parse rules', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [{ style: 'font-weight=bold' }];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect((spec.parseDOM![0] as { style: string }).style).toBe(
+          'font-weight=bold'
+        );
+      });
+
+      it('includes priority in parse rule', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [{ tag: 'strong', priority: 100 }];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        expect((spec.parseDOM![0] as { priority: number }).priority).toBe(100);
+      });
+
+      it('includes getAttrs from rule', () => {
+        const mark = Mark.create({
+          name: 'link',
+          parseHTML() {
+            return [
+              {
+                tag: 'a',
+                getAttrs: (el) =>
+                  typeof el === 'string'
+                    ? null
+                    : { href: el.getAttribute('href') },
+              },
+            ];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockElement = document.createElement('a');
+        mockElement.setAttribute('href', 'https://example.com');
+        const parseRule = spec.parseDOM![0] as {
+          getAttrs: (el: HTMLElement) => unknown;
+        };
+        const attrs = parseRule.getAttrs(mockElement);
+
+        expect(attrs).toEqual({ href: 'https://example.com' });
+      });
+
+      it('returns false when getAttrs returns false', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [
+              {
+                tag: 'span',
+                getAttrs: () => false,
+              },
+            ];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockElement = document.createElement('span');
+        const parseRule = spec.parseDOM![0] as {
+          getAttrs: (el: HTMLElement) => unknown;
+        };
+        const attrs = parseRule.getAttrs(mockElement);
+
+        expect(attrs).toBe(false);
+      });
+
+      it('returns null when getAttrs returns null', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [
+              {
+                tag: 'span',
+                getAttrs: () => null,
+              },
+            ];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockElement = document.createElement('span');
+        const parseRule = spec.parseDOM![0] as {
+          getAttrs: (el: HTMLElement) => unknown;
+        };
+        const attrs = parseRule.getAttrs(mockElement);
+
+        expect(attrs).toBeNull();
+      });
+
+      it('handles style rules with string input', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          parseHTML() {
+            return [
+              {
+                style: 'font-weight',
+                getAttrs: (value) =>
+                  typeof value === 'string' && /bold|[5-9]\d{2}/.test(value)
+                    ? {}
+                    : false,
+              },
+            ];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const parseRule = spec.parseDOM![0] as {
+          getAttrs: (el: HTMLElement | string) => unknown;
+        };
+
+        expect(parseRule.getAttrs('bold')).toEqual({});
+        expect(parseRule.getAttrs('700')).toEqual({});
+        expect(parseRule.getAttrs('normal')).toBe(false);
+      });
+    });
+
+    describe('renderHTML', () => {
+      it('converts renderHTML to toDOM', () => {
+        const mark = Mark.create({
+          name: 'bold',
+          renderHTML({ HTMLAttributes }) {
+            return ['strong', HTMLAttributes, 0];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockMark = { attrs: {} };
+        const result = spec.toDOM!(mockMark as never);
+
+        expect(result).toEqual(['strong', {}, 0]);
+      });
+
+      it('passes mark attributes to renderHTML', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['a', HTMLAttributes, 0];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockMark = { attrs: { href: 'https://example.com' } };
+        const result = spec.toDOM!(mockMark as never);
+
+        expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
+      });
+
+      it('uses attribute renderHTML when defined', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: {
+                default: null,
+                renderHTML: (attributes) => ({
+                  href: attributes['href'] as string,
+                  rel: 'noopener',
+                }),
+              },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['a', HTMLAttributes, 0];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockMark = { attrs: { href: 'https://example.com' } };
+        const result = spec.toDOM!(mockMark as never);
+
+        expect(result).toEqual([
+          'a',
+          { href: 'https://example.com', rel: 'noopener' },
+          0,
+        ]);
+      });
+
+      it('skips attributes with rendered: false', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null },
+              internal: { default: false, rendered: false },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['a', HTMLAttributes, 0];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockMark = { attrs: { href: 'https://example.com', internal: true } };
+        const result = spec.toDOM!(mockMark as never);
+
+        expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
+      });
+
+      it('skips null/undefined attribute values', () => {
+        const mark = Mark.create({
+          name: 'link',
+          addAttributes() {
+            return {
+              href: { default: null },
+              title: { default: null },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['a', HTMLAttributes, 0];
+          },
+        });
+        const spec = mark.createMarkSpec();
+
+        const mockMark = { attrs: { href: 'https://example.com', title: null } };
+        const result = spec.toDOM!(mockMark as never);
+
+        expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
+      });
+    });
+  });
+});

--- a/packages/core/src/Mark.test.ts
+++ b/packages/core/src/Mark.test.ts
@@ -499,7 +499,7 @@ describe('Mark', () => {
         const spec = mark.createMarkSpec();
 
         const mockMark = { attrs: {} };
-        const result = spec.toDOM!(mockMark as never);
+        const result = spec.toDOM!(mockMark as never, true);
 
         expect(result).toEqual(['strong', {}, 0]);
       });
@@ -519,7 +519,7 @@ describe('Mark', () => {
         const spec = mark.createMarkSpec();
 
         const mockMark = { attrs: { href: 'https://example.com' } };
-        const result = spec.toDOM!(mockMark as never);
+        const result = spec.toDOM!(mockMark as never, true);
 
         expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
       });
@@ -545,7 +545,7 @@ describe('Mark', () => {
         const spec = mark.createMarkSpec();
 
         const mockMark = { attrs: { href: 'https://example.com' } };
-        const result = spec.toDOM!(mockMark as never);
+        const result = spec.toDOM!(mockMark as never, true);
 
         expect(result).toEqual([
           'a',
@@ -570,7 +570,7 @@ describe('Mark', () => {
         const spec = mark.createMarkSpec();
 
         const mockMark = { attrs: { href: 'https://example.com', internal: true } };
-        const result = spec.toDOM!(mockMark as never);
+        const result = spec.toDOM!(mockMark as never, true);
 
         expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
       });
@@ -591,7 +591,7 @@ describe('Mark', () => {
         const spec = mark.createMarkSpec();
 
         const mockMark = { attrs: { href: 'https://example.com', title: null } };
-        const result = spec.toDOM!(mockMark as never);
+        const result = spec.toDOM!(mockMark as never, true);
 
         expect(result).toEqual(['a', { href: 'https://example.com' }, 0]);
       });

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -1,0 +1,293 @@
+/**
+ * Mark - Base class for mark extensions
+ *
+ * Marks define inline formatting that can be applied to text.
+ * Examples: Bold, Italic, Link, Code, etc.
+ *
+ * Three-tier model:
+ * - Extension (type: 'extension') → Pure functionality (History, Placeholder, etc.)
+ * - Node (type: 'node') → Schema nodes (Paragraph, Heading, etc.)
+ * - Mark (type: 'mark') → Schema marks (Bold, Italic, etc.)
+ *
+ * @example
+ * const Bold = Mark.create({
+ *   name: 'bold',
+ *   parseHTML() {
+ *     return [
+ *       { tag: 'strong' },
+ *       { tag: 'b' },
+ *       { style: 'font-weight=bold' },
+ *     ];
+ *   },
+ *   renderHTML({ HTMLAttributes }) {
+ *     return ['strong', HTMLAttributes, 0];
+ *   },
+ * });
+ */
+
+import type { MarkSpec, MarkType, ParseRule } from 'prosemirror-model';
+import { Extension, type ExtensionEditorInterface } from './Extension.js';
+import type { MarkConfig } from './types/MarkConfig.js';
+import { callOrReturn } from './helpers/callOrReturn.js';
+
+/**
+ * Extended editor interface for Mark
+ * Includes schema access for MarkType getter
+ */
+export interface MarkEditorInterface extends ExtensionEditorInterface {
+  readonly schema: {
+    marks: Record<string, MarkType>;
+  };
+}
+
+/**
+ * Base class for mark extensions
+ *
+ * @typeParam Options - Mark options type
+ * @typeParam Storage - Mark storage type
+ */
+export class Mark<Options = unknown, Storage = unknown> extends Extension<
+  Options,
+  Storage
+> {
+  /**
+   * Mark type identifier
+   * Distinguishes marks from extensions and nodes
+   */
+  override readonly type = 'mark' as const;
+
+  /**
+   * The original configuration object
+   * Typed as MarkConfig for mark-specific properties
+   */
+  declare readonly config: MarkConfig<Options, Storage>;
+
+  /**
+   * Editor instance with schema access
+   * null until set by ExtensionManager
+   */
+  override editor: MarkEditorInterface | null = null;
+
+  /**
+   * Protected constructor - use Mark.create() instead
+   */
+  protected constructor(config: MarkConfig<Options, Storage>) {
+    super(config);
+  }
+
+  /**
+   * Get the ProseMirror MarkType from schema
+   *
+   * This is a lazy getter because schema doesn't exist at mark creation time.
+   * Schema is built FROM marks by ExtensionManager.
+   *
+   * Returns null if editor is not yet initialized.
+   * Always check editor is set before using markType.
+   */
+  get markType(): MarkType | null {
+    if (!this.editor) {
+      return null;
+    }
+    return this.editor.schema.marks[this.name] ?? null;
+  }
+
+  /**
+   * Creates a new mark instance
+   *
+   * @param config - Mark configuration
+   * @returns New mark instance
+   *
+   * @example
+   * const Bold = Mark.create({
+   *   name: 'bold',
+   *   parseHTML() {
+   *     return [{ tag: 'strong' }, { tag: 'b' }];
+   *   },
+   * });
+   */
+  static override create<O = unknown, S = unknown>(
+    config: MarkConfig<O, S>
+  ): Mark<O, S> {
+    return new Mark(config);
+  }
+
+  /**
+   * Creates a new mark with merged options
+   * Original mark is not modified
+   *
+   * @param options - Options to merge with existing options
+   * @returns New mark instance with merged options
+   *
+   * @example
+   * const CustomBold = Bold.configure({ HTMLAttributes: { class: 'custom-bold' } });
+   */
+  override configure(options: Partial<Options>): Mark<Options, Storage> {
+    const newConfig: MarkConfig<Options, Storage> = {
+      ...this.config,
+      addOptions: () => ({
+        ...this.options,
+        ...options,
+      }),
+    };
+
+    return new Mark(newConfig);
+  }
+
+  /**
+   * Creates a new mark with extended configuration
+   * Original mark is not modified
+   *
+   * @param extendedConfig - Configuration to extend/override
+   * @returns New mark instance with extended config
+   *
+   * @example
+   * const CustomBold = Bold.extend({
+   *   name: 'customBold',
+   *   addAttributes() {
+   *     return { ...this.parent?.(), weight: { default: 'bold' } };
+   *   },
+   * });
+   */
+  override extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>
+  ): Mark<ExtendedOptions, ExtendedStorage> {
+    const newConfig = {
+      ...this.config,
+      ...extendedConfig,
+    } as MarkConfig<ExtendedOptions, ExtendedStorage>;
+
+    return new Mark(newConfig);
+  }
+
+  /**
+   * Creates a ProseMirror MarkSpec from this mark's configuration
+   *
+   * Called by ExtensionManager when building the schema.
+   * Converts our config format to ProseMirror's MarkSpec format.
+   *
+   * @returns ProseMirror MarkSpec
+   */
+  createMarkSpec(): MarkSpec {
+    const spec: MarkSpec = {};
+
+    // Schema properties - copy directly if defined
+    if (this.config.inclusive !== undefined)
+      spec.inclusive = this.config.inclusive;
+    if (this.config.excludes !== undefined)
+      spec.excludes = this.config.excludes;
+    if (this.config.group !== undefined) spec.group = this.config.group;
+    if (this.config.spanning !== undefined)
+      spec.spanning = this.config.spanning;
+
+    // Attributes - convert AttributeSpecs to ProseMirror attrs
+    const attributeSpecs = callOrReturn(this.config.addAttributes, this);
+    if (attributeSpecs) {
+      spec.attrs = {};
+      for (const [name, attrSpec] of Object.entries(attributeSpecs)) {
+        spec.attrs[name] = {
+          default: attrSpec.default,
+        };
+        // Add validate if defined (ProseMirror 1.22.0+)
+        if (attrSpec.validate) {
+          (spec.attrs[name] as { validate?: unknown }).validate =
+            attrSpec.validate;
+        }
+      }
+    }
+
+    // Parse rules - convert to parseDOM
+    const parseRules = callOrReturn(this.config.parseHTML, this);
+    if (parseRules && parseRules.length > 0) {
+      // Build parseDOM array with proper typing
+      const parseDOMRules = parseRules.map((rule) => {
+        // Build parse rule object
+        const parseRule: {
+          tag?: string;
+          style?: string;
+          priority?: number;
+          consuming?: boolean;
+          getAttrs?: (
+            node: HTMLElement | string
+          ) => Record<string, unknown> | false | null;
+        } = {};
+
+        if (rule.tag) parseRule.tag = rule.tag;
+        if (rule.style) parseRule.style = rule.style;
+        if (rule.priority !== undefined) parseRule.priority = rule.priority;
+        if (rule.consuming !== undefined) parseRule.consuming = rule.consuming;
+
+        // Handle getAttrs - need to merge with attribute parseHTML
+        if (rule.getAttrs || attributeSpecs) {
+          parseRule.getAttrs = (node: HTMLElement | string) => {
+            // Get attrs from rule
+            const ruleAttrs = rule.getAttrs ? rule.getAttrs(node) : {};
+
+            // If rule returned null or false, skip this rule
+            if (ruleAttrs === null || ruleAttrs === false) {
+              return ruleAttrs;
+            }
+
+            // Get attrs from attribute parseHTML functions
+            const parsedAttrs: Record<string, unknown> = { ...ruleAttrs };
+            if (attributeSpecs) {
+              for (const [name, attrSpec] of Object.entries(attributeSpecs)) {
+                if (attrSpec.parseHTML) {
+                  // For marks, parseHTML might receive string (style value) or HTMLElement
+                  parsedAttrs[name] =
+                    typeof node === 'string'
+                      ? attrSpec.parseHTML(
+                          document.createElement('span') // fallback element for style parsing
+                        )
+                      : attrSpec.parseHTML(node);
+                }
+              }
+            }
+
+            return parsedAttrs;
+          };
+        }
+
+        return parseRule;
+      });
+
+      // Cast to satisfy strict MarkSpec.parseDOM type
+      spec.parseDOM = parseDOMRules as unknown as readonly ParseRule[];
+    }
+
+    // Render - convert renderHTML to toDOM
+    if (this.config.renderHTML) {
+      const renderFn = this.config.renderHTML;
+      const attrSpecs = attributeSpecs;
+
+      spec.toDOM = (mark) => {
+        // Build HTML attributes from mark attrs and renderHTML functions
+        let htmlAttrs: Record<string, unknown> = {};
+
+        if (attrSpecs) {
+          for (const [name, attrSpec] of Object.entries(attrSpecs)) {
+            // Skip if not rendered
+            if (attrSpec.rendered === false) continue;
+
+            // Use renderHTML if defined, otherwise add directly
+            if (attrSpec.renderHTML) {
+              const rendered = attrSpec.renderHTML(mark.attrs);
+              if (rendered) {
+                htmlAttrs = { ...htmlAttrs, ...rendered };
+              }
+            } else if (
+              mark.attrs[name] !== undefined &&
+              mark.attrs[name] !== null
+            ) {
+              // Default: use attribute value directly
+              htmlAttrs[name] = mark.attrs[name];
+            }
+          }
+        }
+
+        return renderFn({ mark, HTMLAttributes: htmlAttrs });
+      };
+    }
+
+    return spec;
+  }
+}

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -259,7 +259,7 @@ export class Mark<Options = unknown, Storage = unknown> extends Extension<
       const renderFn = this.config.renderHTML;
       const attrSpecs = attributeSpecs;
 
-      spec.toDOM = (mark) => {
+      spec.toDOM = (mark, _inline) => {
         // Build HTML attributes from mark attrs and renderHTML functions
         let htmlAttrs: Record<string, unknown> = {};
 

--- a/packages/core/src/Node.test.ts
+++ b/packages/core/src/Node.test.ts
@@ -1,0 +1,689 @@
+import { describe, it, expect } from 'vitest';
+import { Node } from './Node.js';
+
+describe('Node', () => {
+  describe('create()', () => {
+    it('creates node with name', () => {
+      const node = Node.create({ name: 'paragraph' });
+
+      expect(node.name).toBe('paragraph');
+      expect(node.type).toBe('node');
+    });
+
+    it('creates node with default options from addOptions', () => {
+      const node = Node.create({
+        name: 'heading',
+        addOptions() {
+          return { levels: [1, 2, 3], HTMLAttributes: {} };
+        },
+      });
+
+      expect(node.options).toEqual({ levels: [1, 2, 3], HTMLAttributes: {} });
+    });
+
+    it('creates node with empty options if addOptions not defined', () => {
+      const node = Node.create({ name: 'paragraph' });
+
+      expect(node.options).toEqual({});
+    });
+
+    it('creates node with storage from addStorage', () => {
+      const node = Node.create({
+        name: 'counter',
+        addStorage() {
+          return { count: 0 };
+        },
+      });
+
+      expect(node.storage).toEqual({ count: 0 });
+    });
+
+    it('stores the original config', () => {
+      const config = {
+        name: 'paragraph',
+        group: 'block',
+        content: 'inline*',
+        priority: 900,
+      };
+      const node = Node.create(config);
+
+      expect(node.config.name).toBe('paragraph');
+      expect(node.config.group).toBe('block');
+      expect(node.config.content).toBe('inline*');
+      expect(node.config.priority).toBe(900);
+    });
+
+    it('allows access to this.name in addOptions', () => {
+      const node = Node.create({
+        name: 'myNode',
+        addOptions() {
+          return { nodeName: this.name };
+        },
+      });
+
+      expect(node.options.nodeName).toBe('myNode');
+    });
+
+    it('initializes editor as null', () => {
+      const node = Node.create({ name: 'paragraph' });
+
+      expect(node.editor).toBeNull();
+    });
+  });
+
+  describe('configure()', () => {
+    it('returns new instance with merged options', () => {
+      const node = Node.create({
+        name: 'heading',
+        addOptions() {
+          return { levels: [1, 2, 3], defaultLevel: 1 };
+        },
+      });
+
+      const configured = node.configure({ defaultLevel: 2 });
+
+      expect(configured.options).toEqual({ levels: [1, 2, 3], defaultLevel: 2 });
+    });
+
+    it('does not modify original node', () => {
+      const node = Node.create({
+        name: 'heading',
+        addOptions() {
+          return { level: 1 };
+        },
+      });
+
+      node.configure({ level: 2 });
+
+      expect(node.options.level).toBe(1);
+    });
+
+    it('returns new Node instance', () => {
+      const node = Node.create({ name: 'paragraph' });
+      const configured = node.configure({});
+
+      expect(configured).toBeInstanceOf(Node);
+      expect(configured).not.toBe(node);
+    });
+
+    it('preserves node name', () => {
+      const node = Node.create({ name: 'paragraph' });
+      const configured = node.configure({});
+
+      expect(configured.name).toBe('paragraph');
+    });
+
+    it('preserves node type', () => {
+      const node = Node.create({ name: 'paragraph' });
+      const configured = node.configure({});
+
+      expect(configured.type).toBe('node');
+    });
+
+    it('preserves schema properties', () => {
+      const node = Node.create({
+        name: 'paragraph',
+        group: 'block',
+        content: 'inline*',
+        addOptions() {
+          return { value: 1 };
+        },
+      });
+
+      const configured = node.configure({ value: 2 });
+
+      expect(configured.config.group).toBe('block');
+      expect(configured.config.content).toBe('inline*');
+    });
+  });
+
+  describe('extend()', () => {
+    it('returns new instance with extended config', () => {
+      const base = Node.create({
+        name: 'paragraph',
+        group: 'block',
+      });
+
+      const extended = base.extend({
+        name: 'customParagraph',
+        content: 'inline*',
+      });
+
+      expect(extended.name).toBe('customParagraph');
+      expect(extended.config.content).toBe('inline*');
+    });
+
+    it('does not modify original node', () => {
+      const base = Node.create({ name: 'paragraph' });
+
+      base.extend({ name: 'customParagraph' });
+
+      expect(base.name).toBe('paragraph');
+    });
+
+    it('returns new Node instance', () => {
+      const base = Node.create({ name: 'paragraph' });
+      const extended = base.extend({ name: 'customParagraph' });
+
+      expect(extended).toBeInstanceOf(Node);
+      expect(extended).not.toBe(base);
+    });
+
+    it('inherits config from base when not overridden', () => {
+      const base = Node.create({
+        name: 'paragraph',
+        group: 'block',
+        content: 'inline*',
+        priority: 900,
+      });
+
+      const extended = base.extend({
+        name: 'customParagraph',
+      });
+
+      expect(extended.config.group).toBe('block');
+      expect(extended.config.content).toBe('inline*');
+      expect(extended.config.priority).toBe(900);
+    });
+
+    it('overrides config when specified', () => {
+      const base = Node.create({
+        name: 'paragraph',
+        group: 'block',
+      });
+
+      const extended = base.extend({
+        name: 'customParagraph',
+        group: 'block custom',
+      });
+
+      expect(extended.config.group).toBe('block custom');
+    });
+
+    it('sets type to node', () => {
+      const base = Node.create({ name: 'paragraph' });
+      const extended = base.extend({ name: 'customParagraph' });
+
+      expect(extended.type).toBe('node');
+    });
+  });
+
+  describe('nodeType getter', () => {
+    it('throws error when editor is not set', () => {
+      const node = Node.create({ name: 'paragraph' });
+
+      expect(() => node.nodeType).toThrow(/editor not initialized/);
+    });
+
+    it('returns NodeType from schema when editor is set', () => {
+      const node = Node.create({ name: 'paragraph' });
+
+      // Mock editor with schema
+      const mockNodeType = { name: 'paragraph' };
+      node.editor = {
+        state: {},
+        view: {},
+        schema: {
+          nodes: {
+            paragraph: mockNodeType,
+          },
+        },
+      } as unknown as typeof node.editor;
+
+      expect(node.nodeType).toBe(mockNodeType);
+    });
+  });
+
+  describe('createNodeSpec()', () => {
+    it('creates empty spec for minimal node', () => {
+      const node = Node.create({ name: 'paragraph' });
+      const spec = node.createNodeSpec();
+
+      expect(spec).toEqual({});
+    });
+
+    it('includes group in spec', () => {
+      const node = Node.create({
+        name: 'paragraph',
+        group: 'block',
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.group).toBe('block');
+    });
+
+    it('includes content in spec', () => {
+      const node = Node.create({
+        name: 'paragraph',
+        content: 'inline*',
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.content).toBe('inline*');
+    });
+
+    it('includes inline flag in spec', () => {
+      const node = Node.create({
+        name: 'hardBreak',
+        inline: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.inline).toBe(true);
+    });
+
+    it('includes atom flag in spec', () => {
+      const node = Node.create({
+        name: 'image',
+        atom: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.atom).toBe(true);
+    });
+
+    it('includes selectable flag in spec', () => {
+      const node = Node.create({
+        name: 'hardBreak',
+        selectable: false,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.selectable).toBe(false);
+    });
+
+    it('includes draggable flag in spec', () => {
+      const node = Node.create({
+        name: 'image',
+        draggable: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.draggable).toBe(true);
+    });
+
+    it('includes code flag in spec', () => {
+      const node = Node.create({
+        name: 'codeBlock',
+        code: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.code).toBe(true);
+    });
+
+    it('includes whitespace in spec', () => {
+      const node = Node.create({
+        name: 'codeBlock',
+        whitespace: 'pre',
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.whitespace).toBe('pre');
+    });
+
+    it('includes isolating flag in spec', () => {
+      const node = Node.create({
+        name: 'tableCell',
+        isolating: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.isolating).toBe(true);
+    });
+
+    it('includes defining flag in spec', () => {
+      const node = Node.create({
+        name: 'heading',
+        defining: true,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.defining).toBe(true);
+    });
+
+    it('includes marks in spec', () => {
+      const node = Node.create({
+        name: 'codeBlock',
+        marks: '',
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.marks).toBe('');
+    });
+
+    it('includes leafText as function in spec', () => {
+      const node = Node.create({
+        name: 'hardBreak',
+        leafText: '\n',
+      });
+      const spec = node.createNodeSpec();
+
+      expect(typeof spec.leafText).toBe('function');
+      expect(spec.leafText!({} as never)).toBe('\n');
+    });
+
+    it('includes leafText function directly in spec', () => {
+      const leafTextFn = () => '---';
+      const node = Node.create({
+        name: 'horizontalRule',
+        leafText: leafTextFn,
+      });
+      const spec = node.createNodeSpec();
+
+      expect(spec.leafText).toBe(leafTextFn);
+    });
+
+    describe('attributes', () => {
+      it('converts addAttributes to attrs', () => {
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: { default: 1 },
+            };
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.attrs).toEqual({
+          level: { default: 1 },
+        });
+      });
+
+      it('includes validate function in attrs', () => {
+        const validateFn = (value: unknown) =>
+          typeof value === 'number' && value >= 1 && value <= 6;
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: { default: 1, validate: validateFn },
+            };
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect((spec.attrs!.level as { validate?: unknown }).validate).toBe(
+          validateFn
+        );
+      });
+
+      it('handles multiple attributes', () => {
+        const node = Node.create({
+          name: 'image',
+          addAttributes() {
+            return {
+              src: { default: null },
+              alt: { default: '' },
+              title: { default: null },
+            };
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.attrs).toEqual({
+          src: { default: null },
+          alt: { default: '' },
+          title: { default: null },
+        });
+      });
+    });
+
+    describe('parseHTML', () => {
+      it('converts parseHTML to parseDOM', () => {
+        const node = Node.create({
+          name: 'paragraph',
+          parseHTML() {
+            return [{ tag: 'p' }];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.parseDOM).toHaveLength(1);
+        expect(spec.parseDOM![0].tag).toBe('p');
+      });
+
+      it('handles multiple parse rules', () => {
+        const node = Node.create({
+          name: 'heading',
+          parseHTML() {
+            return [
+              { tag: 'h1' },
+              { tag: 'h2' },
+              { tag: 'h3' },
+            ];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.parseDOM).toHaveLength(3);
+        expect(spec.parseDOM![0].tag).toBe('h1');
+        expect(spec.parseDOM![1].tag).toBe('h2');
+        expect(spec.parseDOM![2].tag).toBe('h3');
+      });
+
+      it('includes priority in parse rule', () => {
+        const node = Node.create({
+          name: 'paragraph',
+          parseHTML() {
+            return [{ tag: 'p', priority: 100 }];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.parseDOM![0].priority).toBe(100);
+      });
+
+      it('includes getAttrs from rule', () => {
+        const node = Node.create({
+          name: 'heading',
+          parseHTML() {
+            return [
+              {
+                tag: 'h1',
+                getAttrs: () => ({ level: 1 }),
+              },
+            ];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockElement = document.createElement('h1');
+        const attrs = spec.parseDOM![0].getAttrs!(mockElement);
+
+        expect(attrs).toEqual({ level: 1 });
+      });
+
+      it('returns false when getAttrs returns null', () => {
+        const node = Node.create({
+          name: 'paragraph',
+          parseHTML() {
+            return [
+              {
+                tag: 'p',
+                getAttrs: () => null,
+              },
+            ];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockElement = document.createElement('p');
+        const attrs = spec.parseDOM![0].getAttrs!(mockElement);
+
+        expect(attrs).toBe(false);
+      });
+
+      it('merges attribute parseHTML with rule getAttrs', () => {
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: {
+                default: 1,
+                parseHTML: (element: HTMLElement) =>
+                  parseInt(element.tagName.charAt(1), 10),
+              },
+            };
+          },
+          parseHTML() {
+            return [{ tag: 'h1' }, { tag: 'h2' }];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const h1 = document.createElement('h1');
+        const h2 = document.createElement('h2');
+
+        expect(spec.parseDOM![0].getAttrs!(h1)).toEqual({ level: 1 });
+        expect(spec.parseDOM![1].getAttrs!(h2)).toEqual({ level: 2 });
+      });
+    });
+
+    describe('renderHTML', () => {
+      it('converts renderHTML to toDOM', () => {
+        const node = Node.create({
+          name: 'paragraph',
+          renderHTML({ HTMLAttributes }) {
+            return ['p', HTMLAttributes, 0];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        expect(spec.toDOM).toBeDefined();
+
+        const mockNode = { attrs: {} };
+        const result = spec.toDOM!(mockNode as never);
+
+        expect(result).toEqual(['p', {}, 0]);
+      });
+
+      it('includes rendered attributes in HTMLAttributes', () => {
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: { default: 1 },
+            };
+          },
+          renderHTML({ node: pmNode, HTMLAttributes }) {
+            return [`h${pmNode.attrs.level}`, HTMLAttributes, 0];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockNode = { attrs: { level: 2 } };
+        const result = spec.toDOM!(mockNode as never);
+
+        expect(result).toEqual(['h2', { level: 2 }, 0]);
+      });
+
+      it('uses attribute renderHTML when defined', () => {
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: {
+                default: 1,
+                renderHTML: (attributes) => ({
+                  'data-level': attributes.level,
+                }),
+              },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['h1', HTMLAttributes, 0];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockNode = { attrs: { level: 2 } };
+        const result = spec.toDOM!(mockNode as never);
+
+        expect(result).toEqual(['h1', { 'data-level': 2 }, 0]);
+      });
+
+      it('skips attributes with rendered: false', () => {
+        const node = Node.create({
+          name: 'heading',
+          addAttributes() {
+            return {
+              level: { default: 1 },
+              internalId: { default: null, rendered: false },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['h1', HTMLAttributes, 0];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockNode = { attrs: { level: 1, internalId: 'abc123' } };
+        const result = spec.toDOM!(mockNode as never);
+
+        expect(result).toEqual(['h1', { level: 1 }, 0]);
+      });
+
+      it('skips null/undefined attribute values', () => {
+        const node = Node.create({
+          name: 'image',
+          addAttributes() {
+            return {
+              src: { default: null },
+              alt: { default: '' },
+            };
+          },
+          renderHTML({ HTMLAttributes }) {
+            return ['img', HTMLAttributes];
+          },
+        });
+        const spec = node.createNodeSpec();
+
+        const mockNode = { attrs: { src: null, alt: 'test' } };
+        const result = spec.toDOM!(mockNode as never);
+
+        expect(result).toEqual(['img', { alt: 'test' }]);
+      });
+    });
+  });
+
+  describe('type safety', () => {
+    it('correctly types options', () => {
+      interface MyOptions {
+        levels: number[];
+        defaultLevel: number;
+      }
+
+      const node = Node.create<MyOptions>({
+        name: 'heading',
+        addOptions() {
+          return { levels: [1, 2, 3], defaultLevel: 1 };
+        },
+      });
+
+      expect(Array.isArray(node.options.levels)).toBe(true);
+      expect(typeof node.options.defaultLevel).toBe('number');
+    });
+
+    it('correctly types storage', () => {
+      interface MyStorage {
+        count: number;
+        history: string[];
+      }
+
+      const node = Node.create<unknown, MyStorage>({
+        name: 'counter',
+        addStorage() {
+          return { count: 0, history: [] };
+        },
+      });
+
+      node.storage.count = 5;
+      node.storage.history.push('action');
+
+      expect(node.storage.count).toBe(5);
+      expect(node.storage.history).toEqual(['action']);
+    });
+  });
+});

--- a/packages/core/src/Node.test.ts
+++ b/packages/core/src/Node.test.ts
@@ -209,10 +209,10 @@ describe('Node', () => {
   });
 
   describe('nodeType getter', () => {
-    it('throws error when editor is not set', () => {
+    it('returns null when editor is not set', () => {
       const node = Node.create({ name: 'paragraph' });
 
-      expect(() => node.nodeType).toThrow(/editor not initialized/);
+      expect(node.nodeType).toBeNull();
     });
 
     it('returns NodeType from schema when editor is set', () => {
@@ -404,7 +404,7 @@ describe('Node', () => {
         });
         const spec = node.createNodeSpec();
 
-        expect((spec.attrs!.level as { validate?: unknown }).validate).toBe(
+        expect((spec.attrs!['level'] as { validate?: unknown }).validate).toBe(
           validateFn
         );
       });
@@ -441,7 +441,7 @@ describe('Node', () => {
         const spec = node.createNodeSpec();
 
         expect(spec.parseDOM).toHaveLength(1);
-        expect(spec.parseDOM![0].tag).toBe('p');
+        expect((spec.parseDOM![0] as { tag: string }).tag).toBe('p');
       });
 
       it('handles multiple parse rules', () => {
@@ -458,9 +458,9 @@ describe('Node', () => {
         const spec = node.createNodeSpec();
 
         expect(spec.parseDOM).toHaveLength(3);
-        expect(spec.parseDOM![0].tag).toBe('h1');
-        expect(spec.parseDOM![1].tag).toBe('h2');
-        expect(spec.parseDOM![2].tag).toBe('h3');
+        expect((spec.parseDOM![0] as { tag: string }).tag).toBe('h1');
+        expect((spec.parseDOM![1] as { tag: string }).tag).toBe('h2');
+        expect((spec.parseDOM![2] as { tag: string }).tag).toBe('h3');
       });
 
       it('includes priority in parse rule', () => {
@@ -472,7 +472,7 @@ describe('Node', () => {
         });
         const spec = node.createNodeSpec();
 
-        expect(spec.parseDOM![0].priority).toBe(100);
+        expect((spec.parseDOM![0] as { priority: number }).priority).toBe(100);
       });
 
       it('includes getAttrs from rule', () => {
@@ -490,7 +490,8 @@ describe('Node', () => {
         const spec = node.createNodeSpec();
 
         const mockElement = document.createElement('h1');
-        const attrs = spec.parseDOM![0].getAttrs!(mockElement);
+        const parseRule = spec.parseDOM![0] as { getAttrs: (el: HTMLElement) => unknown };
+        const attrs = parseRule.getAttrs(mockElement);
 
         expect(attrs).toEqual({ level: 1 });
       });
@@ -510,7 +511,8 @@ describe('Node', () => {
         const spec = node.createNodeSpec();
 
         const mockElement = document.createElement('p');
-        const attrs = spec.parseDOM![0].getAttrs!(mockElement);
+        const parseRule = spec.parseDOM![0] as { getAttrs: (el: HTMLElement) => unknown };
+        const attrs = parseRule.getAttrs(mockElement);
 
         expect(attrs).toBe(false);
       });
@@ -536,8 +538,10 @@ describe('Node', () => {
         const h1 = document.createElement('h1');
         const h2 = document.createElement('h2');
 
-        expect(spec.parseDOM![0].getAttrs!(h1)).toEqual({ level: 1 });
-        expect(spec.parseDOM![1].getAttrs!(h2)).toEqual({ level: 2 });
+        const rule0 = spec.parseDOM![0] as { getAttrs: (el: HTMLElement) => unknown };
+        const rule1 = spec.parseDOM![1] as { getAttrs: (el: HTMLElement) => unknown };
+        expect(rule0.getAttrs(h1)).toEqual({ level: 1 });
+        expect(rule1.getAttrs(h2)).toEqual({ level: 2 });
       });
     });
 
@@ -568,7 +572,7 @@ describe('Node', () => {
             };
           },
           renderHTML({ node: pmNode, HTMLAttributes }) {
-            return [`h${pmNode.attrs.level}`, HTMLAttributes, 0];
+            return [`h${pmNode.attrs['level']}`, HTMLAttributes, 0];
           },
         });
         const spec = node.createNodeSpec();
@@ -587,7 +591,7 @@ describe('Node', () => {
               level: {
                 default: 1,
                 renderHTML: (attributes) => ({
-                  'data-level': attributes.level,
+                  'data-level': attributes['level'] as number,
                 }),
               },
             };

--- a/packages/core/src/Node.test.ts
+++ b/packages/core/src/Node.test.ts
@@ -364,7 +364,7 @@ describe('Node', () => {
     });
 
     it('includes leafText function directly in spec', () => {
-      const leafTextFn = () => '---';
+      const leafTextFn = (): string => '---';
       const node = Node.create({
         name: 'horizontalRule',
         leafText: leafTextFn,
@@ -392,7 +392,7 @@ describe('Node', () => {
       });
 
       it('includes validate function in attrs', () => {
-        const validateFn = (value: unknown) =>
+        const validateFn = (value: unknown): boolean =>
           typeof value === 'number' && value >= 1 && value <= 6;
         const node = Node.create({
           name: 'heading',
@@ -572,7 +572,7 @@ describe('Node', () => {
             };
           },
           renderHTML({ node: pmNode, HTMLAttributes }) {
-            return [`h${pmNode.attrs['level']}`, HTMLAttributes, 0];
+            return [`h${String(pmNode.attrs['level'])}`, HTMLAttributes, 0];
           },
         });
         const spec = node.createNodeSpec();

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -1,0 +1,311 @@
+/**
+ * Node - Base class for node extensions
+ *
+ * Nodes define document structure elements that contribute to the schema.
+ * Examples: Paragraph, Heading, List, Image, etc.
+ *
+ * Three-tier model:
+ * - Extension (type: 'extension') → Pure functionality (History, Placeholder, etc.)
+ * - Node (type: 'node') → Schema nodes (Paragraph, Heading, etc.)
+ * - Mark (type: 'mark') → Schema marks (Bold, Italic, etc.)
+ *
+ * @example
+ * const Paragraph = Node.create({
+ *   name: 'paragraph',
+ *   group: 'block',
+ *   content: 'inline*',
+ *   parseHTML() {
+ *     return [{ tag: 'p' }];
+ *   },
+ *   renderHTML({ HTMLAttributes }) {
+ *     return ['p', HTMLAttributes, 0];
+ *   },
+ * });
+ */
+
+import type { NodeSpec, NodeType } from 'prosemirror-model';
+import { Extension, type ExtensionEditorInterface } from './Extension.js';
+import type { NodeConfig } from './types/NodeConfig.js';
+import { callOrReturn } from './helpers/callOrReturn.js';
+
+/**
+ * Extended editor interface for Node
+ * Includes schema access for NodeType getter
+ */
+export interface NodeEditorInterface extends ExtensionEditorInterface {
+  readonly schema: {
+    nodes: Record<string, NodeType>;
+  };
+}
+
+/**
+ * Base class for node extensions
+ *
+ * @typeParam Options - Node options type
+ * @typeParam Storage - Node storage type
+ */
+export class Node<Options = unknown, Storage = unknown> extends Extension<
+  Options,
+  Storage
+> {
+  /**
+   * Node type identifier
+   * Distinguishes nodes from extensions and marks
+   */
+  declare readonly type: 'node';
+
+  /**
+   * The original configuration object
+   * Typed as NodeConfig for node-specific properties
+   */
+  declare readonly config: NodeConfig<Options, Storage>;
+
+  /**
+   * Editor instance with schema access
+   */
+  declare editor: NodeEditorInterface;
+
+  /**
+   * Protected constructor - use Node.create() instead
+   */
+  protected constructor(config: NodeConfig<Options, Storage>) {
+    super(config);
+    // Override type after super() call
+    (this as { type: 'node' }).type = 'node';
+  }
+
+  /**
+   * Get the ProseMirror NodeType from schema
+   *
+   * This is a lazy getter because schema doesn't exist at node creation time.
+   * Schema is built FROM nodes by ExtensionManager.
+   *
+   * @throws Error if accessed before editor is set
+   */
+  get nodeType(): NodeType {
+    if (!this.editor) {
+      throw new Error(
+        `Cannot access nodeType for "${this.name}" - editor not initialized. ` +
+          `nodeType is available after ExtensionManager binds the editor.`
+      );
+    }
+    return this.editor.schema.nodes[this.name];
+  }
+
+  /**
+   * Creates a new node instance
+   *
+   * @param config - Node configuration
+   * @returns New node instance
+   *
+   * @example
+   * const Paragraph = Node.create({
+   *   name: 'paragraph',
+   *   group: 'block',
+   *   content: 'inline*',
+   * });
+   */
+  static create<O = unknown, S = unknown>(
+    config: NodeConfig<O, S>
+  ): Node<O, S> {
+    return new Node(config);
+  }
+
+  /**
+   * Creates a new node with merged options
+   * Original node is not modified
+   *
+   * @param options - Options to merge with existing options
+   * @returns New node instance with merged options
+   *
+   * @example
+   * const CustomParagraph = Paragraph.configure({ HTMLAttributes: { class: 'custom' } });
+   */
+  configure(options: Partial<Options>): Node<Options, Storage> {
+    const newConfig: NodeConfig<Options, Storage> = {
+      ...this.config,
+      addOptions: () => ({
+        ...this.options,
+        ...options,
+      }),
+    };
+
+    return new Node(newConfig);
+  }
+
+  /**
+   * Creates a new node with extended configuration
+   * Original node is not modified
+   *
+   * @param extendedConfig - Configuration to extend/override
+   * @returns New node instance with extended config
+   *
+   * @example
+   * const CustomParagraph = Paragraph.extend({
+   *   name: 'customParagraph',
+   *   addAttributes() {
+   *     return { ...this.parent?.(), align: { default: 'left' } };
+   *   },
+   * });
+   */
+  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>
+  ): Node<ExtendedOptions, ExtendedStorage> {
+    const newConfig = {
+      ...this.config,
+      ...extendedConfig,
+    } as NodeConfig<ExtendedOptions, ExtendedStorage>;
+
+    return new Node(newConfig);
+  }
+
+  /**
+   * Creates a ProseMirror NodeSpec from this node's configuration
+   *
+   * Called by ExtensionManager when building the schema.
+   * Converts our config format to ProseMirror's NodeSpec format.
+   *
+   * @returns ProseMirror NodeSpec
+   */
+  createNodeSpec(): NodeSpec {
+    const spec: NodeSpec = {};
+
+    // Schema properties - copy directly if defined
+    if (this.config.group !== undefined) spec.group = this.config.group;
+    if (this.config.content !== undefined) spec.content = this.config.content;
+    if (this.config.inline !== undefined) spec.inline = this.config.inline;
+    if (this.config.atom !== undefined) spec.atom = this.config.atom;
+    if (this.config.selectable !== undefined)
+      spec.selectable = this.config.selectable;
+    if (this.config.draggable !== undefined)
+      spec.draggable = this.config.draggable;
+    if (this.config.code !== undefined) spec.code = this.config.code;
+    if (this.config.whitespace !== undefined)
+      spec.whitespace = this.config.whitespace;
+    if (this.config.isolating !== undefined)
+      spec.isolating = this.config.isolating;
+    if (this.config.defining !== undefined)
+      spec.defining = this.config.defining;
+    if (this.config.marks !== undefined) spec.marks = this.config.marks;
+
+    // Top node (only for document)
+    if (this.config.topNode) {
+      // ProseMirror doesn't have a topNode property on NodeSpec
+      // This is handled by Schema constructor's topNode option
+      // We'll handle this in ExtensionManager
+    }
+
+    // Leaf text
+    if (this.config.leafText !== undefined) {
+      spec.leafText =
+        typeof this.config.leafText === 'function'
+          ? this.config.leafText
+          : () => this.config.leafText as string;
+    }
+
+    // Attributes - convert AttributeSpecs to ProseMirror attrs
+    const attributeSpecs = callOrReturn(this.config.addAttributes, this);
+    if (attributeSpecs) {
+      spec.attrs = {};
+      for (const [name, attrSpec] of Object.entries(attributeSpecs)) {
+        spec.attrs[name] = {
+          default: attrSpec.default,
+        };
+        // Add validate if defined (ProseMirror 1.22.0+)
+        if (attrSpec.validate) {
+          (spec.attrs[name] as { validate?: unknown }).validate =
+            attrSpec.validate;
+        }
+      }
+    }
+
+    // Parse rules - convert to parseDOM
+    const parseRules = callOrReturn(this.config.parseHTML, this);
+    if (parseRules && parseRules.length > 0) {
+      spec.parseDOM = parseRules.map((rule) => {
+        const parseRule: {
+          tag?: string;
+          style?: string;
+          priority?: number;
+          consuming?: boolean;
+          context?: string;
+          preserveWhitespace?: boolean | 'full';
+          getAttrs?: (node: HTMLElement | string) => Record<string, unknown> | false | null;
+        } = {};
+
+        if (rule.tag) parseRule.tag = rule.tag;
+        if (rule.style) parseRule.style = rule.style;
+        if (rule.priority !== undefined) parseRule.priority = rule.priority;
+        if (rule.consuming !== undefined) parseRule.consuming = rule.consuming;
+        if (rule.context) parseRule.context = rule.context;
+        if (rule.preserveWhitespace !== undefined)
+          parseRule.preserveWhitespace = rule.preserveWhitespace;
+
+        // Handle getAttrs - need to merge with attribute parseHTML
+        if (rule.getAttrs || attributeSpecs) {
+          parseRule.getAttrs = (node: HTMLElement | string) => {
+            // If node is string (for style rules), skip attribute parsing
+            if (typeof node === 'string') {
+              return rule.getAttrs ? rule.getAttrs(node as unknown as HTMLElement) ?? {} : {};
+            }
+
+            // Get attrs from rule
+            const ruleAttrs = rule.getAttrs ? rule.getAttrs(node) : {};
+
+            // If rule returned null, skip this rule
+            if (ruleAttrs === null || ruleAttrs === undefined) {
+              return false;
+            }
+
+            // Get attrs from attribute parseHTML functions
+            const parsedAttrs: Record<string, unknown> = { ...ruleAttrs };
+            if (attributeSpecs) {
+              for (const [name, attrSpec] of Object.entries(attributeSpecs)) {
+                if (attrSpec.parseHTML) {
+                  parsedAttrs[name] = attrSpec.parseHTML(node);
+                }
+              }
+            }
+
+            return parsedAttrs;
+          };
+        }
+
+        return parseRule;
+      });
+    }
+
+    // Render - convert renderHTML to toDOM
+    if (this.config.renderHTML) {
+      const renderFn = this.config.renderHTML;
+      const attrSpecs = attributeSpecs;
+
+      spec.toDOM = (node) => {
+        // Build HTML attributes from node attrs and renderHTML functions
+        let htmlAttrs: Record<string, unknown> = {};
+
+        if (attrSpecs) {
+          for (const [name, attrSpec] of Object.entries(attrSpecs)) {
+            // Skip if not rendered
+            if (attrSpec.rendered === false) continue;
+
+            // Use renderHTML if defined, otherwise add directly
+            if (attrSpec.renderHTML) {
+              const rendered = attrSpec.renderHTML(node.attrs);
+              if (rendered) {
+                htmlAttrs = { ...htmlAttrs, ...rendered };
+              }
+            } else if (node.attrs[name] !== undefined && node.attrs[name] !== null) {
+              // Default: use attribute value directly
+              htmlAttrs[name] = node.attrs[name];
+            }
+          }
+        }
+
+        return renderFn({ node, HTMLAttributes: htmlAttrs });
+      };
+    }
+
+    return spec;
+  }
+}

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -62,8 +62,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
 
   /**
    * Editor instance with schema access
+   * null until set by ExtensionManager
    */
-  declare editor: NodeEditorInterface;
+  override editor: NodeEditorInterface | null = null;
 
   /**
    * Protected constructor - use Node.create() instead

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -23,7 +23,7 @@
  * });
  */
 
-import type { NodeSpec, NodeType } from 'prosemirror-model';
+import type { NodeSpec, NodeType, TagParseRule } from 'prosemirror-model';
 import { Extension, type ExtensionEditorInterface } from './Extension.js';
 import type { NodeConfig } from './types/NodeConfig.js';
 import { callOrReturn } from './helpers/callOrReturn.js';
@@ -52,7 +52,7 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    * Node type identifier
    * Distinguishes nodes from extensions and marks
    */
-  declare readonly type: 'node';
+  override readonly type = 'node' as const;
 
   /**
    * The original configuration object
@@ -70,8 +70,6 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    */
   protected constructor(config: NodeConfig<Options, Storage>) {
     super(config);
-    // Override type after super() call
-    (this as { type: 'node' }).type = 'node';
   }
 
   /**
@@ -80,16 +78,14 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    * This is a lazy getter because schema doesn't exist at node creation time.
    * Schema is built FROM nodes by ExtensionManager.
    *
-   * @throws Error if accessed before editor is set
+   * Returns null if editor is not yet initialized.
+   * Always check editor is set before using nodeType.
    */
-  get nodeType(): NodeType {
+  get nodeType(): NodeType | null {
     if (!this.editor) {
-      throw new Error(
-        `Cannot access nodeType for "${this.name}" - editor not initialized. ` +
-          `nodeType is available after ExtensionManager binds the editor.`
-      );
+      return null;
     }
-    return this.editor.schema.nodes[this.name];
+    return this.editor.schema.nodes[this.name] ?? null;
   }
 
   /**
@@ -105,7 +101,7 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    *   content: 'inline*',
    * });
    */
-  static create<O = unknown, S = unknown>(
+  static override create<O = unknown, S = unknown>(
     config: NodeConfig<O, S>
   ): Node<O, S> {
     return new Node(config);
@@ -121,7 +117,7 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    * @example
    * const CustomParagraph = Paragraph.configure({ HTMLAttributes: { class: 'custom' } });
    */
-  configure(options: Partial<Options>): Node<Options, Storage> {
+  override configure(options: Partial<Options>): Node<Options, Storage> {
     const newConfig: NodeConfig<Options, Storage> = {
       ...this.config,
       addOptions: () => ({
@@ -148,7 +144,7 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    *   },
    * });
    */
-  extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
+  override extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
     extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>
   ): Node<ExtendedOptions, ExtendedStorage> {
     const newConfig = {
@@ -222,7 +218,10 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
     // Parse rules - convert to parseDOM
     const parseRules = callOrReturn(this.config.parseHTML, this);
     if (parseRules && parseRules.length > 0) {
-      spec.parseDOM = parseRules.map((rule) => {
+      // Build parseDOM array with proper typing
+      // ProseMirror's TagParseRule type is strict, so we cast through unknown
+      const parseDOMRules = parseRules.map((rule) => {
+        // Build parse rule object using object literal to avoid index signature issues
         const parseRule: {
           tag?: string;
           style?: string;
@@ -230,7 +229,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
           consuming?: boolean;
           context?: string;
           preserveWhitespace?: boolean | 'full';
-          getAttrs?: (node: HTMLElement | string) => Record<string, unknown> | false | null;
+          getAttrs?: (
+            node: HTMLElement | string
+          ) => Record<string, unknown> | false | null;
         } = {};
 
         if (rule.tag) parseRule.tag = rule.tag;
@@ -246,7 +247,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
           parseRule.getAttrs = (node: HTMLElement | string) => {
             // If node is string (for style rules), skip attribute parsing
             if (typeof node === 'string') {
-              return rule.getAttrs ? rule.getAttrs(node as unknown as HTMLElement) ?? {} : {};
+              return rule.getAttrs
+                ? rule.getAttrs(node as unknown as HTMLElement) ?? {}
+                : {};
             }
 
             // Get attrs from rule
@@ -273,6 +276,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
 
         return parseRule;
       });
+
+      // Cast through unknown to satisfy strict NodeSpec.parseDOM type
+      spec.parseDOM = parseDOMRules as unknown as readonly TagParseRule[];
     }
 
     // Render - convert renderHTML to toDOM

--- a/packages/core/src/helpers/callOrReturn.ts
+++ b/packages/core/src/helpers/callOrReturn.ts
@@ -1,0 +1,39 @@
+/**
+ * callOrReturn - Helper for context binding in extension config
+ *
+ * Used to call config functions with proper `this` context,
+ * or return the value directly if it's not a function.
+ *
+ * This enables patterns like:
+ * ```typescript
+ * const Bold = Mark.create({
+ *   name: 'bold',
+ *   addCommands() {
+ *     return {
+ *       toggleBold: () => ({ commands }) => {
+ *         return commands.toggleMark(this.name); // this.name = 'bold'
+ *       },
+ *     };
+ *   },
+ * });
+ * ```
+ */
+
+/**
+ * Calls a function with the given context, or returns the value if not a function
+ *
+ * @param value - Function to call or value to return
+ * @param context - The `this` context to bind when calling the function
+ * @param args - Additional arguments to pass to the function
+ * @returns The function result or the value itself
+ */
+export function callOrReturn<T>(
+  value: T | ((...args: unknown[]) => T),
+  context: unknown,
+  ...args: unknown[]
+): T {
+  if (typeof value === 'function') {
+    return (value as (...args: unknown[]) => T).call(context, ...args);
+  }
+  return value;
+}

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -8,3 +8,4 @@ export {
   isDocumentEmpty,
   type IsNodeEmptyOptions,
 } from './isNodeEmpty.js';
+export { callOrReturn } from './callOrReturn.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,10 @@ export type {
   NodeParseRule,
   NodeRenderHTMLProps,
   NodeConfig,
+  // Mark config types
+  MarkParseRule,
+  MarkRenderHTMLProps,
+  MarkConfig,
 } from './types/index.js';
 
 // === Core classes ===
@@ -79,5 +83,4 @@ export {
 // === Extension System ===
 export { Extension } from './Extension.js';
 export { Node } from './Node.js';
-// Mark class will be added in Step 2.1c
-// export { Mark } from './Mark.js';
+export { Mark } from './Mark.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,10 @@ export type {
   CanCommands,
   CanChainedCommands,
   KeyboardShortcutCommand,
+  // Extension config types
+  ExtensionEditor,
+  AnyExtensionConfig,
+  ExtensionConfig,
 } from './types/index.js';
 
 // === Core classes ===
@@ -60,11 +64,13 @@ export {
   createDocument,
   isNodeEmpty,
   isDocumentEmpty,
+  callOrReturn,
   type CreateDocumentOptions,
   type IsNodeEmptyOptions,
 } from './helpers/index.js';
 
-// Extension system will be implemented in Step 2
-// export { Extension } from './Extension';
-// export { Node } from './Node';
-// export { Mark } from './Mark';
+// === Extension System ===
+export { Extension } from './Extension.js';
+// Node and Mark classes will be added in Step 2.1b and 2.1c
+// export { Node } from './Node.js';
+// export { Mark } from './Mark.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,13 @@ export type {
   ExtensionEditor,
   AnyExtensionConfig,
   ExtensionConfig,
+  // Attribute types
+  AttributeSpec,
+  AttributeSpecs,
+  // Node config types
+  NodeParseRule,
+  NodeRenderHTMLProps,
+  NodeConfig,
 } from './types/index.js';
 
 // === Core classes ===
@@ -71,6 +78,6 @@ export {
 
 // === Extension System ===
 export { Extension } from './Extension.js';
-// Node and Mark classes will be added in Step 2.1b and 2.1c
-// export { Node } from './Node.js';
+export { Node } from './Node.js';
+// Mark class will be added in Step 2.1c
 // export { Mark } from './Mark.js';

--- a/packages/core/src/types/AttributeSpec.ts
+++ b/packages/core/src/types/AttributeSpec.ts
@@ -1,0 +1,83 @@
+/**
+ * Attribute specification for Node and Mark extensions
+ *
+ * Used by addAttributes() to define node/mark attributes
+ * with parsing, rendering, and validation rules.
+ *
+ * @example
+ * addAttributes() {
+ *   return {
+ *     level: {
+ *       default: 1,
+ *       parseHTML: (element) => parseInt(element.tagName.charAt(1), 10),
+ *       renderHTML: (attributes) => ({ 'data-level': attributes.level }),
+ *     },
+ *   };
+ * }
+ */
+
+/**
+ * Specification for a single attribute
+ */
+export interface AttributeSpec {
+  /**
+   * Default value for the attribute
+   * Used when the attribute is not explicitly set
+   */
+  default?: unknown;
+
+  /**
+   * Whether this attribute is rendered to the DOM
+   * @default true
+   */
+  rendered?: boolean;
+
+  /**
+   * Keep this attribute when splitting the node
+   * For example, heading level should be kept when pressing Enter
+   * @default true
+   */
+  keepOnSplit?: boolean;
+
+  /**
+   * Validate attribute value
+   * Returns true if valid, false otherwise
+   * Available in ProseMirror 1.22.0+
+   *
+   * @example
+   * validate: (value) => typeof value === 'number' && value >= 1 && value <= 6
+   */
+  validate?: (value: unknown) => boolean;
+
+  /**
+   * Parse attribute value from HTML element
+   * Called during HTML parsing to extract attribute value
+   *
+   * @param element - The HTML element being parsed
+   * @returns The attribute value
+   *
+   * @example
+   * parseHTML: (element) => element.getAttribute('data-level')
+   */
+  parseHTML?: (element: HTMLElement) => unknown;
+
+  /**
+   * Render attribute to HTML attributes object
+   * Called during HTML serialization
+   *
+   * @param attributes - All attributes of the node/mark
+   * @returns HTML attributes object or null to skip
+   *
+   * @example
+   * renderHTML: (attributes) => ({ 'data-level': attributes.level })
+   */
+  renderHTML?: (
+    attributes: Record<string, unknown>
+  ) => Record<string, string | number | boolean | null | undefined> | null;
+}
+
+/**
+ * Collection of attribute specifications
+ * Keyed by attribute name
+ */
+export type AttributeSpecs = Record<string, AttributeSpec>;

--- a/packages/core/src/types/ExtensionConfig.ts
+++ b/packages/core/src/types/ExtensionConfig.ts
@@ -1,0 +1,171 @@
+/**
+ * Extension configuration types
+ *
+ * These types define the configuration object passed to Extension.create(),
+ * Node.create(), and Mark.create() factory methods.
+ */
+
+import type { Plugin, Transaction } from 'prosemirror-state';
+import type { InputRule } from 'prosemirror-inputrules';
+import type { Command, KeyboardShortcutCommand } from './Commands.js';
+
+/**
+ * Editor instance type (forward declaration)
+ * Will be properly typed when Extension class is implemented
+ */
+export interface ExtensionEditor {
+  readonly state: unknown;
+  readonly view: unknown;
+  readonly schema: unknown;
+}
+
+/**
+ * Any extension type (forward declaration)
+ */
+export interface AnyExtensionConfig {
+  name: string;
+  type?: 'extension' | 'node' | 'mark';
+}
+
+/**
+ * Base configuration for all extension types
+ *
+ * @typeParam Options - Extension options type
+ * @typeParam Storage - Extension storage type
+ */
+export interface ExtensionConfig<Options = unknown, Storage = unknown> {
+  /**
+   * Unique extension name
+   * Used for identification, storage access, and error messages
+   */
+  name: string;
+
+  /**
+   * Extension priority (higher = loaded first)
+   *
+   * Reserved ranges:
+   * - 900-1000: Core nodes (Document, Text, Paragraph)
+   * - 500-899: Standard extensions (Heading, Bold, etc.)
+   * - 100-499: Default range for user extensions
+   * - 0-99: Low priority extensions (run after everything)
+   *
+   * @default 100
+   */
+  priority?: number;
+
+  /**
+   * Required extensions that must be present
+   * ExtensionManager throws if any dependency is missing
+   *
+   * @example
+   * dependencies: ['bulletList', 'orderedList']
+   */
+  dependencies?: string[];
+
+  /**
+   * Default options for this extension
+   * Called during extension creation with `this` bound to the extension
+   */
+  addOptions?: () => Options;
+
+  /**
+   * Initial storage state for this extension
+   * Storage is mutable and accessible via editor.storage[extensionName]
+   */
+  addStorage?: () => Storage;
+
+  /**
+   * Commands this extension provides
+   * Commands are accessible via editor.commands.commandName()
+   *
+   * @example
+   * addCommands() {
+   *   return {
+   *     toggleBold: () => ({ commands }) => commands.toggleMark('bold'),
+   *   };
+   * }
+   */
+  addCommands?: () => Record<string, (...args: never[]) => Command>;
+
+  /**
+   * Keyboard shortcuts for this extension
+   * Keys are shortcut strings (e.g., 'Mod-b'), values are handler functions
+   *
+   * @example
+   * addKeyboardShortcuts() {
+   *   return {
+   *     'Mod-b': () => this.editor.commands.toggleBold(),
+   *   };
+   * }
+   */
+  addKeyboardShortcuts?: () => Record<string, KeyboardShortcutCommand>;
+
+  /**
+   * Input rules (markdown-style shortcuts)
+   * Triggered when user types matching patterns
+   *
+   * @example
+   * addInputRules() {
+   *   return [
+   *     textblockTypeInputRule(/^## $/, this.type),
+   *   ];
+   * }
+   */
+  addInputRules?: () => InputRule[];
+
+  /**
+   * ProseMirror plugins for this extension
+   */
+  addProseMirrorPlugins?: () => Plugin[];
+
+  /**
+   * Nested extensions (for extension bundles like StarterKit)
+   * These extensions are flattened and processed like top-level extensions
+   */
+  addExtensions?: () => AnyExtensionConfig[];
+
+  // === Lifecycle Hooks ===
+
+  /**
+   * Called before editor is created
+   * Can be used to modify editor options
+   */
+  onBeforeCreate?: () => void;
+
+  /**
+   * Called when editor is fully initialized and ready
+   */
+  onCreate?: () => void;
+
+  /**
+   * Called when document content changes
+   */
+  onUpdate?: () => void;
+
+  /**
+   * Called when selection changes (without content change)
+   */
+  onSelectionUpdate?: () => void;
+
+  /**
+   * Called on every transaction
+   * Can be used to intercept or modify transactions
+   */
+  onTransaction?: (props: { transaction: Transaction }) => void;
+
+  /**
+   * Called when editor receives focus
+   */
+  onFocus?: (props: { event: FocusEvent }) => void;
+
+  /**
+   * Called when editor loses focus
+   */
+  onBlur?: (props: { event: FocusEvent }) => void;
+
+  /**
+   * Called when editor is being destroyed
+   * Use for cleanup (remove event listeners, etc.)
+   */
+  onDestroy?: () => void;
+}

--- a/packages/core/src/types/MarkConfig.ts
+++ b/packages/core/src/types/MarkConfig.ts
@@ -1,0 +1,179 @@
+/**
+ * Mark configuration types
+ *
+ * These types define the configuration object passed to Mark.create()
+ * for creating ProseMirror mark extensions.
+ */
+
+import type { Mark as PMMark, DOMOutputSpec } from 'prosemirror-model';
+import type { ExtensionConfig } from './ExtensionConfig.js';
+import type { AttributeSpecs } from './AttributeSpec.js';
+
+/**
+ * Parse rule for converting HTML to ProseMirror mark
+ * Simplified version of ProseMirror's ParseRule for marks
+ */
+export interface MarkParseRule {
+  /**
+   * CSS selector or tag name to match
+   * @example 'strong', 'b', 'span.bold'
+   */
+  tag?: string;
+
+  /**
+   * Match by CSS style property
+   * Can include expected value after '='
+   * @example 'font-weight', 'font-weight=bold'
+   */
+  style?: string;
+
+  /**
+   * Priority for this rule (higher = checked first)
+   * @default 50
+   */
+  priority?: number;
+
+  /**
+   * Whether to consume the matched element
+   * @default true
+   */
+  consuming?: boolean;
+
+  /**
+   * Get attributes from the matched element
+   * Return null/undefined to skip this rule
+   * Return false to explicitly not match
+   *
+   * For style rules, receives the style value as string
+   */
+  getAttrs?:
+    | ((node: HTMLElement | string) => Record<string, unknown> | false | null)
+    | null;
+}
+
+/**
+ * Props passed to renderHTML function for marks
+ */
+export interface MarkRenderHTMLProps {
+  /**
+   * The ProseMirror mark being rendered
+   */
+  mark: PMMark;
+
+  /**
+   * Merged HTML attributes from all sources
+   */
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/**
+ * Configuration for Mark extensions
+ * Extends ExtensionConfig with mark-specific schema properties
+ *
+ * @typeParam Options - Mark options type
+ * @typeParam Storage - Mark storage type
+ *
+ * @example
+ * const Bold = Mark.create({
+ *   name: 'bold',
+ *   parseHTML() {
+ *     return [
+ *       { tag: 'strong' },
+ *       { tag: 'b' },
+ *       { style: 'font-weight=bold' },
+ *     ];
+ *   },
+ *   renderHTML({ HTMLAttributes }) {
+ *     return ['strong', HTMLAttributes, 0];
+ *   },
+ * });
+ */
+export interface MarkConfig<Options = unknown, Storage = unknown>
+  extends ExtensionConfig<Options, Storage> {
+  // === Schema Properties ===
+
+  /**
+   * Whether this mark should be active when the cursor
+   * is at its end (or beginning for marks that open).
+   *
+   * When true, typing at the mark's boundary continues the mark.
+   * When false, typing creates unmarked content.
+   *
+   * @default true
+   */
+  inclusive?: boolean;
+
+  /**
+   * Marks that this mark excludes (cannot coexist with)
+   *
+   * - '_' excludes all marks
+   * - Space-separated mark names exclude specific marks
+   * - Empty string or undefined means no exclusions
+   *
+   * @example 'code' - excludes code mark
+   * @example 'bold italic' - excludes bold and italic
+   * @example '_' - excludes all other marks
+   */
+  excludes?: string;
+
+  /**
+   * Mark group(s) this mark belongs to
+   * Used in node's marks property
+   *
+   * @example 'formatting', 'inline'
+   */
+  group?: string;
+
+  /**
+   * Whether this mark can span multiple nodes
+   *
+   * When true (default), the mark persists across inline nodes.
+   * When false, the mark only applies within a single text node.
+   *
+   * @default true
+   */
+  spanning?: boolean;
+
+  // === Mark-specific Methods ===
+
+  /**
+   * Define mark attributes
+   * Returns attribute specifications
+   *
+   * @example
+   * addAttributes() {
+   *   return {
+   *     color: { default: null },
+   *   };
+   * }
+   */
+  addAttributes?: () => AttributeSpecs;
+
+  /**
+   * Parse rules for converting HTML to this mark
+   * Each rule defines how to match and parse HTML elements
+   *
+   * @example
+   * parseHTML() {
+   *   return [
+   *     { tag: 'strong' },
+   *     { tag: 'b' },
+   *     { style: 'font-weight', getAttrs: (value) => /bold|[5-9]\d{2}/.test(value) && null },
+   *   ];
+   * }
+   */
+  parseHTML?: () => MarkParseRule[];
+
+  /**
+   * Render this mark to DOM
+   * Returns DOMOutputSpec (tag, attributes, hole)
+   *
+   * The 0 in the return array indicates where child content goes.
+   *
+   * @example
+   * renderHTML({ mark, HTMLAttributes }) {
+   *   return ['strong', HTMLAttributes, 0];
+   * }
+   */
+  renderHTML?: (props: MarkRenderHTMLProps) => DOMOutputSpec;
+}

--- a/packages/core/src/types/NodeConfig.ts
+++ b/packages/core/src/types/NodeConfig.ts
@@ -1,0 +1,244 @@
+/**
+ * Node configuration types
+ *
+ * These types define the configuration object passed to Node.create()
+ * for creating ProseMirror node extensions.
+ */
+
+import type { Node as PMNode, DOMOutputSpec } from 'prosemirror-model';
+import type { NodeViewConstructor } from 'prosemirror-view';
+import type { ExtensionConfig } from './ExtensionConfig.js';
+import type { AttributeSpecs } from './AttributeSpec.js';
+
+/**
+ * Parse rule for converting HTML to ProseMirror node
+ * Simplified version of ProseMirror's ParseRule
+ */
+export interface NodeParseRule {
+  /**
+   * CSS selector or tag name to match
+   * @example 'p', 'h1', 'div.my-class'
+   */
+  tag?: string;
+
+  /**
+   * Match by CSS style
+   * @example 'font-weight'
+   */
+  style?: string;
+
+  /**
+   * Priority for this rule (higher = checked first)
+   * @default 50
+   */
+  priority?: number;
+
+  /**
+   * Whether to consume the matched element
+   * @default true
+   */
+  consuming?: boolean;
+
+  /**
+   * Context required for this rule to match
+   * ProseMirror content expression
+   */
+  context?: string;
+
+  /**
+   * Get attributes from the matched element
+   * Return null/undefined to skip this rule
+   */
+  getAttrs?:
+    | ((node: HTMLElement) => Record<string, unknown> | null | undefined)
+    | null;
+
+  /**
+   * Get content from the matched element
+   * Return false to use default content parsing
+   */
+  getContent?: (
+    node: HTMLElement,
+    schema: unknown
+  ) => unknown | null | undefined;
+
+  /**
+   * How to preserve whitespace
+   */
+  preserveWhitespace?: boolean | 'full';
+}
+
+/**
+ * Props passed to renderHTML function
+ */
+export interface NodeRenderHTMLProps {
+  /**
+   * The ProseMirror node being rendered
+   */
+  node: PMNode;
+
+  /**
+   * Merged HTML attributes from all sources
+   */
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/**
+ * Configuration for Node extensions
+ * Extends ExtensionConfig with node-specific schema properties
+ *
+ * @typeParam Options - Node options type
+ * @typeParam Storage - Node storage type
+ *
+ * @example
+ * const Paragraph = Node.create({
+ *   name: 'paragraph',
+ *   group: 'block',
+ *   content: 'inline*',
+ *   parseHTML() {
+ *     return [{ tag: 'p' }];
+ *   },
+ *   renderHTML({ HTMLAttributes }) {
+ *     return ['p', HTMLAttributes, 0];
+ *   },
+ * });
+ */
+export interface NodeConfig<Options = unknown, Storage = unknown>
+  extends ExtensionConfig<Options, Storage> {
+  // === Schema Properties ===
+
+  /**
+   * Node group(s) this node belongs to
+   * Used in content expressions
+   *
+   * @example 'block', 'inline', 'block list'
+   */
+  group?: string;
+
+  /**
+   * Content expression defining allowed children
+   * Uses ProseMirror content expression syntax
+   *
+   * @example 'inline*', 'block+', 'paragraph block*'
+   */
+  content?: string;
+
+  /**
+   * Whether this is an inline node
+   * @default false
+   */
+  inline?: boolean;
+
+  /**
+   * Whether this node is an atom (no direct content editing)
+   * Cursor moves around atoms, not into them
+   *
+   * @example true for images, mentions, emoji
+   */
+  atom?: boolean;
+
+  /**
+   * Whether the node can be selected as a whole
+   * @default true for leaf nodes, false for others
+   */
+  selectable?: boolean;
+
+  /**
+   * Whether the node can be dragged
+   * @default false
+   */
+  draggable?: boolean;
+
+  /**
+   * Whether this node represents code
+   * Affects text input handling (disables smart quotes, etc.)
+   */
+  code?: boolean;
+
+  /**
+   * How whitespace is handled in this node
+   * - 'pre': preserve whitespace (like <pre>)
+   * - 'normal': collapse whitespace (default)
+   */
+  whitespace?: 'pre' | 'normal';
+
+  /**
+   * Whether this node isolates marks at its boundaries
+   * Marks don't extend across isolating boundaries
+   */
+  isolating?: boolean;
+
+  /**
+   * Whether this is a top-level node (document root)
+   * Only one node should have this set to true
+   */
+  topNode?: boolean;
+
+  /**
+   * Whether this node defines its own scope
+   * Content and marks don't leak out of defining nodes
+   */
+  defining?: boolean;
+
+  /**
+   * Which marks are allowed in this node
+   * Empty string means no marks allowed
+   *
+   * @example '', '_', 'bold italic'
+   */
+  marks?: string;
+
+  /**
+   * Custom text for leaf nodes
+   * Used by getText() and textContent
+   *
+   * @example '\n' for hard break
+   */
+  leafText?: string | ((node: PMNode) => string);
+
+  // === Node-specific Methods ===
+
+  /**
+   * Define node attributes
+   * Returns attribute specifications
+   *
+   * @example
+   * addAttributes() {
+   *   return {
+   *     level: { default: 1 },
+   *   };
+   * }
+   */
+  addAttributes?: () => AttributeSpecs;
+
+  /**
+   * Parse rules for converting HTML to this node
+   * Each rule defines how to match and parse HTML elements
+   *
+   * @example
+   * parseHTML() {
+   *   return [
+   *     { tag: 'p' },
+   *     { tag: 'div', priority: 10 },
+   *   ];
+   * }
+   */
+  parseHTML?: () => NodeParseRule[];
+
+  /**
+   * Render this node to DOM
+   * Returns DOMOutputSpec (tag, attributes, children)
+   *
+   * @example
+   * renderHTML({ node, HTMLAttributes }) {
+   *   return ['p', HTMLAttributes, 0];
+   * }
+   */
+  renderHTML?: (props: NodeRenderHTMLProps) => DOMOutputSpec;
+
+  /**
+   * Custom node view constructor
+   * For complex interactive nodes
+   */
+  addNodeView?: () => NodeViewConstructor;
+}

--- a/packages/core/src/types/NodeConfig.ts
+++ b/packages/core/src/types/NodeConfig.ts
@@ -57,10 +57,7 @@ export interface NodeParseRule {
    * Get content from the matched element
    * Return false to use default content parsing
    */
-  getContent?: (
-    node: HTMLElement,
-    schema: unknown
-  ) => unknown | null | undefined;
+  getContent?: (node: HTMLElement, schema: unknown) => unknown;
 
   /**
    * How to preserve whitespace

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -55,3 +55,13 @@ export type {
   AnyExtensionConfig,
   ExtensionConfig,
 } from './ExtensionConfig.js';
+
+// Attribute types
+export type { AttributeSpec, AttributeSpecs } from './AttributeSpec.js';
+
+// Node config types
+export type {
+  NodeParseRule,
+  NodeRenderHTMLProps,
+  NodeConfig,
+} from './NodeConfig.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -65,3 +65,10 @@ export type {
   NodeRenderHTMLProps,
   NodeConfig,
 } from './NodeConfig.js';
+
+// Mark config types
+export type {
+  MarkParseRule,
+  MarkRenderHTMLProps,
+  MarkConfig,
+} from './MarkConfig.js';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -48,3 +48,10 @@ export type {
   CanChainedCommands,
   KeyboardShortcutCommand,
 } from './Commands.js';
+
+// Extension config types
+export type {
+  ExtensionEditor,
+  AnyExtensionConfig,
+  ExtensionConfig,
+} from './ExtensionConfig.js';


### PR DESCRIPTION
## Summary
Core extension system classes that form the foundation for the ProseMirror schema generation.

## Features
- **Extension** - Base class for pure functionality extensions (History, Placeholder, etc.)
- **Node** - Schema node extensions with `createNodeSpec()` (Paragraph, Heading, Image, etc.)
- **Mark** - Schema mark extensions with `createMarkSpec()` (Bold, Italic, Link, etc.)
- **callOrReturn** helper for extension context binding
- Full TypeScript types: ExtensionConfig, NodeConfig, MarkConfig, AttributeSpec

## Test plan
- [x] Extension tests
- [x] Node tests
- [x] Mark tests
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
