### PR TITLE
feat(core): add built-in commands and extension error isolation

### DIFF
--- a/packages/core/src/CommandManager.test.ts
+++ b/packages/core/src/CommandManager.test.ts
@@ -5,14 +5,34 @@
  * ESLint rules for `any` are disabled as this is standard practice for testing dynamic APIs.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Schema } from 'prosemirror-model';
-import { EditorState } from 'prosemirror-state';
+import { EditorState, TextSelection } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { CommandManager } from './CommandManager.js';
 import type { RawCommands } from './types/Commands.js';
 
-// Test schema
+// Mock getClientRects for JSDOM (ProseMirror uses it for scrolling)
+Range.prototype.getClientRects = vi.fn(() => ({
+  length: 0,
+  item: () => null,
+  [Symbol.iterator]: function* () {},
+})) as any;
+
+// Mock getBoundingClientRect for Range
+Range.prototype.getBoundingClientRect = vi.fn(() => ({
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  width: 0,
+  height: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+})) as any;
+
+// Basic test schema (for original tests)
 const testSchema = new Schema({
   nodes: {
     doc: { content: 'paragraph+' },
@@ -27,10 +47,91 @@ const testSchema = new Schema({
   },
 });
 
+// Extended test schema with marks and more node types
+const extendedSchema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      toDOM() {
+        return ['p', 0];
+      },
+      parseDOM: [{ tag: 'p' }],
+    },
+    heading: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { level: { default: 1 } },
+      toDOM(node) {
+        return [`h${node.attrs['level'] as number}`, 0];
+      },
+      parseDOM: [
+        { tag: 'h1', attrs: { level: 1 } },
+        { tag: 'h2', attrs: { level: 2 } },
+      ],
+    },
+    blockquote: {
+      group: 'block',
+      content: 'block+',
+      toDOM() {
+        return ['blockquote', 0];
+      },
+      parseDOM: [{ tag: 'blockquote' }],
+    },
+    bulletList: {
+      group: 'block list',
+      content: 'listItem+',
+      toDOM() {
+        return ['ul', 0];
+      },
+      parseDOM: [{ tag: 'ul' }],
+    },
+    orderedList: {
+      group: 'block list',
+      content: 'listItem+',
+      toDOM() {
+        return ['ol', 0];
+      },
+      parseDOM: [{ tag: 'ol' }],
+    },
+    listItem: {
+      content: 'paragraph block*',
+      toDOM() {
+        return ['li', 0];
+      },
+      parseDOM: [{ tag: 'li' }],
+    },
+    horizontalRule: {
+      group: 'block',
+      toDOM() {
+        return ['hr'];
+      },
+      parseDOM: [{ tag: 'hr' }],
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    bold: {
+      toDOM() {
+        return ['strong', 0];
+      },
+      parseDOM: [{ tag: 'strong' }, { tag: 'b' }],
+    },
+    italic: {
+      toDOM() {
+        return ['em', 0];
+      },
+      parseDOM: [{ tag: 'em' }, { tag: 'i' }],
+    },
+  },
+});
+
 // Mock editor interface for testing
 interface MockEditor {
   view: EditorView;
   state: EditorState;
+  schema: Schema;
   isDestroyed: boolean;
   emit: () => void;
   extensionManager: {
@@ -58,6 +159,41 @@ function createMockEditor(content?: string): MockEditor {
     get state() {
       return this.view.state;
     },
+    schema: testSchema,
+    isDestroyed: false,
+    emit: (): void => {
+      // No-op for tests
+    },
+    extensionManager: {
+      commands: {} as RawCommands,
+    },
+    cleanup: () => {
+      view.destroy();
+      element.remove();
+    },
+  };
+}
+
+// Create mock editor with extended schema (marks, blockquote, lists, etc.)
+function createExtendedMockEditor(content?: string): MockEditor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+
+  const doc = content
+    ? extendedSchema.node('doc', null, [
+        extendedSchema.node('paragraph', null, [extendedSchema.text(content)]),
+      ])
+    : extendedSchema.node('doc', null, [extendedSchema.node('paragraph')]);
+
+  const state = EditorState.create({ schema: extendedSchema, doc });
+  const view = new EditorView(element, { state });
+
+  return {
+    view,
+    get state() {
+      return this.view.state;
+    },
+    schema: extendedSchema,
     isDestroyed: false,
     emit: (): void => {
       // No-op for tests
@@ -376,5 +512,463 @@ describe('CommandManager', () => {
       expect(commands3).not.toBe(commands1);
       expect(commands3['newCommand']).toBeDefined();
     });
+  });
+});
+
+// =============================================================================
+// Extended Command Tests (Mark, Block, List commands)
+// =============================================================================
+
+describe('CommandManager - Mark Commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('toggleMark', () => {
+    it('applies mark to selection', () => {
+      // Use TextSelection instead of AllSelection for marks
+      const { state, view } = mockEditor;
+      const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, state.doc.content.size - 1));
+      view.dispatch(tr);
+
+      const result = commands.toggleMark('bold');
+      expect(result).toBe(true);
+
+      // Check that bold mark is applied
+      const { doc } = mockEditor.view.state;
+      const textNode = doc.firstChild?.firstChild;
+      expect(textNode?.marks.some((m: any) => m.type.name === 'bold')).toBe(true);
+    });
+
+    it('removes mark when already applied', () => {
+      // First apply bold with TextSelection
+      const { state, view } = mockEditor;
+      const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, state.doc.content.size - 1));
+      view.dispatch(tr);
+      commands.toggleMark('bold');
+
+      // Reselect (state changed after toggleMark)
+      const state2 = mockEditor.view.state;
+      const tr2 = state2.tr.setSelection(TextSelection.create(state2.doc, 1, state2.doc.content.size - 1));
+      mockEditor.view.dispatch(tr2);
+
+      // Then toggle again to remove
+      const result = commands.toggleMark('bold');
+      expect(result).toBe(true);
+
+      // Check that bold mark is removed
+      const { doc } = mockEditor.view.state;
+      const textNode = doc.firstChild?.firstChild;
+      expect(textNode?.marks.some((m: any) => m.type.name === 'bold')).toBe(false);
+    });
+
+    it('returns false for unknown mark', () => {
+      commands.focus('start');
+      const result = commands.toggleMark('unknownMark');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setMark', () => {
+    it('adds mark to selection', () => {
+      // Use TextSelection for marks
+      const { state, view } = mockEditor;
+      const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, state.doc.content.size - 1));
+      view.dispatch(tr);
+
+      const result = commands.setMark('italic');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      const textNode = doc.firstChild?.firstChild;
+      expect(textNode?.marks.some((m: any) => m.type.name === 'italic')).toBe(true);
+    });
+
+    it('adds stored mark on empty selection', () => {
+      commands.focus('start');
+      const result = commands.setMark('bold');
+      expect(result).toBe(true);
+
+      // Check stored marks
+      const storedMarks = mockEditor.view.state.storedMarks;
+      expect(storedMarks?.some((m: any) => m.type.name === 'bold')).toBe(true);
+    });
+
+    it('returns false for unknown mark', () => {
+      commands.focus('start');
+      const result = commands.setMark('unknownMark');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('unsetMark', () => {
+    it('removes mark from selection', () => {
+      // First apply mark with TextSelection
+      const { state, view } = mockEditor;
+      const tr = state.tr.setSelection(TextSelection.create(state.doc, 1, state.doc.content.size - 1));
+      view.dispatch(tr);
+      commands.setMark('bold');
+
+      // Reselect and unset
+      const state2 = mockEditor.view.state;
+      const tr2 = state2.tr.setSelection(TextSelection.create(state2.doc, 1, state2.doc.content.size - 1));
+      mockEditor.view.dispatch(tr2);
+
+      const result = commands.unsetMark('bold');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      const textNode = doc.firstChild?.firstChild;
+      expect(textNode?.marks.some((m: any) => m.type.name === 'bold')).toBe(false);
+    });
+
+    it('removes stored mark on empty selection', () => {
+      // First add stored mark
+      commands.focus('start');
+      commands.setMark('bold');
+
+      // Then unset it
+      const result = commands.unsetMark('bold');
+      expect(result).toBe(true);
+
+      const storedMarks = mockEditor.view.state.storedMarks;
+      expect(storedMarks?.some((m: any) => m.type.name === 'bold')).toBeFalsy();
+    });
+
+    it('returns false for unknown mark', () => {
+      const result = commands.unsetMark('unknownMark');
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('CommandManager - Block Commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('setBlockType', () => {
+    it('changes paragraph to heading', () => {
+      commands.focus('start');
+      const result = commands.setBlockType('heading', { level: 1 });
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('heading');
+      expect(doc.firstChild?.attrs['level']).toBe(1);
+    });
+
+    it('returns false for unknown node type', () => {
+      commands.focus('start');
+      const result = commands.setBlockType('unknownNode');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('toggleBlockType', () => {
+    it('toggles paragraph to heading', () => {
+      commands.focus('start');
+      const result = commands.toggleBlockType('heading', 'paragraph', { level: 2 });
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('heading');
+    });
+
+    it('toggles heading back to paragraph', () => {
+      // First change to heading
+      commands.focus('start');
+      commands.setBlockType('heading', { level: 1 });
+
+      // Then toggle back
+      const result = commands.toggleBlockType('heading', 'paragraph', { level: 1 });
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+  });
+
+  describe('wrapIn', () => {
+    it('wraps paragraph in blockquote', () => {
+      commands.focus('start');
+      const result = commands.wrapIn('blockquote');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('blockquote');
+      expect(doc.firstChild?.firstChild?.type.name).toBe('paragraph');
+    });
+
+    it('returns false for unknown node type', () => {
+      commands.focus('start');
+      const result = commands.wrapIn('unknownNode');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('toggleWrap', () => {
+    it('wraps paragraph in blockquote', () => {
+      commands.focus('start');
+      const result = commands.toggleWrap('blockquote');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('blockquote');
+    });
+
+    it('unwraps blockquote when already wrapped', () => {
+      // First wrap
+      commands.focus('start');
+      commands.wrapIn('blockquote');
+
+      // Then toggle to unwrap
+      commands.focus('start');
+      const result = commands.toggleWrap('blockquote');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+  });
+
+  describe('lift', () => {
+    it('lifts paragraph out of blockquote', () => {
+      // First wrap in blockquote
+      commands.focus('start');
+      commands.wrapIn('blockquote');
+
+      // Then lift out
+      commands.focus('start');
+      const result = commands.lift();
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+
+    it('returns false when nothing to lift', () => {
+      commands.focus('start');
+      const result = commands.lift();
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('CommandManager - List Commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('toggleList', () => {
+    it('wraps paragraph in bullet list', () => {
+      commands.focus('start');
+      const result = commands.toggleList('bulletList', 'listItem');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('bulletList');
+      expect(doc.firstChild?.firstChild?.type.name).toBe('listItem');
+    });
+
+    it('wraps paragraph in ordered list', () => {
+      commands.focus('start');
+      const result = commands.toggleList('orderedList', 'listItem');
+      expect(result).toBe(true);
+
+      const { doc } = mockEditor.view.state;
+      expect(doc.firstChild?.type.name).toBe('orderedList');
+    });
+
+    it('returns false for unknown list type', () => {
+      commands.focus('start');
+      const result = commands.toggleList('unknownList', 'listItem');
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('CommandManager - Insert Commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('insertContent', () => {
+    it('inserts HTML content', () => {
+      commands.focus('end');
+      const result = commands.insertContent('<p>Inserted</p>');
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toContain('Inserted');
+    });
+
+    it('inserts JSON node content', () => {
+      commands.focus('end');
+      const result = commands.insertContent({
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'JSON inserted' }],
+      });
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toContain('JSON inserted');
+    });
+
+    it('inserts array of JSON nodes', () => {
+      commands.focus('end');
+      const result = commands.insertContent([
+        { type: 'paragraph', content: [{ type: 'text', text: 'First' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Second' }] },
+      ]);
+      expect(result).toBe(true);
+
+      const text = mockEditor.view.state.doc.textContent;
+      expect(text).toContain('First');
+      expect(text).toContain('Second');
+    });
+
+    it('returns false for invalid content', () => {
+      commands.focus('start');
+      const result = commands.insertContent(null);
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('CommandManager - Selection Commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  describe('selectNodeBackward', () => {
+    it('exists and is callable', () => {
+      // selectNodeBackward is a ProseMirror command that selects the node
+      // before the cursor when at the start of a textblock
+      expect(typeof commands.selectNodeBackward).toBe('function');
+
+      // At the start of document, there's no node to select backward
+      commands.focus('start');
+      const result = commands.selectNodeBackward();
+      // Should return false when there's nothing to select
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('CommandManager - can() for new commands', () => {
+  let mockEditor: MockEditor;
+  let manager: CommandManager;
+  let can: any;
+  let commands: any;
+
+  beforeEach(() => {
+    mockEditor = createExtendedMockEditor('Hello world');
+    manager = new CommandManager(mockEditor as any);
+    can = manager.can();
+    commands = manager.commands;
+  });
+
+  afterEach(() => {
+    mockEditor.cleanup();
+  });
+
+  it('can.toggleMark() returns true with selection', () => {
+    commands.selectAll();
+    expect(can.toggleMark('bold')).toBe(true);
+  });
+
+  it('can.setBlockType() returns true for valid node', () => {
+    commands.focus('start');
+    expect(can.setBlockType('heading', { level: 1 })).toBe(true);
+  });
+
+  it('can.wrapIn() returns true for valid wrapper', () => {
+    commands.focus('start');
+    expect(can.wrapIn('blockquote')).toBe(true);
+  });
+
+  it('can.lift() returns false when nothing to lift', () => {
+    commands.focus('start');
+    expect(can.lift()).toBe(false);
+  });
+
+  it('can.lift() returns true when wrapped', () => {
+    commands.focus('start');
+    commands.wrapIn('blockquote');
+    commands.focus('start');
+    expect(can.lift()).toBe(true);
+  });
+
+  it('can.toggleList() returns true', () => {
+    commands.focus('start');
+    expect(can.toggleList('bulletList', 'listItem')).toBe(true);
+  });
+
+  it('can.insertContent() returns true for valid content', () => {
+    commands.focus('start');
+    expect(can.insertContent('<p>Test</p>')).toBe(true);
+  });
+
+  it('can() does not modify document', () => {
+    const initialContent = mockEditor.view.state.doc.textContent;
+
+    commands.selectAll();
+    can.toggleMark('bold');
+    can.setBlockType('heading');
+    can.wrapIn('blockquote');
+    can.insertContent('<p>Should not appear</p>');
+
+    expect(mockEditor.view.state.doc.textContent).toBe(initialContent);
   });
 });

--- a/packages/core/src/CommandManager.test.ts
+++ b/packages/core/src/CommandManager.test.ts
@@ -4,7 +4,7 @@
  * Testing Proxy-based dynamic command API requires flexible typing.
  * ESLint rules for `any` are disabled as this is standard practice for testing dynamic APIs.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-empty-function, @typescript-eslint/restrict-template-expressions */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Schema } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Schema } from 'prosemirror-model';
+import { TextSelection } from 'prosemirror-state';
 import { Editor } from './Editor.js';
 import type { EditorOptions } from './types/index.js';
 
@@ -350,6 +351,83 @@ describe('Editor', () => {
       editor.setContent('<p>New content</p>');
 
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('emits mount event after view is attached', () => {
+      const onMount = vi.fn();
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      editor = new Editor({
+        schema: testSchema,
+        element,
+        onMount,
+      });
+
+      expect(onMount).toHaveBeenCalledTimes(1);
+      expect(onMount).toHaveBeenCalledWith({ editor, view: editor.view });
+      element.remove();
+    });
+
+    it('emits selectionUpdate event when selection changes', () => {
+      const onSelectionUpdate = vi.fn();
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      editor = new Editor({
+        schema: testSchema,
+        element,
+        content: '<p>Hello world</p>',
+        onSelectionUpdate,
+      });
+
+      // Change selection without changing content
+      const { state, view } = editor;
+      const tr = state.tr.setSelection(
+        TextSelection.create(state.doc, 3)
+      );
+      view.dispatch(tr);
+
+      expect(onSelectionUpdate).toHaveBeenCalled();
+      element.remove();
+    });
+
+    it('emits focus event when editor receives focus', () => {
+      const onFocus = vi.fn();
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      editor = new Editor({
+        schema: testSchema,
+        element,
+        onFocus,
+      });
+
+      // Simulate focus event
+      const focusEvent = new FocusEvent('focus');
+      editor.view.dom.dispatchEvent(focusEvent);
+
+      expect(onFocus).toHaveBeenCalled();
+      element.remove();
+    });
+
+    it('emits blur event when editor loses focus', () => {
+      const onBlur = vi.fn();
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      editor = new Editor({
+        schema: testSchema,
+        element,
+        onBlur,
+      });
+
+      // Simulate blur event
+      const blurEvent = new FocusEvent('blur');
+      editor.view.dom.dispatchEvent(blurEvent);
+
+      expect(onBlur).toHaveBeenCalled();
+      element.remove();
     });
   });
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -371,6 +371,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     // 1. Emit beforeCreate - extensions can modify options in Step 2
     this.emit('beforeCreate', { editor: this });
     this.options.onBeforeCreate?.({ editor: this });
+    // Note: Extension onBeforeCreate is called after ExtensionManager is created (step 2)
 
     // 2. Initialize ExtensionManager with extensions or schema
     this._extensionManager = new ExtensionManager(
@@ -380,6 +381,10 @@ export class Editor extends EventEmitter<EditorEvents> {
       },
       this
     );
+
+    // 2.1 Call onBeforeCreate on all extensions (now that they have editor reference)
+    this._extensionManager.callOnBeforeCreate();
+
     this._extensionManager.validateSchema();
 
     // 3. Create initial document from content
@@ -411,11 +416,13 @@ export class Editor extends EventEmitter<EditorEvents> {
         focus: (_view, event) => {
           this.emit('focus', { editor: this, event: event });
           this.options.onFocus?.({ editor: this, event: event });
+          this._extensionManager.callOnFocus({ event });
           return false;
         },
         blur: (_view, event) => {
           this.emit('blur', { editor: this, event: event });
           this.options.onBlur?.({ editor: this, event: event });
+          this._extensionManager.callOnBlur({ event });
           return false;
         },
       },
@@ -441,9 +448,10 @@ export class Editor extends EventEmitter<EditorEvents> {
       this.options.onError?.(props);
     });
 
-    // 12. Emit create event
+    // 12. Emit create event and call extension onCreate hooks
     this.emit('create', { editor: this });
     this.options.onCreate?.({ editor: this });
+    this._extensionManager.callOnCreate();
   }
 
   /**
@@ -463,6 +471,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     // 3. Emit transaction event (fires for EVERY transaction)
     this.emit('transaction', { editor: this, transaction });
     this.options.onTransaction?.({ editor: this, transaction });
+    this._extensionManager.callOnTransaction({ transaction });
 
     // 4. Check if we should skip update event
     const skipUpdate = transaction.getMeta('skipUpdate') as boolean | undefined;
@@ -471,12 +480,14 @@ export class Editor extends EventEmitter<EditorEvents> {
     if (!transaction.docChanged && transaction.selectionSet) {
       this.emit('selectionUpdate', { editor: this, transaction });
       this.options.onSelectionUpdate?.({ editor: this, transaction });
+      this._extensionManager.callOnSelectionUpdate();
     }
 
     // 6. Emit update if document changed
     if (transaction.docChanged && !skipUpdate) {
       this.emit('update', { editor: this, transaction });
       this.options.onUpdate?.({ editor: this, transaction });
+      this._extensionManager.callOnUpdate();
     }
   }
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -436,7 +436,12 @@ export class Editor extends EventEmitter<EditorEvents> {
       }, 0);
     }
 
-    // 11. Emit create event
+    // 11. Set up error event handler for onError callback
+    this.on('error', (props) => {
+      this.options.onError?.(props);
+    });
+
+    // 12. Emit create event
     this.emit('create', { editor: this });
     this.options.onCreate?.({ editor: this });
   }

--- a/packages/core/src/ExtensionManager.test.ts
+++ b/packages/core/src/ExtensionManager.test.ts
@@ -1,3 +1,9 @@
+/**
+ * ExtensionManager tests
+ *
+ * ESLint rules disabled for testing patterns that require flexible typing.
+ */
+/* eslint-disable @typescript-eslint/no-confusing-void-expression, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/only-throw-error */
 import { describe, it, expect, vi } from 'vitest';
 import { Schema } from 'prosemirror-model';
 import { ExtensionManager } from './ExtensionManager.js';
@@ -334,6 +340,120 @@ describe('ExtensionManager', () => {
       );
 
       manager.destroy();
+      expect(onDestroySpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('safeCall (2.7: Extension Error Isolation)', () => {
+    it('returns result on successful execution', () => {
+      const manager = new ExtensionManager({ schema: validSchema }, mockEditor);
+
+      const result = manager.safeCall(() => 42, 'test.context');
+      expect(result).toBe(42);
+    });
+
+    it('returns undefined on error', () => {
+      const manager = new ExtensionManager({ schema: validSchema }, mockEditor);
+
+      const result = manager.safeCall(() => {
+        throw new Error('Test error');
+      }, 'test.context');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('emits error event when error occurs', () => {
+      const emit = vi.fn();
+      const editorWithEmit = {
+        schema: validSchema,
+        emit,
+      };
+
+      const manager = new ExtensionManager({ schema: validSchema }, editorWithEmit);
+
+      manager.safeCall(() => {
+        throw new Error('Test error');
+      }, 'TestExt.addCommands');
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith('error', {
+        error: expect.any(Error),
+        context: 'TestExt.addCommands',
+      });
+    });
+
+    it('converts non-Error throws to Error', () => {
+      const emit = vi.fn();
+      const editorWithEmit = {
+        schema: validSchema,
+        emit,
+      };
+
+      const manager = new ExtensionManager({ schema: validSchema }, editorWithEmit);
+
+      manager.safeCall(() => {
+        throw 'string error';
+      }, 'test.context');
+
+      expect(emit).toHaveBeenCalledWith('error', {
+        error: expect.objectContaining({ message: 'string error' }),
+        context: 'test.context',
+      });
+    });
+  });
+
+  describe('error isolation in extension lifecycle', () => {
+    it('continues processing other extensions after one throws in addCommands', () => {
+      const ExtThatThrows = Extension.create({
+        name: 'throws',
+        addCommands() {
+          throw new Error('Commands error');
+        },
+      });
+
+      const ExtWithCommands = Extension.create({
+        name: 'works',
+        addCommands() {
+          return {
+            testCommand:
+              () =>
+              (): boolean =>
+                true,
+          };
+        },
+      });
+
+      const manager = new ExtensionManager(
+        { extensions: [DocumentNode, ParagraphNode, TextNode, ExtThatThrows, ExtWithCommands] },
+        mockEditor
+      );
+
+      // ExtThatThrows should not crash, and ExtWithCommands should work
+      expect(manager.commands['testCommand']).toBeDefined();
+    });
+
+    it('continues processing other extensions after one throws in onDestroy', () => {
+      const onDestroySpy = vi.fn();
+
+      const ExtThatThrows = Extension.create({
+        name: 'throws',
+        onDestroy() {
+          throw new Error('Destroy error');
+        },
+      });
+
+      const ExtWithDestroy = Extension.create({
+        name: 'works',
+        onDestroy: onDestroySpy,
+      });
+
+      const manager = new ExtensionManager(
+        { extensions: [DocumentNode, ParagraphNode, TextNode, ExtThatThrows, ExtWithDestroy] },
+        mockEditor
+      );
+
+      // Should not throw, and should call both onDestroy handlers
+      expect(() => { manager.destroy(); }).not.toThrow();
       expect(onDestroySpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -25,11 +25,20 @@ import type { Mark } from './Mark.js';
 import { callOrReturn } from './helpers/callOrReturn.js';
 
 /**
+ * Error event props for safeCall
+ */
+interface ErrorEventProps {
+  error: Error;
+  context: string;
+}
+
+/**
  * Editor interface for ExtensionManager
  * Forward declaration to avoid circular dependency
  */
 export interface ExtensionManagerEditor {
   readonly schema: Schema;
+  emit?(event: 'error', props: ErrorEventProps): void;
 }
 
 /**
@@ -300,9 +309,14 @@ export class ExtensionManager {
     for (const ext of this._extensions) {
       const storageFactory = (ext as Extension).config.addStorage;
       if (storageFactory) {
-        const storage = callOrReturn(storageFactory, ext);
-        this._storage[ext.name] = storage;
-        (ext as Extension).storage = storage;
+        const storage = this.safeCall(
+          () => callOrReturn(storageFactory, ext),
+          `${ext.name}.addStorage`
+        );
+        if (storage !== undefined) {
+          this._storage[ext.name] = storage;
+          (ext as Extension).storage = storage;
+        }
       }
     }
   }
@@ -331,7 +345,10 @@ export class ExtensionManager {
     for (const ext of this._extensions) {
       const addPlugins = (ext as Extension).config.addProseMirrorPlugins;
       if (addPlugins) {
-        const extPlugins = callOrReturn(addPlugins, ext) as Plugin[] | undefined;
+        const extPlugins = this.safeCall(
+          () => callOrReturn(addPlugins, ext) as Plugin[] | undefined,
+          `${ext.name}.addProseMirrorPlugins`
+        );
         if (extPlugins && extPlugins.length > 0) {
           plugins.push(...extPlugins);
         }
@@ -353,9 +370,14 @@ export class ExtensionManager {
     for (const ext of this._extensions) {
       const addShortcuts = (ext as Extension).config.addKeyboardShortcuts;
       if (addShortcuts) {
-        const extShortcuts = callOrReturn(addShortcuts, ext);
-        // Cast needed: KeyboardShortcutCommand should be PM-compatible in practice
-        Object.assign(shortcuts, extShortcuts as unknown as Record<string, PMCommand>);
+        const extShortcuts = this.safeCall(
+          () => callOrReturn(addShortcuts, ext),
+          `${ext.name}.addKeyboardShortcuts`
+        );
+        if (extShortcuts) {
+          // Cast needed: KeyboardShortcutCommand should be PM-compatible in practice
+          Object.assign(shortcuts, extShortcuts as unknown as Record<string, PMCommand>);
+        }
       }
     }
 
@@ -371,7 +393,10 @@ export class ExtensionManager {
     for (const ext of this._extensions) {
       const addRules = (ext as Extension).config.addInputRules;
       if (addRules) {
-        const extRules = callOrReturn(addRules, ext) as InputRule[] | undefined;
+        const extRules = this.safeCall(
+          () => callOrReturn(addRules, ext) as InputRule[] | undefined,
+          `${ext.name}.addInputRules`
+        );
         if (extRules && extRules.length > 0) {
           rules.push(...extRules);
         }
@@ -390,7 +415,10 @@ export class ExtensionManager {
     for (const ext of this._extensions) {
       const addCommands = (ext as Extension).config.addCommands;
       if (addCommands) {
-        const extCommands = callOrReturn(addCommands, ext) as RawCommands | undefined;
+        const extCommands = this.safeCall(
+          () => callOrReturn(addCommands, ext) as RawCommands | undefined,
+          `${ext.name}.addCommands`
+        );
         if (extCommands) {
           Object.assign(commands, extCommands);
         }
@@ -439,14 +467,39 @@ export class ExtensionManager {
       return;
     }
 
-    // Call onDestroy on all extensions
+    // Call onDestroy on all extensions (wrapped in safeCall)
     for (const ext of this._extensions) {
       const onDestroy = (ext as Extension).config.onDestroy;
       if (onDestroy) {
-        callOrReturn(onDestroy, ext);
+        this.safeCall(() => {
+          callOrReturn(onDestroy, ext);
+        }, `${ext.name}.onDestroy`);
       }
     }
 
     this.isDestroyed = true;
+  }
+
+  // === Error Handling (2.7: Extension Error Isolation) ===
+
+  /**
+   * Safely executes a function, catching and reporting errors
+   * Prevents a single extension error from crashing the entire editor
+   *
+   * @param fn - Function to execute
+   * @param context - Context for error reporting (e.g., 'Bold.onUpdate')
+   * @returns The function result, or undefined if an error occurred
+   */
+  safeCall<T>(fn: () => T, context: string): T | undefined {
+    try {
+      return fn();
+    } catch (error) {
+      const errorObj = error instanceof Error ? error : new Error(String(error));
+
+      // Emit error event (Editor will call onError callback via event listener)
+      this.editor.emit?.('error', { error: errorObj, context });
+
+      return undefined;
+    }
   }
 }

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -10,7 +10,7 @@
  */
 import { Schema } from 'prosemirror-model';
 import type { NodeSpec, MarkSpec } from 'prosemirror-model';
-import type { Plugin } from 'prosemirror-state';
+import type { Plugin, Transaction } from 'prosemirror-state';
 import { keymap } from 'prosemirror-keymap';
 import { inputRules as createInputRulesPlugin } from 'prosemirror-inputrules';
 import type { InputRule } from 'prosemirror-inputrules';
@@ -500,6 +500,109 @@ export class ExtensionManager {
       this.editor.emit?.('error', { error: errorObj, context });
 
       return undefined;
+    }
+  }
+
+  // === Extension Lifecycle Hook Calls ===
+
+  /**
+   * Calls onBeforeCreate on all extensions
+   */
+  callOnBeforeCreate(): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onBeforeCreate;
+      if (hook) {
+        this.safeCall(() => {
+          callOrReturn(hook, ext);
+        }, `${ext.name}.onBeforeCreate`);
+      }
+    }
+  }
+
+  /**
+   * Calls onCreate on all extensions
+   */
+  callOnCreate(): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onCreate;
+      if (hook) {
+        this.safeCall(() => {
+          callOrReturn(hook, ext);
+        }, `${ext.name}.onCreate`);
+      }
+    }
+  }
+
+  /**
+   * Calls onUpdate on all extensions
+   */
+  callOnUpdate(): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onUpdate;
+      if (hook) {
+        this.safeCall(() => {
+          callOrReturn(hook, ext);
+        }, `${ext.name}.onUpdate`);
+      }
+    }
+  }
+
+  /**
+   * Calls onSelectionUpdate on all extensions
+   */
+  callOnSelectionUpdate(): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onSelectionUpdate;
+      if (hook) {
+        this.safeCall(() => {
+          callOrReturn(hook, ext);
+        }, `${ext.name}.onSelectionUpdate`);
+      }
+    }
+  }
+
+  /**
+   * Calls onTransaction on all extensions
+   * @param props - Transaction props
+   */
+  callOnTransaction(props: { transaction: Transaction }): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onTransaction;
+      if (hook) {
+        this.safeCall(() => {
+          hook.call(ext, props);
+        }, `${ext.name}.onTransaction`);
+      }
+    }
+  }
+
+  /**
+   * Calls onFocus on all extensions
+   * @param props - Focus event props
+   */
+  callOnFocus(props: { event: FocusEvent }): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onFocus;
+      if (hook) {
+        this.safeCall(() => {
+          hook.call(ext, props);
+        }, `${ext.name}.onFocus`);
+      }
+    }
+  }
+
+  /**
+   * Calls onBlur on all extensions
+   * @param props - Blur event props
+   */
+  callOnBlur(props: { event: FocusEvent }): void {
+    for (const ext of this._extensions) {
+      const hook = (ext as Extension).config.onBlur;
+      if (hook) {
+        this.safeCall(() => {
+          hook.call(ext, props);
+        }, `${ext.name}.onBlur`);
+      }
     }
   }
 }

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -275,15 +275,16 @@ export const selectAll: CommandSpec =
  */
 export const toggleMark: CommandSpec<[markName: string, attributes?: Attrs]> =
   (markName: string, attributes?: Attrs) =>
-  ({ state, tr, dispatch }) => {
+  ({ state, dispatch }) => {
     const markType = state.schema.marks[markName];
 
     if (!markType) {
       return false;
     }
 
-    // Use ProseMirror's toggleMark command
-    return pmToggleMark(markType, attributes)(state, dispatch ? () => dispatch(tr) : undefined);
+    // Use ProseMirror's toggleMark command directly
+    // Note: pmToggleMark manages its own transaction, so we pass dispatch directly
+    return pmToggleMark(markType, attributes)(state, dispatch);
   };
 
 /**

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -6,7 +6,7 @@
  */
 import { TextSelection, AllSelection } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
-import { toggleMark as pmToggleMark } from 'prosemirror-commands';
+import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType } from 'prosemirror-commands';
 import type { Attrs } from 'prosemirror-model';
 import type { CommandSpec, RawCommands } from '../types/Commands.js';
 import type { FocusPosition, Content } from '../types/index.js';
@@ -359,6 +359,28 @@ export const unsetMark: CommandSpec<[markName: string]> =
     return true;
   };
 
+// ============================================================================
+// Block Commands
+// ============================================================================
+
+/**
+ * SetBlockType command - changes the block type of the selection
+ *
+ * @param nodeName - The name of the node type to set
+ * @param attributes - Optional attributes for the node
+ */
+export const setBlockType: CommandSpec<[nodeName: string, attributes?: Attrs]> =
+  (nodeName: string, attributes?: Attrs) =>
+  ({ state, dispatch }) => {
+    const nodeType = state.schema.nodes[nodeName];
+
+    if (!nodeType) {
+      return false;
+    }
+
+    return pmSetBlockType(nodeType, attributes)(state, dispatch);
+  };
+
 /**
  * All built-in commands as RawCommands
  * These are merged with extension commands in CommandManager
@@ -375,4 +397,6 @@ export const builtInCommands: RawCommands = {
   toggleMark,
   setMark,
   unsetMark,
+  // Block commands
+  setBlockType,
 } as RawCommands;

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -537,7 +537,7 @@ export const toggleList: CommandSpec<[listNodeName: string, listItemNodeName: st
     }
 
     // If we're in the same list type, lift the items out
-    if (parentList && parentList.type === listType) {
+    if (parentList?.type === listType) {
       return liftListItem(listItemType)(state, dispatch);
     }
 

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -6,7 +6,7 @@
  */
 import { TextSelection, AllSelection } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
-import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType } from 'prosemirror-commands';
+import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType, wrapIn as pmWrapIn, lift as pmLift } from 'prosemirror-commands';
 import type { Attrs } from 'prosemirror-model';
 import type { CommandSpec, RawCommands } from '../types/Commands.js';
 import type { FocusPosition, Content } from '../types/index.js';
@@ -382,6 +382,94 @@ export const setBlockType: CommandSpec<[nodeName: string, attributes?: Attrs]> =
   };
 
 /**
+ * ToggleBlockType command - toggles between a block type and a default type
+ *
+ * If the current block is of the target type, changes it to the default type.
+ * If the current block is not of the target type, changes it to the target type.
+ *
+ * @param nodeName - The name of the node type to toggle to
+ * @param defaultNodeName - The name of the default node type (usually 'paragraph')
+ * @param attributes - Optional attributes for the node
+ */
+export const toggleBlockType: CommandSpec<[nodeName: string, defaultNodeName: string, attributes?: Attrs]> =
+  (nodeName: string, defaultNodeName: string, attributes?: Attrs) =>
+  ({ state, dispatch }) => {
+    const nodeType = state.schema.nodes[nodeName];
+    const defaultNodeType = state.schema.nodes[defaultNodeName];
+
+    if (!nodeType || !defaultNodeType) {
+      return false;
+    }
+
+    // Check if the current block is of the target type
+    const { $from } = state.selection;
+    const currentNode = $from.parent;
+
+    // If current block matches target type, toggle to default
+    if (currentNode.type === nodeType) {
+      return pmSetBlockType(defaultNodeType)(state, dispatch);
+    }
+
+    // Otherwise, set to target type
+    return pmSetBlockType(nodeType, attributes)(state, dispatch);
+  };
+
+/**
+ * WrapIn command - wraps the selection in a node type
+ *
+ * @param nodeName - The name of the wrapping node type
+ * @param attributes - Optional attributes for the node
+ */
+export const wrapIn: CommandSpec<[nodeName: string, attributes?: Attrs]> =
+  (nodeName: string, attributes?: Attrs) =>
+  ({ state, dispatch }) => {
+    const nodeType = state.schema.nodes[nodeName];
+
+    if (!nodeType) {
+      return false;
+    }
+
+    return pmWrapIn(nodeType, attributes)(state, dispatch);
+  };
+
+/**
+ * ToggleWrap command - toggles wrapping of the selection in a node type
+ *
+ * If the selection is already wrapped in the node type, lifts it out.
+ * Otherwise, wraps the selection in the node type.
+ *
+ * @param nodeName - The name of the wrapping node type
+ * @param attributes - Optional attributes for the node
+ */
+export const toggleWrap: CommandSpec<[nodeName: string, attributes?: Attrs]> =
+  (nodeName: string, attributes?: Attrs) =>
+  ({ state, dispatch }) => {
+    const nodeType = state.schema.nodes[nodeName];
+
+    if (!nodeType) {
+      return false;
+    }
+
+    // Check if we're already inside a node of this type
+    const { $from } = state.selection;
+    let isWrapped = false;
+
+    for (let depth = $from.depth; depth > 0; depth--) {
+      if ($from.node(depth).type === nodeType) {
+        isWrapped = true;
+        break;
+      }
+    }
+
+    // If wrapped, lift out; otherwise wrap
+    if (isWrapped) {
+      return pmLift(state, dispatch);
+    }
+
+    return pmWrapIn(nodeType, attributes)(state, dispatch);
+  };
+
+/**
  * All built-in commands as RawCommands
  * These are merged with extension commands in CommandManager
  */
@@ -399,4 +487,8 @@ export const builtInCommands: RawCommands = {
   unsetMark,
   // Block commands
   setBlockType,
+  toggleBlockType,
+  // Wrap commands
+  wrapIn,
+  toggleWrap,
 } as RawCommands;

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -6,7 +6,9 @@
  */
 import { TextSelection, AllSelection } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
-import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType, wrapIn as pmWrapIn, lift as pmLift } from 'prosemirror-commands';
+import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType, wrapIn as pmWrapIn, lift as pmLift, selectNodeBackward as pmSelectNodeBackward } from 'prosemirror-commands';
+import { wrapInList, liftListItem } from 'prosemirror-schema-list';
+import { Fragment, Slice, DOMParser as ProseMirrorDOMParser } from 'prosemirror-model';
 import type { Attrs } from 'prosemirror-model';
 import type { CommandSpec, RawCommands } from '../types/Commands.js';
 import type { FocusPosition, Content } from '../types/index.js';
@@ -469,6 +471,166 @@ export const toggleWrap: CommandSpec<[nodeName: string, attributes?: Attrs]> =
     return pmWrapIn(nodeType, attributes)(state, dispatch);
   };
 
+// ============================================================================
+// Lift Command
+// ============================================================================
+
+/**
+ * Lift command - lifts the current block out of its parent wrapper
+ *
+ * For example, lifts a paragraph out of a blockquote.
+ */
+export const lift: CommandSpec =
+  () =>
+  ({ state, dispatch }) => {
+    return pmLift(state, dispatch);
+  };
+
+// ============================================================================
+// List Commands
+// ============================================================================
+
+/**
+ * ToggleList command - toggles a list type on the current selection
+ *
+ * If the selection is not in a list, wraps it in the specified list type.
+ * If it's in the same list type, lifts the list items out.
+ * If it's in a different list type, converts to the new list type.
+ *
+ * @param listNodeName - The name of the list node type (e.g., 'bulletList', 'orderedList')
+ * @param listItemNodeName - The name of the list item node type (usually 'listItem')
+ * @param attributes - Optional attributes for the list node
+ */
+export const toggleList: CommandSpec<[listNodeName: string, listItemNodeName: string, attributes?: Attrs]> =
+  (listNodeName: string, listItemNodeName: string, attributes?: Attrs) =>
+  ({ state, dispatch }) => {
+    const listType = state.schema.nodes[listNodeName];
+    const listItemType = state.schema.nodes[listItemNodeName];
+
+    if (!listType || !listItemType) {
+      return false;
+    }
+
+    // Check if we're inside a list of the target type
+    const { $from, $to } = state.selection;
+    const range = $from.blockRange($to);
+
+    if (!range) {
+      return false;
+    }
+
+    // Find if we're already in a list
+    let parentList: { type: typeof listType; pos: number } | null = null;
+
+    for (let depth = range.depth; depth >= 0; depth--) {
+      const node = $from.node(depth);
+      if (node.type === listType) {
+        parentList = { type: node.type, pos: $from.before(depth) };
+        break;
+      }
+      // Check if we're in any list type
+      if (node.type.spec.group?.includes('list')) {
+        parentList = { type: node.type, pos: $from.before(depth) };
+        break;
+      }
+    }
+
+    // If we're in the same list type, lift the items out
+    if (parentList && parentList.type === listType) {
+      return liftListItem(listItemType)(state, dispatch);
+    }
+
+    // If we're in a different list type, we need to convert
+    // For now, just wrap - converting between list types is complex
+    // and will be handled by lifting then wrapping
+    if (parentList && parentList.type !== listType) {
+      // First lift out of current list, then wrap in new list
+      // This is a simplified approach - a full implementation would
+      // preserve the list structure better
+      const lifted = liftListItem(listItemType)(state, dispatch ? undefined : dispatch);
+      if (lifted && dispatch) {
+        // After lifting, wrap in new list type
+        return wrapInList(listType, attributes)(state, dispatch);
+      }
+      return lifted;
+    }
+
+    // Not in a list, wrap in the target list type
+    return wrapInList(listType, attributes)(state, dispatch);
+  };
+
+// ============================================================================
+// Insert Content Command
+// ============================================================================
+
+/**
+ * InsertContent command - inserts content at the current selection
+ *
+ * @param content - The content to insert (JSON object, array, or HTML string)
+ */
+export const insertContent: CommandSpec<[content: Content]> =
+  (content: Content) =>
+  ({ state, tr, dispatch }) => {
+    const { schema } = state;
+    const { from, to } = tr.selection;
+
+    // Parse content based on type
+    let fragment: Fragment;
+
+    if (typeof content === 'string') {
+      // HTML string - parse using DOMParser
+      if (typeof window === 'undefined') {
+        return false; // Can't parse HTML in SSR without DOM
+      }
+
+      const parser = ProseMirrorDOMParser.fromSchema(schema);
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = content;
+      const parsed = parser.parse(wrapper);
+      fragment = parsed.content;
+    } else if (content && typeof content === 'object') {
+      // JSON content
+      if (Array.isArray(content)) {
+        // Array of nodes
+        const nodes = content.map(item => schema.nodeFromJSON(item));
+        fragment = Fragment.from(nodes);
+      } else if ('type' in content) {
+        // Single node or document
+        const node = schema.nodeFromJSON(content);
+        // If it's a doc, use its content; otherwise wrap in fragment
+        fragment = node.type.name === 'doc' ? node.content : Fragment.from(node);
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    // Insert the content
+    tr.replaceRange(from, to, new Slice(fragment, 0, 0));
+    dispatch(tr);
+    return true;
+  };
+
+// ============================================================================
+// Selection Commands
+// ============================================================================
+
+/**
+ * SelectNodeBackward command - selects the node before the cursor
+ *
+ * When the cursor is at the start of a textblock, this selects the node before it.
+ */
+export const selectNodeBackward: CommandSpec =
+  () =>
+  ({ state, dispatch }) => {
+    return pmSelectNodeBackward(state, dispatch);
+  };
+
 /**
  * All built-in commands as RawCommands
  * These are merged with extension commands in CommandManager
@@ -491,4 +653,12 @@ export const builtInCommands: RawCommands = {
   // Wrap commands
   wrapIn,
   toggleWrap,
+  // Lift command
+  lift,
+  // List commands
+  toggleList,
+  // Insert commands
+  insertContent,
+  // Selection commands
+  selectNodeBackward,
 } as RawCommands;

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -1,11 +1,13 @@
 /**
  * Built-in commands converted to CommandSpec format
  *
- * These 7 essential commands are merged with extension commands
+ * These commands are merged with extension commands
  * to provide a unified command API.
  */
 import { TextSelection, AllSelection } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
+import { toggleMark as pmToggleMark } from 'prosemirror-commands';
+import type { Attrs } from 'prosemirror-model';
 import type { CommandSpec, RawCommands } from '../types/Commands.js';
 import type { FocusPosition, Content } from '../types/index.js';
 import { createDocument } from '../helpers/index.js';
@@ -259,6 +261,104 @@ export const selectAll: CommandSpec =
     return true;
   };
 
+// ============================================================================
+// Mark Commands
+// ============================================================================
+
+/**
+ * ToggleMark command - toggles a mark on the current selection
+ *
+ * @param markName - The name of the mark to toggle
+ * @param attributes - Optional attributes for the mark
+ */
+export const toggleMark: CommandSpec<[markName: string, attributes?: Attrs]> =
+  (markName: string, attributes?: Attrs) =>
+  ({ state, tr, dispatch }) => {
+    const markType = state.schema.marks[markName];
+
+    if (!markType) {
+      return false;
+    }
+
+    // Use ProseMirror's toggleMark command
+    return pmToggleMark(markType, attributes)(state, dispatch ? () => dispatch(tr) : undefined);
+  };
+
+/**
+ * SetMark command - adds a mark to the current selection
+ *
+ * @param markName - The name of the mark to set
+ * @param attributes - Optional attributes for the mark
+ */
+export const setMark: CommandSpec<[markName: string, attributes?: Attrs]> =
+  (markName: string, attributes?: Attrs) =>
+  ({ state, tr, dispatch }) => {
+    const markType = state.schema.marks[markName];
+
+    if (!markType) {
+      return false;
+    }
+
+    const { from, to, empty } = tr.selection;
+
+    // Can't add mark to empty selection (unless storedMarks)
+    if (empty) {
+      // For empty selection, add to stored marks
+      if (!dispatch) {
+        return true;
+      }
+
+      const mark = markType.create(attributes);
+      tr.addStoredMark(mark);
+      dispatch(tr);
+      return true;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    tr.addMark(from, to, markType.create(attributes));
+    dispatch(tr);
+    return true;
+  };
+
+/**
+ * UnsetMark command - removes a mark from the current selection
+ *
+ * @param markName - The name of the mark to remove
+ */
+export const unsetMark: CommandSpec<[markName: string]> =
+  (markName: string) =>
+  ({ state, tr, dispatch }) => {
+    const markType = state.schema.marks[markName];
+
+    if (!markType) {
+      return false;
+    }
+
+    const { from, to, empty } = tr.selection;
+
+    // For empty selection, remove from stored marks
+    if (empty) {
+      if (!dispatch) {
+        return true;
+      }
+
+      tr.removeStoredMark(markType);
+      dispatch(tr);
+      return true;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    tr.removeMark(from, to, markType);
+    dispatch(tr);
+    return true;
+  };
+
 /**
  * All built-in commands as RawCommands
  * These are merged with extension commands in CommandManager
@@ -271,4 +371,8 @@ export const builtInCommands: RawCommands = {
   insertText,
   deleteSelection,
   selectAll,
+  // Mark commands
+  toggleMark,
+  setMark,
+  unsetMark,
 } as RawCommands;

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -10,6 +10,10 @@ export {
   insertText,
   deleteSelection,
   selectAll,
+  // Mark commands
+  toggleMark,
+  setMark,
+  unsetMark,
   type SetContentOptions,
   type ClearContentOptions,
 } from './builtIn.js';

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -16,6 +16,10 @@ export {
   unsetMark,
   // Block commands
   setBlockType,
+  toggleBlockType,
+  // Wrap commands
+  wrapIn,
+  toggleWrap,
   type SetContentOptions,
   type ClearContentOptions,
 } from './builtIn.js';

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -14,6 +14,8 @@ export {
   toggleMark,
   setMark,
   unsetMark,
+  // Block commands
+  setBlockType,
   type SetContentOptions,
   type ClearContentOptions,
 } from './builtIn.js';

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -20,6 +20,14 @@ export {
   // Wrap commands
   wrapIn,
   toggleWrap,
+  // Lift command
+  lift,
+  // List commands
+  toggleList,
+  // Insert commands
+  insertContent,
+  // Selection commands
+  selectNodeBackward,
   type SetContentOptions,
   type ClearContentOptions,
 } from './builtIn.js';

--- a/packages/core/src/types/EditorEvents.ts
+++ b/packages/core/src/types/EditorEvents.ts
@@ -86,6 +86,17 @@ export interface DeleteEventProps {
 }
 
 /**
+ * Props passed to error event handler (2.7: Extension Error Isolation)
+ */
+export interface ErrorEventProps {
+  editor: EditorInstance;
+  /** The error that was thrown */
+  error: Error;
+  /** Context describing where the error occurred (e.g., 'Bold.onUpdate', 'History.addProseMirrorPlugins') */
+  context: string;
+}
+
+/**
  * All editor events with their payload types
  * Used by EventEmitter for type-safe event handling
  */
@@ -131,6 +142,9 @@ export interface EditorEvents {
 
   /** Fired when content is deleted */
   delete: DeleteEventProps;
+
+  /** Fired when an extension throws an error (2.7: Extension Error Isolation) */
+  error: ErrorEventProps;
 }
 
 /**

--- a/packages/core/src/types/EditorOptions.ts
+++ b/packages/core/src/types/EditorOptions.ts
@@ -9,6 +9,7 @@ import type {
   DropEventProps,
   MountEventProps,
   DeleteEventProps,
+  ErrorEventProps,
 } from './EditorEvents.js';
 import type { Extension } from '../Extension.js';
 import type { Node } from '../Node.js';
@@ -204,6 +205,12 @@ export interface EditorOptions {
    * Called when content is deleted
    */
   onDelete?: (props: DeleteEventProps) => void;
+
+  /**
+   * Called when an extension throws an error (2.7: Extension Error Isolation)
+   * Allows graceful error handling without crashing the editor
+   */
+  onError?: (props: ErrorEventProps) => void;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   DropEventProps,
   MountEventProps,
   DeleteEventProps,
+  ErrorEventProps,
   EditorEvents,
   EditorEventName,
 } from './EditorEvents.js';


### PR DESCRIPTION
## Summary

Adds comprehensive built-in editor commands and implements extension error isolation to prevent single extension failures from crashing the editor.

## Features

### Built-in Commands
- **Mark commands**: `toggleMark`, `setMark`, `unsetMark`
- **Block commands**: `setBlockType`, `wrapIn`, `toggleWrap`
- **List commands**: `lift`, `toggleList`
- **Content commands**: `insertContent`, `selectNodeBackward`

### Extension Error Isolation 
- `safeCall()` method wraps all extension lifecycle hooks
- Errors are caught and emitted via `onError` callback
- One extension failure doesn't crash others
- Context provided for debugging (e.g., `Bold.onUpdate`)

### Lifecycle Hook Integration
- All hooks wrapped: `onBeforeCreate`, `onCreate`, `onUpdate`, `onSelectionUpdate`, `onTransaction`, `onFocus`, `onBlur`, `onDestroy`
- `ErrorEventProps` type added to `EditorEvents`

## Test plan

- [x] All command tests pass (602 new test lines)
- [x] Editor event tests added (mount, selectionUpdate, focus, blur)
- [x] Error isolation tests verify:
  - `safeCall` returns result on success, undefined on error
  - Error event emitted with context
  - Extensions continue processing after one throws
