### PR TITLE
feat(core): add core nodes (Document, Text, Paragraph)

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -286,6 +286,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
     if (this.config.renderHTML) {
       const renderFn = this.config.renderHTML;
       const attrSpecs = attributeSpecs;
+      // Capture 'this' (the Node instance) for use in toDOM
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const nodeInstance = this;
 
       spec.toDOM = (node) => {
         // Build HTML attributes from node attrs and renderHTML functions
@@ -309,7 +312,8 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
           }
         }
 
-        return renderFn({ node, HTMLAttributes: htmlAttrs });
+        // Call renderFn with Node instance as 'this' context
+        return renderFn.call(nodeInstance, { node, HTMLAttributes: htmlAttrs });
       };
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,3 +112,11 @@ export {
   deleteSelection,
   selectAll,
 } from './commands/index.js';
+
+// === Nodes ===
+export {
+  Document,
+  Text,
+  Paragraph,
+  type ParagraphOptions,
+} from './nodes/index.js';

--- a/packages/core/src/nodes/Document.test.ts
+++ b/packages/core/src/nodes/Document.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { Document } from './Document.js';
+
+describe('Document', () => {
+  it('has correct name', () => {
+    expect(Document.name).toBe('doc');
+  });
+
+  it('is a node type', () => {
+    expect(Document.type).toBe('node');
+  });
+
+  it('is a topNode', () => {
+    expect(Document.config.topNode).toBe(true);
+  });
+
+  it('requires block+ content', () => {
+    expect(Document.config.content).toBe('block+');
+  });
+
+  it('creates correct NodeSpec', () => {
+    const spec = Document.createNodeSpec();
+
+    expect(spec.content).toBe('block+');
+  });
+});

--- a/packages/core/src/nodes/Document.ts
+++ b/packages/core/src/nodes/Document.ts
@@ -1,0 +1,14 @@
+/**
+ * Document Node
+ *
+ * The root node of every ProseMirror document.
+ * Must have at least one block child.
+ */
+
+import { Node } from '../Node.js';
+
+export const Document = Node.create({
+  name: 'doc',
+  topNode: true,
+  content: 'block+',
+});

--- a/packages/core/src/nodes/Paragraph.test.ts
+++ b/packages/core/src/nodes/Paragraph.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { Paragraph } from './Paragraph.js';
+import { Document } from './Document.js';
+import { Text } from './Text.js';
+import { Editor } from '../Editor.js';
+
+describe('Paragraph', () => {
+  describe('configuration', () => {
+    it('has correct name', () => {
+      expect(Paragraph.name).toBe('paragraph');
+    });
+
+    it('is a node type', () => {
+      expect(Paragraph.type).toBe('node');
+    });
+
+    it('belongs to block group', () => {
+      expect(Paragraph.config.group).toBe('block');
+    });
+
+    it('has inline* content', () => {
+      expect(Paragraph.config.content).toBe('inline*');
+    });
+
+    it('has priority 1000', () => {
+      expect(Paragraph.config.priority).toBe(1000);
+    });
+
+    it('has default HTMLAttributes option', () => {
+      expect(Paragraph.options).toEqual({ HTMLAttributes: {} });
+    });
+  });
+
+  describe('parseHTML', () => {
+    it('returns rule for p tag', () => {
+      const rules = Paragraph.config.parseHTML?.call(Paragraph);
+
+      expect(rules).toEqual([{ tag: 'p' }]);
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('returns correct DOMOutputSpec', () => {
+      const spec = Paragraph.createNodeSpec();
+      const mockNode = { attrs: {} } as any;
+
+      const result = spec.toDOM?.(mockNode);
+
+      expect(result).toEqual(['p', {}, 0]);
+    });
+
+    it('merges HTMLAttributes from options', () => {
+      const CustomParagraph = Paragraph.configure({
+        HTMLAttributes: { class: 'custom-paragraph' },
+      });
+
+      const spec = CustomParagraph.createNodeSpec();
+      const mockNode = { attrs: {} } as any;
+
+      const result = spec.toDOM?.(mockNode);
+
+      expect(result).toEqual(['p', { class: 'custom-paragraph' }, 0]);
+    });
+  });
+
+  describe('addCommands', () => {
+    it('provides setParagraph command', () => {
+      const commands = Paragraph.config.addCommands?.call(Paragraph);
+
+      expect(commands).toHaveProperty('setParagraph');
+      expect(typeof commands?.setParagraph).toBe('function');
+    });
+  });
+
+  describe('addKeyboardShortcuts', () => {
+    it('provides Mod-Alt-0 shortcut', () => {
+      const shortcuts = Paragraph.config.addKeyboardShortcuts?.call(Paragraph);
+
+      expect(shortcuts).toHaveProperty('Mod-Alt-0');
+    });
+  });
+
+  describe('integration', () => {
+    let editor: Editor;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('works with Editor using extensions', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph],
+        content: '<p>Hello world</p>',
+      });
+
+      expect(editor.getText()).toBe('Hello world');
+    });
+
+    it('creates paragraph on empty init', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph],
+      });
+
+      const doc = editor.state.doc;
+      expect(doc.childCount).toBe(1);
+      expect(doc.firstChild?.type.name).toBe('paragraph');
+    });
+
+    it('parses HTML content correctly', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph],
+        content: '<p>First</p><p>Second</p>',
+      });
+
+      const doc = editor.state.doc;
+      expect(doc.childCount).toBe(2);
+      expect(doc.child(0).type.name).toBe('paragraph');
+      expect(doc.child(1).type.name).toBe('paragraph');
+    });
+
+    it('renders to HTML correctly', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph],
+        content: '<p>Test content</p>',
+      });
+
+      const html = editor.getHTML();
+      expect(html).toBe('<p>Test content</p>');
+    });
+  });
+});

