### PR TITLE
feat(core): add BaseKeymap, this.parent support, and excludes fix

### DIFF
--- a/packages/core/src/Extension.test.ts
+++ b/packages/core/src/Extension.test.ts
@@ -251,6 +251,65 @@ describe('Extension', () => {
 
       expect(extended.type).toBe('extension');
     });
+
+    it('provides this.parent to call parent config method', () => {
+      const base = Extension.create({
+        name: 'base',
+        addOptions() {
+          return { a: 1 };
+        },
+      });
+
+      const extended = base.extend<Record<string, unknown>>({
+        name: 'extended',
+        addOptions() {
+          return { ...(this.parent?.() as Record<string, unknown>), b: 2 };
+        },
+      });
+
+      expect(extended.options).toEqual({ a: 1, b: 2 });
+    });
+
+    it('this.parent is undefined when no parent method exists', () => {
+      const base = Extension.create({
+        name: 'base',
+      });
+
+      const extended = base.extend<{ fromParent: unknown; own: boolean }>({
+        name: 'extended',
+        addOptions() {
+          const parentResult = this.parent?.();
+          return { fromParent: parentResult, own: true };
+        },
+      });
+
+      expect(extended.options).toEqual({ fromParent: undefined, own: true });
+    });
+
+    it('supports chained extends with nested this.parent', () => {
+      const base = Extension.create({
+        name: 'base',
+        addOptions() {
+          return { a: 1 };
+        },
+      });
+
+      const mid = base.extend<Record<string, unknown>>({
+        name: 'mid',
+        addOptions() {
+          return { ...(this.parent?.() as Record<string, unknown>), b: 2 };
+        },
+      });
+
+      const top = mid.extend<Record<string, unknown>>({
+        name: 'top',
+        addOptions() {
+          return { ...(this.parent?.() as Record<string, unknown>), c: 3 };
+        },
+      });
+
+      expect(top.options).toEqual({ a: 1, b: 2, c: 3 });
+    });
   });
 
   describe('storage mutation', () => {

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -24,8 +24,50 @@
  * });
  */
 
-import type { ExtensionConfig } from './types/ExtensionConfig.js';
+import type { ExtensionConfig, ExtensionConfigBase, ExtensionContext } from './types/ExtensionConfig.js';
 import { callOrReturn } from './helpers/callOrReturn.js';
+
+/**
+ * Merges extension config with parent binding support.
+ *
+ * For each function in `extendedConfig` that overrides a function in `parentConfig`,
+ * wraps the override so that `this.parent` temporarily points to the parent's version.
+ * This enables the `this.parent?.()` pattern in extend():
+ *
+ * ```typescript
+ * Paragraph.extend({
+ *   addAttributes() {
+ *     return { ...this.parent?.(), align: { default: 'left' } };
+ *   },
+ * });
+ * ```
+ */
+export function mergeConfigWithParentBinding(
+  parentConfig: object,
+  extendedConfig: object,
+): object {
+  const parent = parentConfig as Record<string, unknown>;
+  const merged: Record<string, unknown> = { ...parent };
+
+  for (const [key, value] of Object.entries(extendedConfig)) {
+    if (typeof value === 'function' && typeof parent[key] === 'function') {
+      const parentFn = parent[key] as (...args: unknown[]) => unknown;
+      const childFn = value as (...args: unknown[]) => unknown;
+
+      merged[key] = function (this: Extension, ...args: unknown[]) {
+        const previousParent = this.parent;
+        this.parent = (...pArgs: unknown[]) => parentFn.call(this, ...pArgs);
+        const result = childFn.call(this, ...args);
+        this.parent = previousParent;
+        return result;
+      };
+    } else {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}
 
 /**
  * Editor interface for Extension
@@ -77,6 +119,13 @@ export class Extension<Options = unknown, Storage = unknown> {
    * null until ExtensionManager binds it
    */
   editor: ExtensionEditorInterface | null = null;
+
+  /**
+   * Reference to the parent config method when using extend().
+   * Set temporarily during config method execution so overridden
+   * methods can call `this.parent?.()` to invoke the original.
+   */
+  parent?: ((...args: unknown[]) => unknown) | undefined;
 
   /**
    * Protected constructor - use Extension.create() instead
@@ -191,14 +240,11 @@ export class Extension<Options = unknown, Storage = unknown> {
    * });
    */
   extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<ExtensionConfig<ExtendedOptions, ExtendedStorage>>
+    extendedConfig: Partial<ExtensionConfigBase<ExtendedOptions, ExtendedStorage>> &
+      ThisType<ExtensionContext<ExtendedOptions, ExtendedStorage>>
   ): Extension<ExtendedOptions, ExtendedStorage> {
-    // Merge base config with extended config
-    const newConfig = {
-      ...this.config,
-      ...extendedConfig,
-    } as ExtensionConfig<ExtendedOptions, ExtendedStorage>;
+    const newConfig = mergeConfigWithParentBinding(this.config, extendedConfig);
 
-    return new Extension(newConfig);
+    return new Extension(newConfig as ExtensionConfig<ExtendedOptions, ExtendedStorage>);
   }
 }