--- a/packages/core/src/nodes/Paragraph.test.ts
+++ b/packages/core/src/nodes/Paragraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { Schema } from 'prosemirror-model';
+import type { Node as PMNode } from 'prosemirror-model';
 import { Paragraph } from './Paragraph.js';
 import { Document } from './Document.js';
 import { Text } from './Text.js';
@@ -43,7 +43,7 @@ describe('Paragraph', () => {
   describe('renderHTML', () => {
     it('returns correct DOMOutputSpec', () => {
       const spec = Paragraph.createNodeSpec();
-      const mockNode = { attrs: {} } as any;
+      const mockNode = { attrs: {} } as PMNode;
 
       const result = spec.toDOM?.(mockNode);
 
@@ -56,7 +56,7 @@ describe('Paragraph', () => {
       });
 
       const spec = CustomParagraph.createNodeSpec();
-      const mockNode = { attrs: {} } as any;
+      const mockNode = { attrs: {} } as PMNode;
 
       const result = spec.toDOM?.(mockNode);
 
@@ -69,7 +69,7 @@ describe('Paragraph', () => {
       const commands = Paragraph.config.addCommands?.call(Paragraph);
 
       expect(commands).toHaveProperty('setParagraph');
-      expect(typeof commands?.setParagraph).toBe('function');
+      expect(typeof commands?.['setParagraph']).toBe('function');
     });
   });
 
@@ -82,7 +82,7 @@ describe('Paragraph', () => {
   });
 
   describe('integration', () => {
-    let editor: Editor;
+    let editor: Editor | undefined;
 
     afterEach(() => {
       if (editor && !editor.isDestroyed) {

--- a/packages/core/src/nodes/Paragraph.ts
+++ b/packages/core/src/nodes/Paragraph.ts
@@ -1,0 +1,49 @@
+/**
+ * Paragraph Node
+ *
+ * The default block-level text container.
+ * Contains inline content (text and inline nodes).
+ */
+
+import { Node } from '../Node.js';
+
+export interface ParagraphOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const Paragraph = Node.create<ParagraphOptions>({
+  name: 'paragraph',
+  group: 'block',
+  content: 'inline*',
+  priority: 1000,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'p' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['p', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+  },
+
+  addCommands() {
+    return {
+      setParagraph:
+        () =>
+        ({ commands }) => {
+          return commands.setBlockType(this.name);
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Alt-0': () => this.editor!.commands.setParagraph(),
+    };
+  },
+});

--- a/packages/core/src/nodes/Paragraph.ts
+++ b/packages/core/src/nodes/Paragraph.ts
@@ -5,6 +5,7 @@
  * Contains inline content (text and inline nodes).
  */
 
+import type { Node as NodeClass } from '../Node.js';
 import { Node } from '../Node.js';
 
 export interface ParagraphOptions {
@@ -28,22 +29,29 @@ export const Paragraph = Node.create<ParagraphOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ['p', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+    const self = this as unknown as NodeClass<ParagraphOptions>;
+    return ['p', { ...self.options.HTMLAttributes, ...HTMLAttributes }, 0];
   },
 
   addCommands() {
+    const self = this as unknown as NodeClass<ParagraphOptions>;
     return {
       setParagraph:
         () =>
         ({ commands }) => {
-          return commands.setBlockType(this.name);
+          const cmds = commands as Record<string, (name: string) => boolean>;
+          return cmds['setBlockType']?.(self.name) ?? false;
         },
     };
   },
 
   addKeyboardShortcuts() {
+    const self = this as unknown as NodeClass<ParagraphOptions>;
     return {
-      'Mod-Alt-0': () => this.editor!.commands.setParagraph(),
+      'Mod-Alt-0': () => {
+        const editor = self.editor as { commands: Record<string, () => boolean> } | null;
+        return editor?.commands['setParagraph']?.() ?? false;
+      },
     };
   },
 });

--- a/packages/core/src/nodes/Text.test.ts
+++ b/packages/core/src/nodes/Text.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { Text } from './Text.js';
+
+describe('Text', () => {
+  it('has correct name', () => {
+    expect(Text.name).toBe('text');
+  });
+
+  it('is a node type', () => {
+    expect(Text.type).toBe('node');
+  });
+
+  it('belongs to inline group', () => {
+    expect(Text.config.group).toBe('inline');
+  });
+
+  it('creates correct NodeSpec', () => {
+    const spec = Text.createNodeSpec();
+
+    expect(spec.group).toBe('inline');
+  });
+});

--- a/packages/core/src/nodes/Text.ts
+++ b/packages/core/src/nodes/Text.ts
@@ -1,0 +1,13 @@
+/**
+ * Text Node
+ *
+ * Inline text content. Can hold marks (bold, italic, etc.).
+ * This is the leaf node that contains actual text content.
+ */
+
+import { Node } from '../Node.js';
+
+export const Text = Node.create({
+  name: 'text',
+  group: 'inline',
+});

--- a/packages/core/src/nodes/index.ts
+++ b/packages/core/src/nodes/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Node Extensions
+ *
+ * Pre-built node types for common document structures.
+ */
+
+export { Document } from './Document.js';
+export { Text } from './Text.js';
+export { Paragraph, type ParagraphOptions } from './Paragraph.js';


### PR DESCRIPTION
## Summary
Foundation nodes required by all documents.

## Features
- **Document** - Root node with `block+` content, marked as `topNode`
- **Text** - Inline text container in `inline` group
- **Paragraph** - Default block-level text container with:
  - `setParagraph` command
  - `Mod-Alt-0` keyboard shortcut
  - Configurable `HTMLAttributes`

## Changes
- Fix `this` binding in `Node.createNodeSpec()` for `renderHTML` method