--- a/packages/core/src/Mark.test.ts
+++ b/packages/core/src/Mark.test.ts
@@ -186,6 +186,67 @@ describe('Mark', () => {
 
       expect(extended.type).toBe('mark');
     });
+
+    it('provides this.parent to call parent addAttributes', () => {
+      const base = Mark.create({
+        name: 'bold',
+        addAttributes() {
+          return { weight: { default: 'bold' } };
+        },
+      });
+
+      const extended = base.extend({
+        name: 'customBold',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            color: { default: 'red' },
+          };
+        },
+      });
+
+      const spec = extended.createMarkSpec();
+      expect(spec.attrs).toEqual({
+        weight: { default: 'bold' },
+        color: { default: 'red' },
+      });
+    });
+
+    it('supports chained extends with this.parent', () => {
+      const base = Mark.create({
+        name: 'bold',
+        addAttributes() {
+          return { a: { default: 1 } };
+        },
+      });
+
+      const mid = base.extend({
+        name: 'mid',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            b: { default: 2 },
+          };
+        },
+      });
+
+      const top = mid.extend({
+        name: 'top',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            c: { default: 3 },
+          };
+        },
+      });
+
+      const spec = top.createMarkSpec();
+      expect(spec.attrs).toEqual({
+        a: { default: 1 },
+        b: { default: 2 },
+        c: { default: 3 },
+      });
+    });
   });
 
   describe('markType getter', () => {

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -26,8 +26,8 @@
  */
 
 import type { MarkSpec, MarkType, ParseRule } from 'prosemirror-model';
-import { Extension, type ExtensionEditorInterface } from './Extension.js';
-import type { MarkConfig } from './types/MarkConfig.js';
+import { Extension, type ExtensionEditorInterface, mergeConfigWithParentBinding } from './Extension.js';
+import type { MarkConfig, MarkContext } from './types/MarkConfig.js';
 import { callOrReturn } from './helpers/callOrReturn.js';
 
 /**
@@ -188,14 +188,12 @@ export class Mark<Options = unknown, Storage = unknown> extends Extension<
    * });
    */
   override extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>>
+    extendedConfig: Partial<MarkConfig<ExtendedOptions, ExtendedStorage>> &
+      ThisType<MarkContext<ExtendedOptions, ExtendedStorage>>
   ): Mark<ExtendedOptions, ExtendedStorage> {
-    const newConfig = {
-      ...this.config,
-      ...extendedConfig,
-    } as MarkConfig<ExtendedOptions, ExtendedStorage>;
+    const newConfig = mergeConfigWithParentBinding(this.config, extendedConfig);
 
-    return new Mark(newConfig);
+    return new Mark(newConfig as MarkConfig<ExtendedOptions, ExtendedStorage>);
   }
 
   /**

--- a/packages/core/src/Node.test.ts
+++ b/packages/core/src/Node.test.ts
@@ -206,6 +206,69 @@ describe('Node', () => {
 
       expect(extended.type).toBe('node');
     });
+
+    it('provides this.parent to call parent addAttributes', () => {
+      const base = Node.create({
+        name: 'paragraph',
+        group: 'block',
+        addAttributes() {
+          return { level: { default: 1 } };
+        },
+      });
+
+      const extended = base.extend({
+        name: 'customParagraph',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            align: { default: 'left' },
+          };
+        },
+      });
+
+      const spec = extended.createNodeSpec();
+      expect(spec.attrs).toEqual({
+        level: { default: 1 },
+        align: { default: 'left' },
+      });
+    });
+
+    it('supports chained extends with this.parent', () => {
+      const base = Node.create({
+        name: 'paragraph',
+        group: 'block',
+        addAttributes() {
+          return { a: { default: 1 } };
+        },
+      });
+
+      const mid = base.extend({
+        name: 'mid',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            b: { default: 2 },
+          };
+        },
+      });
+
+      const top = mid.extend({
+        name: 'top',
+        addAttributes() {
+          return {
+            ...(this.parent?.() as Record<string, unknown>),
+            c: { default: 3 },
+          };
+        },
+      });
+
+      const spec = top.createNodeSpec();
+      expect(spec.attrs).toEqual({
+        a: { default: 1 },
+        b: { default: 2 },
+        c: { default: 3 },
+      });
+    });
   });
 
   describe('nodeType getter', () => {

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -24,8 +24,8 @@
  */
 
 import type { NodeSpec, NodeType, TagParseRule } from 'prosemirror-model';
-import { Extension, type ExtensionEditorInterface } from './Extension.js';
-import type { NodeConfig } from './types/NodeConfig.js';
+import { Extension, type ExtensionEditorInterface, mergeConfigWithParentBinding } from './Extension.js';
+import type { NodeConfig, NodeContext } from './types/NodeConfig.js';
 import { callOrReturn } from './helpers/callOrReturn.js';
 
 /**
@@ -185,14 +185,12 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
    * });
    */
   override extend<ExtendedOptions = Options, ExtendedStorage = Storage>(
-    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>>
+    extendedConfig: Partial<NodeConfig<ExtendedOptions, ExtendedStorage>> &
+      ThisType<NodeContext<ExtendedOptions, ExtendedStorage>>
   ): Node<ExtendedOptions, ExtendedStorage> {
-    const newConfig = {
-      ...this.config,
-      ...extendedConfig,
-    } as NodeConfig<ExtendedOptions, ExtendedStorage>;
+    const newConfig = mergeConfigWithParentBinding(this.config, extendedConfig);
 
-    return new Node(newConfig);
+    return new Node(newConfig as NodeConfig<ExtendedOptions, ExtendedStorage>);
   }
 
   /**

--- a/packages/core/src/extensions/BaseKeymap.ts
+++ b/packages/core/src/extensions/BaseKeymap.ts
@@ -1,0 +1,74 @@
+/**
+ * BaseKeymap Extension
+ *
+ * Adds essential keyboard shortcuts for basic editing operations.
+ * This includes Enter (new paragraph), Backspace, Delete, and other
+ * fundamental editing commands from ProseMirror's baseKeymap.
+ *
+ * @example
+ * ```ts
+ * import { BaseKeymap } from '@domternal/core';
+ *
+ * const editor = new Editor({
+ *   extensions: [Document, Paragraph, Text, BaseKeymap],
+ * });
+ * ```
+ *
+ * ## Included Shortcuts
+ * - Enter: Create new paragraph / split block
+ * - Backspace: Delete backward
+ * - Delete: Delete forward
+ * - Mod-Backspace: Delete to start of line
+ * - Mod-Delete: Delete to end of line
+ * - Alt-ArrowUp/Down: Join with block above/below
+ * - Mod-a: Select all
+ * - And more standard editing commands
+ */
+import { Extension } from '../Extension.js';
+import { keymap } from 'prosemirror-keymap';
+import {
+  baseKeymap,
+  chainCommands,
+  createParagraphNear,
+  liftEmptyBlock,
+  newlineInCode,
+  splitBlock,
+} from 'prosemirror-commands';
+import type { Command } from 'prosemirror-state';
+
+export interface BaseKeymapOptions {
+  /**
+   * Whether to include the default Enter behavior.
+   * @default true
+   */
+  enter: boolean;
+}
+
+// Enhanced Enter command that handles more cases
+const enterCommand: Command = chainCommands(
+  newlineInCode,
+  createParagraphNear,
+  liftEmptyBlock,
+  splitBlock
+);
+
+export const BaseKeymap = Extension.create<BaseKeymapOptions>({
+  name: 'baseKeymap',
+
+  addOptions() {
+    return {
+      enter: true,
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const bindings = { ...baseKeymap };
+
+    // Override Enter with our enhanced version if enabled
+    if (this.options.enter) {
+      bindings['Enter'] = enterCommand;
+    }
+
+    return [keymap(bindings)];
+  },
+});

--- a/packages/core/src/extensions/StarterKit.ts
+++ b/packages/core/src/extensions/StarterKit.ts
@@ -34,6 +34,7 @@ import { Code, type CodeOptions } from '../marks/Code.js';
 import { Link, type LinkOptions } from '../marks/Link.js';
 
 // Functionality
+import { BaseKeymap, type BaseKeymapOptions } from './BaseKeymap.js';
 import { History, type HistoryOptions } from './History.js';
 import { Dropcursor, type DropcursorOptions } from './Dropcursor.js';
 import { Gapcursor } from './Gapcursor.js';
@@ -123,6 +124,10 @@ export interface StarterKitOptions {
 
   // Functionality
   /**
+   * Set to false to disable the BaseKeymap extension, or pass options to configure it.
+   */
+  baseKeymap?: false | Partial<BaseKeymapOptions>;
+  /**
    * Set to false to disable the History extension, or pass options to configure it.
    */
   history?: false | Partial<HistoryOptions>;
@@ -191,6 +196,7 @@ export const StarterKit = Extension.create<StarterKitOptions>({
     maybeAdd(Link, this.options.link);
 
     // Functionality
+    maybeAdd(BaseKeymap, this.options.baseKeymap);
     maybeAdd(History, this.options.history);
     maybeAdd(Dropcursor, this.options.dropcursor);
     maybeAdd(Gapcursor as never, this.options.gapcursor as never);

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -3,6 +3,7 @@
  */
 
 // Core functionality
+export { BaseKeymap, type BaseKeymapOptions } from './BaseKeymap.js';
 export { History, type HistoryOptions } from './History.js';
 export { Dropcursor, type DropcursorOptions } from './Dropcursor.js';
 export { Gapcursor } from './Gapcursor.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -213,6 +213,8 @@ export {
 // === Extensions ===
 export {
   // Core functionality
+  BaseKeymap,
+  type BaseKeymapOptions,
   History,
   type HistoryOptions,
   Dropcursor,

--- a/packages/core/src/marks/Code.ts
+++ b/packages/core/src/marks/Code.ts
@@ -42,7 +42,8 @@ export const Code = Mark.create<CodeOptions>({
   },
 
   // Code mark is exclusive - it cannot be combined with other marks
-  excludes: '_all',
+  // ProseMirror uses '_' to mean "exclude all marks"
+  excludes: '_',
 
   // Code should not span across multiple nodes
   spanning: false,

--- a/packages/core/src/types/ExtensionConfig.ts
+++ b/packages/core/src/types/ExtensionConfig.ts
@@ -92,6 +92,12 @@ export interface ExtensionContext<Options = unknown, Storage = unknown> {
   storage: Storage;
   /** Editor instance (null until bound by ExtensionManager) */
   editor: ExtensionEditor | null;
+  /**
+   * Reference to the parent config method when using extend().
+   * Available only inside overridden config methods.
+   * Use `this.parent?.()` to call the parent's version of the current method.
+   */
+  parent?: ((...args: unknown[]) => unknown) | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add BaseKeymap extension for essential keyboard shortcuts (Enter, Backspace, Delete, Mod-Backspace, etc.)
- Implement `this.parent` support in `extend()` enabling config method inheritance across Extension, Node, and Mark
- Fix ProseMirror `excludes` syntax: use `'_'` instead of `'_all'` in Code mark

## Features

- **BaseKeymap extension** — wraps `prosemirror-commands` base keymap with configurable shortcut overrides, included in StarterKit
- **`this.parent?.()` in extend()** — overridden config methods can now call the parent's version via `this.parent?.()`, supports chained extends (A → B → C)
- **`mergeConfigWithParentBinding()` helper** — transparently binds parent methods during config execution with save/restore for nested chains

## Changes

- `Extension.ts` — added `parent` property, `mergeConfigWithParentBinding()` helper, updated `extend()` signature with explicit `ThisType<>`
- `Node.ts`, `Mark.ts` — updated `extend()` to use `mergeConfigWithParentBinding` with proper `ThisType<>` for `this.parent` support
- `ExtensionConfig.ts` — added `parent` to `ExtensionContext` interface
- `Code.ts` — changed `excludes: '_all'` to `excludes: '_'` (correct ProseMirror syntax)
- Added `BaseKeymap` extension, exported from core, added to StarterKit
- 7 new tests for `this.parent` across Extension, Node, and Mark

## Test plan

- All existing tests pass
- New tests verify `this.parent` for single extend and chained extends
- TypeScript compiles clean with strict mode
