### PR TITLE
feat(core): refactor command types, fix extension bugs, improve type safety

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,10 @@ export default defineConfig(
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
       '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/no-empty-object-type': [
+        'error',
+        { allowInterfaces: 'always' },
+      ],
       '@typescript-eslint/no-non-null-assertion': 'warn',
       '@typescript-eslint/prefer-nullish-coalescing': 'error',
       '@typescript-eslint/prefer-optional-chain': 'error',

--- a/packages/core/src/CanChecker.test.ts
+++ b/packages/core/src/CanChecker.test.ts
@@ -4,7 +4,7 @@ import { Schema } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { CanChecker, createCanChecker } from './CanChecker.js';
-import type { RawCommands } from './types/Commands.js';
+import type { CommandMap } from './types/Commands.js';
 
 // Test schema with toDOM functions
 const schema = new Schema({
@@ -35,7 +35,7 @@ function createMockEditor(options: { isDestroyed?: boolean } = {}) {
 }
 
 // Test commands
-const testCommands: RawCommands = {
+const testCommands: CommandMap = {
   canExecute:
     () =>
     () => {
@@ -55,8 +55,9 @@ const testCommands: RawCommands = {
       return dispatch === undefined;
     },
   withArgs:
-    (a: number, b: string) =>
+    (...args: unknown[]) =>
     () => {
+      const [a, b] = args as [number, string];
       return a > 0 && b.length > 0;
     },
 };

--- a/packages/core/src/CanChecker.ts
+++ b/packages/core/src/CanChecker.ts
@@ -20,7 +20,7 @@ import type { EditorView } from 'prosemirror-view';
 import type {
   CommandProps,
   Command,
-  RawCommands,
+  CommandMap,
   CanCommands,
   CanChainedCommands,
   SingleCommands,
@@ -42,7 +42,7 @@ export interface CanCheckerEditor {
  */
 export interface CanCheckerOptions {
   editor: CanCheckerEditor;
-  rawCommands: RawCommands;
+  rawCommands: CommandMap;
   /** Function to create a ChainBuilder for chain() within commands */
   createChainBuilder: () => ChainedCommands;
   /**
@@ -60,7 +60,7 @@ export interface CanCheckerOptions {
  */
 export class CanChecker {
   private readonly editor: CanCheckerEditor;
-  private readonly rawCommands: RawCommands;
+  private readonly rawCommands: CommandMap;
   private readonly createChainBuilder: () => ChainedCommands;
   private readonly onUnknownCommand: ((name: string, context: 'single' | 'chain') => void) | undefined;
 

--- a/packages/core/src/ChainBuilder.test.ts
+++ b/packages/core/src/ChainBuilder.test.ts
@@ -4,7 +4,7 @@ import { Schema } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { ChainBuilder, createChainBuilder } from './ChainBuilder.js';
-import type { RawCommands, CommandProps } from './types/Commands.js';
+import type { CommandMap, CommandProps } from './types/Commands.js';
 
 // Test schema with toDOM functions
 const schema = new Schema({
@@ -35,7 +35,7 @@ function createMockEditor(options: { isDestroyed?: boolean } = {}) {
 }
 
 // Test commands
-const testCommands: RawCommands = {
+const testCommands: CommandMap = {
   succeed:
     () =>
     ({ dispatch }) => {
@@ -53,16 +53,18 @@ const testCommands: RawCommands = {
       return false;
     },
   insertText:
-    (text: string) =>
-    ({ tr, dispatch }) => {
+    (...args: unknown[]) =>
+    ({ tr, dispatch }: CommandProps) => {
+      const text = args[0] as string;
       if (dispatch) {
         tr.insertText(text);
       }
       return true;
     },
   withArgs:
-    (a: number, b: string) =>
-    ({ dispatch }) => {
+    (...args: unknown[]) =>
+    ({ dispatch }: CommandProps) => {
+      const [a, b] = args as [number, string];
       if (dispatch) {
         // Use args
       }

--- a/packages/core/src/ChainBuilder.ts
+++ b/packages/core/src/ChainBuilder.ts
@@ -16,7 +16,7 @@ import type { EditorView } from 'prosemirror-view';
 import type {
   CommandProps,
   Command,
-  RawCommands,
+  CommandMap,
   ChainedCommands,
   SingleCommands,
   CanCommands,
@@ -41,7 +41,7 @@ export interface ChainBuilderEditor {
  */
 export interface ChainBuilderOptions {
   editor: ChainBuilderEditor;
-  rawCommands: RawCommands;
+  rawCommands: CommandMap;
   tr?: Transaction;
 }
 
@@ -53,7 +53,7 @@ export interface ChainBuilderOptions {
  */
 export class ChainBuilder {
   private readonly editor: ChainBuilderEditor;
-  private readonly rawCommands: RawCommands;
+  private readonly rawCommands: CommandMap;
   private readonly tr: Transaction;
   private shouldDispatch = true;
   /** Cached proxy instance for performance (avoids creating new Proxy per command) */

--- a/packages/core/src/CommandManager.test.ts
+++ b/packages/core/src/CommandManager.test.ts
@@ -10,7 +10,7 @@ import { Schema } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { CommandManager } from './CommandManager.js';
-import type { RawCommands } from './types/Commands.js';
+import type { CommandMap } from './types/Commands.js';
 
 // Mock getClientRects for JSDOM (ProseMirror uses it for scrolling)
 Range.prototype.getClientRects = vi.fn(() => ({
@@ -135,7 +135,7 @@ interface MockEditor {
   isDestroyed: boolean;
   emit: () => void;
   extensionManager: {
-    commands: RawCommands;
+    commands: CommandMap;
   };
   cleanup: () => void;
 }
@@ -165,7 +165,7 @@ function createMockEditor(content?: string): MockEditor {
       // No-op for tests
     },
     extensionManager: {
-      commands: {} as RawCommands,
+      commands: {} as CommandMap,
     },
     cleanup: () => {
       view.destroy();
@@ -199,7 +199,7 @@ function createExtendedMockEditor(content?: string): MockEditor {
       // No-op for tests
     },
     extensionManager: {
-      commands: {} as RawCommands,
+      commands: {} as CommandMap,
     },
     cleanup: () => {
       view.destroy();
@@ -238,7 +238,7 @@ describe('CommandManager', () => {
       const customCommand = () => () => true;
       mockEditor.extensionManager.commands = {
         customCommand,
-      } as unknown as RawCommands;
+      } as unknown as CommandMap;
 
       // Clear cache to pick up new commands
       manager.clearCache();
@@ -500,7 +500,7 @@ describe('CommandManager', () => {
       // Add new extension command
       mockEditor.extensionManager.commands = {
         newCommand: () => () => true,
-      } as unknown as RawCommands;
+      } as unknown as CommandMap;
 
       // Without clearing, should still return old cache
       const commands2 = manager.rawCommands;

--- a/packages/core/src/CommandManager.ts
+++ b/packages/core/src/CommandManager.ts
@@ -12,7 +12,7 @@ import type { EditorView } from 'prosemirror-view';
 import type {
   CommandProps,
   Command,
-  RawCommands,
+  CommandMap,
   SingleCommands,
   ChainedCommands,
   CanCommands,
@@ -35,7 +35,7 @@ export interface CommandManagerEditor {
   emit(event: string, props?: unknown): void;
   /** Extension manager for collecting extension commands */
   readonly extensionManager: {
-    readonly commands: RawCommands;
+    readonly commands: CommandMap;
   };
 }
 
@@ -51,7 +51,7 @@ export class CommandManager {
   private readonly editor: CommandManagerEditor;
 
   /** Cached raw commands (built-in + extension) */
-  private _rawCommands: RawCommands | null = null;
+  private _rawCommands: CommandMap | null = null;
 
   /** Cached dispatch function to avoid allocation on every command */
   private readonly _dispatch: (tr: Transaction) => void;
@@ -67,7 +67,7 @@ export class CommandManager {
    * Gets all raw commands (built-in + extension commands)
    * Cached after first access
    */
-  get rawCommands(): RawCommands {
+  get rawCommands(): CommandMap {
     this._rawCommands ??= {
       ...builtInCommands,
       ...this.editor.extensionManager.commands,

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -145,7 +145,7 @@ describe('Editor', () => {
 
     it('commands returns SingleCommands', () => {
       expect(editor.commands).toBeDefined();
-      expect(typeof editor.commands['focus']).toBe('function');
+      expect(typeof editor.commands.focus).toBe('function');
     });
   });
 

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -25,6 +25,8 @@
  */
 
 import type { ExtensionConfig, ExtensionConfigBase, ExtensionContext } from './types/ExtensionConfig.js';
+import type { EditorState } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
 import { callOrReturn } from './helpers/callOrReturn.js';
 
 /**
@@ -74,8 +76,8 @@ export function mergeConfigWithParentBinding(
  * Forward declaration to avoid circular dependency
  */
 export interface ExtensionEditorInterface {
-  readonly state: unknown;
-  readonly view: unknown;
+  readonly state: EditorState;
+  readonly view: EditorView;
   readonly schema: unknown;
 }
 

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -18,7 +18,7 @@ import type { InputRule } from 'prosemirror-inputrules';
 import type { Command as PMCommand } from 'prosemirror-state';
 
 import type { AnyExtension } from './types/EditorOptions.js';
-import type { RawCommands } from './types/Commands.js';
+import type { CommandMap } from './types/Commands.js';
 import type { GlobalAttributes, GlobalAttributeSpec } from './types/ExtensionConfig.js';
 import type { Extension } from './Extension.js';
 import type { Node } from './Node.js';
@@ -100,7 +100,7 @@ export class ExtensionManager {
   /**
    * Cached commands (collected lazily)
    */
-  private _commands: RawCommands | null = null;
+  private _commands: CommandMap | null = null;
 
   /**
    * Creates a new ExtensionManager
@@ -179,7 +179,7 @@ export class ExtensionManager {
   /**
    * Gets commands from all extensions
    */
-  get commands(): RawCommands {
+  get commands(): CommandMap {
     this._commands ??= this.collectCommands();
     return this._commands;
   }
@@ -634,14 +634,14 @@ export class ExtensionManager {
    * (lower priority extensions override higher priority). This is intentional
    * to allow customization of built-in commands.
    */
-  private collectCommands(): RawCommands {
-    const commands: RawCommands = {};
+  private collectCommands(): CommandMap {
+    const commands: CommandMap = {};
 
     for (const ext of this._extensions) {
       const addCommands = (ext as Extension).config.addCommands;
       if (addCommands) {
         const extCommands = this.safeCall(
-          () => callOrReturn(addCommands, ext) as RawCommands | undefined,
+          () => callOrReturn(addCommands, ext) as CommandMap | undefined,
           `${ext.name}.addCommands`
         );
         if (extCommands) {

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -66,6 +66,29 @@ export interface ExtensionManagerOptions {
  * 1. Extensions mode: Schema built from Node/Mark extensions
  * 2. Schema mode: Direct schema passed (backward compatible)
  */
+/**
+ * Merge HTML attribute objects, concatenating 'style' and 'class' values
+ * instead of overwriting them.
+ */
+function mergeHTMLAttrs(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...target };
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key === 'style' && typeof result[key] === 'string' && typeof value === 'string') {
+      result[key] = `${result[key]}; ${value}`;
+    } else if (key === 'class' && typeof result[key] === 'string' && typeof value === 'string') {
+      result[key] = `${result[key]} ${value}`;
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
 export class ExtensionManager {
   /**
    * Processed extensions (flattened, sorted by priority)
@@ -402,7 +425,7 @@ export class ExtensionManager {
                 if (attrSpec.renderHTML) {
                   const rendered = attrSpec.renderHTML(node.attrs);
                   if (rendered) {
-                    extraHtmlAttrs = { ...extraHtmlAttrs, ...rendered };
+                    extraHtmlAttrs = mergeHTMLAttrs(extraHtmlAttrs, rendered) as Record<string, string>;
                   }
                 }
               }
@@ -489,7 +512,7 @@ export class ExtensionManager {
                 if (attrSpec.renderHTML) {
                   const rendered = attrSpec.renderHTML(mark.attrs);
                   if (rendered) {
-                    extraHtmlAttrs = { ...extraHtmlAttrs, ...rendered };
+                    extraHtmlAttrs = mergeHTMLAttrs(extraHtmlAttrs, rendered) as Record<string, string>;
                   }
                 }
               }
@@ -596,8 +619,18 @@ export class ExtensionManager {
           `${ext.name}.addKeyboardShortcuts`
         );
         if (extShortcuts) {
-          // Cast needed: KeyboardShortcutCommand should be PM-compatible in practice
-          Object.assign(shortcuts, extShortcuts as unknown as Record<string, PMCommand>);
+          const cast = extShortcuts as unknown as Record<string, PMCommand>;
+          for (const [key, handler] of Object.entries(cast)) {
+            if (shortcuts[key]) {
+              // Chain: try new handler first, fall back to previous
+              const prev = shortcuts[key];
+              shortcuts[key] = (state, dispatch, view) => {
+                return handler(state, dispatch, view) || prev(state, dispatch, view);
+              };
+            } else {
+              shortcuts[key] = handler;
+            }
+          }
         }
       }
     }

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -418,12 +418,17 @@ export const toggleBlockType: CommandSpec<[nodeName: string, defaultNodeName: st
       return false;
     }
 
-    // Check if the current block is of the target type
+    // Check if the current block is of the target type with matching attributes
     const { $from } = state.selection;
     const currentNode = $from.parent;
 
-    // If current block matches target type, toggle to default
-    if (currentNode.type === nodeType) {
+    // If current block matches target type AND attributes, toggle to default
+    const typeMatches = currentNode.type === nodeType;
+    const attrsMatch = !attributes || Object.keys(attributes).every(
+      (key) => currentNode.attrs[key] === attributes[key]
+    );
+
+    if (typeMatches && attrsMatch) {
       return pmSetBlockType(defaultNodeType)(state, dispatch);
     }
 

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -10,7 +10,7 @@ import { toggleMark as pmToggleMark, setBlockType as pmSetBlockType, wrapIn as p
 import { wrapInList, liftListItem } from 'prosemirror-schema-list';
 import { Fragment, Slice, DOMParser as ProseMirrorDOMParser } from 'prosemirror-model';
 import type { Attrs } from 'prosemirror-model';
-import type { CommandSpec, RawCommands } from '../types/Commands.js';
+import type { CommandSpec, CommandMap } from '../types/Commands.js';
 import type { FocusPosition, Content } from '../types/index.js';
 import { createDocument } from '../helpers/index.js';
 
@@ -796,7 +796,7 @@ export const resetAttributes: CommandSpec<[typeOrName: string, attributeName: st
  * All built-in commands as RawCommands
  * These are merged with extension commands in CommandManager
  */
-export const builtInCommands: RawCommands = {
+export const builtInCommands: CommandMap = {
   focus,
   blur,
   setContent,
@@ -825,4 +825,30 @@ export const builtInCommands: RawCommands = {
   // Attribute commands
   updateAttributes,
   resetAttributes,
-} as RawCommands;
+} as CommandMap;
+
+// Module augmentation: register built-in commands with typed signatures
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    focus: CommandSpec<[position?: FocusPosition]>;
+    blur: CommandSpec;
+    setContent: CommandSpec<[content: Content, options?: SetContentOptions]>;
+    clearContent: CommandSpec<[options?: ClearContentOptions]>;
+    insertText: CommandSpec<[text: string]>;
+    deleteSelection: CommandSpec;
+    selectAll: CommandSpec;
+    toggleMark: CommandSpec<[markName: string, attributes?: Attrs]>;
+    setMark: CommandSpec<[markName: string, attributes?: Attrs]>;
+    unsetMark: CommandSpec<[markName: string]>;
+    setBlockType: CommandSpec<[nodeName: string, attributes?: Attrs]>;
+    toggleBlockType: CommandSpec<[nodeName: string, defaultNodeName: string, attributes?: Attrs]>;
+    wrapIn: CommandSpec<[nodeName: string, attributes?: Attrs]>;
+    toggleWrap: CommandSpec<[nodeName: string, attributes?: Attrs]>;
+    lift: CommandSpec;
+    toggleList: CommandSpec<[listNodeName: string, listItemNodeName: string, attributes?: Attrs]>;
+    insertContent: CommandSpec<[content: Content]>;
+    selectNodeBackward: CommandSpec;
+    updateAttributes: CommandSpec<[typeOrName: string, attributes: Record<string, unknown>]>;
+    resetAttributes: CommandSpec<[typeOrName: string, attributeName: string]>;
+  }
+}

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -325,7 +325,14 @@ export const setMark: CommandSpec<[markName: string, attributes?: Attrs]> =
         return true;
       }
 
-      const mark = markType.create(attributes);
+      // Merge with existing stored mark attributes
+      const existingStoredMark = tr.storedMarks?.find(m => m.type === markType)
+        ?? state.storedMarks?.find(m => m.type === markType);
+      const mergedAttrs = existingStoredMark
+        ? { ...existingStoredMark.attrs, ...attributes }
+        : attributes;
+
+      const mark = markType.create(mergedAttrs);
       tr.addStoredMark(mark);
       dispatch(tr);
       return true;
@@ -335,7 +342,20 @@ export const setMark: CommandSpec<[markName: string, attributes?: Attrs]> =
       return true;
     }
 
-    tr.addMark(from, to, markType.create(attributes));
+    // Merge with existing mark attributes in the selection
+    let existingAttrs: Attrs = {};
+    state.doc.nodesBetween(from, to, (node) => {
+      const existing = markType.isInSet(node.marks);
+      if (existing) {
+        existingAttrs = { ...existingAttrs, ...existing.attrs };
+      }
+    });
+
+    const mergedAttrs = Object.keys(existingAttrs).length > 0
+      ? { ...existingAttrs, ...attributes }
+      : attributes;
+
+    tr.addMark(from, to, markType.create(mergedAttrs));
     dispatch(tr);
     return true;
   };

--- a/packages/core/src/extensions/FontFamily.test.ts
+++ b/packages/core/src/extensions/FontFamily.test.ts
@@ -142,8 +142,7 @@ describe('FontFamily', () => {
 
       editor.focus('all');
 
-      const setFontFamily = editor.commands['setFontFamily'] as ((font: string) => boolean) | undefined;
-      const result = setFontFamily?.('Arial');
+      const result = editor.commands.setFontFamily('Arial');
 
       expect(result).toBe(true);
     });

--- a/packages/core/src/extensions/FontFamily.ts
+++ b/packages/core/src/extensions/FontFamily.ts
@@ -23,6 +23,14 @@
  * ```
  */
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setFontFamily: CommandSpec<[fontFamily: string]>;
+    unsetFontFamily: CommandSpec;
+  }
+}
 
 export interface FontFamilyOptions {
   /**
@@ -84,19 +92,14 @@ export const FontFamily = Extension.create<FontFamilyOptions>({
             return false;
           }
 
-          const cmd = commands as Record<
-            string,
-            (name: string, attrs?: Record<string, unknown>) => boolean
-          >;
-          return cmd['setMark']?.('textStyle', { fontFamily }) ?? false;
+          return commands.setMark('textStyle', { fontFamily });
         },
 
       unsetFontFamily:
         () =>
         ({ commands }) => {
-          const cmd = commands as Record<string, (...args: unknown[]) => boolean>;
-          cmd['setMark']?.('textStyle', { fontFamily: null });
-          cmd['removeEmptyTextStyle']?.();
+          commands.setMark('textStyle', { fontFamily: null });
+          commands.removeEmptyTextStyle();
           return true;
         },
     };

--- a/packages/core/src/extensions/FontSize.test.ts
+++ b/packages/core/src/extensions/FontSize.test.ts
@@ -138,8 +138,7 @@ describe('FontSize', () => {
 
       editor.focus('all');
 
-      const setFontSize = editor.commands['setFontSize'] as ((size: string) => boolean) | undefined;
-      const result = setFontSize?.('20px');
+      const result = editor.commands.setFontSize('20px');
 
       expect(result).toBe(true);
     });

--- a/packages/core/src/extensions/FontSize.ts
+++ b/packages/core/src/extensions/FontSize.ts
@@ -23,6 +23,14 @@
  * ```
  */
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setFontSize: CommandSpec<[fontSize: string]>;
+    unsetFontSize: CommandSpec;
+  }
+}
 
 export interface FontSizeOptions {
   /**
@@ -85,19 +93,14 @@ export const FontSize = Extension.create<FontSizeOptions>({
             return false;
           }
 
-          const cmd = commands as Record<
-            string,
-            (name: string, attrs?: Record<string, unknown>) => boolean
-          >;
-          return cmd['setMark']?.('textStyle', { fontSize }) ?? false;
+          return commands.setMark('textStyle', { fontSize });
         },
 
       unsetFontSize:
         () =>
         ({ commands }) => {
-          const cmd = commands as Record<string, (...args: unknown[]) => boolean>;
-          cmd['setMark']?.('textStyle', { fontSize: null });
-          cmd['removeEmptyTextStyle']?.();
+          commands.setMark('textStyle', { fontSize: null });
+          commands.removeEmptyTextStyle();
           return true;
         },
     };

--- a/packages/core/src/extensions/History.ts
+++ b/packages/core/src/extensions/History.ts
@@ -5,6 +5,14 @@
  */
 import { history, undo, redo } from 'prosemirror-history';
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    undo: CommandSpec;
+    redo: CommandSpec;
+  }
+}
 
 export interface HistoryOptions {
   /**

--- a/packages/core/src/extensions/InvisibleChars.test.ts
+++ b/packages/core/src/extensions/InvisibleChars.test.ts
@@ -196,10 +196,7 @@ describe('InvisibleChars', () => {
         const storage = editor.storage['invisibleChars'] as typeof InvisibleChars.storage;
         expect(storage.isVisible()).toBe(false);
 
-        const toggleInvisibleChars = editor.commands[
-          'toggleInvisibleChars'
-        ] as () => boolean;
-        toggleInvisibleChars();
+        editor.commands.toggleInvisibleChars();
 
         expect(storage.isVisible()).toBe(true);
       });
@@ -215,10 +212,7 @@ describe('InvisibleChars', () => {
         const storage = editor.storage['invisibleChars'] as typeof InvisibleChars.storage;
         expect(storage.isVisible()).toBe(false);
 
-        const showInvisibleChars = editor.commands[
-          'showInvisibleChars'
-        ] as () => boolean;
-        showInvisibleChars();
+        editor.commands.showInvisibleChars();
 
         expect(storage.isVisible()).toBe(true);
       });
@@ -236,10 +230,7 @@ describe('InvisibleChars', () => {
         const storage = editor.storage['invisibleChars'] as typeof InvisibleChars.storage;
         expect(storage.isVisible()).toBe(true);
 
-        const showInvisibleChars = editor.commands[
-          'showInvisibleChars'
-        ] as () => boolean;
-        showInvisibleChars();
+        editor.commands.showInvisibleChars();
 
         expect(storage.isVisible()).toBe(true);
       });
@@ -259,10 +250,7 @@ describe('InvisibleChars', () => {
         const storage = editor.storage['invisibleChars'] as typeof InvisibleChars.storage;
         expect(storage.isVisible()).toBe(true);
 
-        const hideInvisibleChars = editor.commands[
-          'hideInvisibleChars'
-        ] as () => boolean;
-        hideInvisibleChars();
+        editor.commands.hideInvisibleChars();
 
         expect(storage.isVisible()).toBe(false);
       });
@@ -276,10 +264,7 @@ describe('InvisibleChars', () => {
         const storage = editor.storage['invisibleChars'] as typeof InvisibleChars.storage;
         expect(storage.isVisible()).toBe(false);
 
-        const hideInvisibleChars = editor.commands[
-          'hideInvisibleChars'
-        ] as () => boolean;
-        hideInvisibleChars();
+        editor.commands.hideInvisibleChars();
 
         expect(storage.isVisible()).toBe(false);
       });
@@ -297,10 +282,7 @@ describe('InvisibleChars', () => {
           | undefined;
         expect(pluginState?.visible).toBe(false);
 
-        const toggleInvisibleChars = editor.commands[
-          'toggleInvisibleChars'
-        ] as () => boolean;
-        toggleInvisibleChars();
+        editor.commands.toggleInvisibleChars();
 
         const newPluginState = invisibleCharsPluginKey.getState(editor.state) as
           | { visible: boolean }

--- a/packages/core/src/extensions/InvisibleChars.ts
+++ b/packages/core/src/extensions/InvisibleChars.ts
@@ -43,6 +43,15 @@ import { Extension } from '../Extension.js';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import type { Editor } from '../Editor.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    toggleInvisibleChars: CommandSpec;
+    showInvisibleChars: CommandSpec;
+    hideInvisibleChars: CommandSpec;
+  }
+}
 
 export const invisibleCharsPluginKey = new PluginKey('invisibleChars');
 

--- a/packages/core/src/extensions/LineHeight.ts
+++ b/packages/core/src/extensions/LineHeight.ts
@@ -110,17 +110,17 @@ export const LineHeight = Extension.create<LineHeightOptions>({
             return false;
           }
 
-          return this.options.types.every((type) =>
-            commands.updateAttributes(type, { lineHeight })
-          );
+          return this.options.types
+            .map((type) => commands.updateAttributes(type, { lineHeight }))
+            .some(Boolean);
         },
 
       unsetLineHeight:
         () =>
         ({ commands }) => {
-          return this.options.types.every((type) =>
-            commands.resetAttributes(type, 'lineHeight')
-          );
+          return this.options.types
+            .map((type) => commands.resetAttributes(type, 'lineHeight'))
+            .some(Boolean);
         },
     };
   },

--- a/packages/core/src/extensions/LineHeight.ts
+++ b/packages/core/src/extensions/LineHeight.ts
@@ -22,6 +22,14 @@
  * ```
  */
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setLineHeight: CommandSpec<[lineHeight: string]>;
+    unsetLineHeight: CommandSpec;
+  }
+}
 
 export interface LineHeightOptions {
   /**
@@ -102,26 +110,16 @@ export const LineHeight = Extension.create<LineHeightOptions>({
             return false;
           }
 
-          const cmds = commands as Record<
-            string,
-            (type: string, attrs: unknown) => boolean
-          >;
-
           return this.options.types.every((type) =>
-            cmds['updateAttributes']?.(type, { lineHeight })
+            commands.updateAttributes(type, { lineHeight })
           );
         },
 
       unsetLineHeight:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<
-            string,
-            (type: string, attr: string) => boolean
-          >;
-
           return this.options.types.every((type) =>
-            cmds['resetAttributes']?.(type, 'lineHeight')
+            commands.resetAttributes(type, 'lineHeight')
           );
         },
     };

--- a/packages/core/src/extensions/Placeholder.ts
+++ b/packages/core/src/extensions/Placeholder.ts
@@ -70,7 +70,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
         props: {
           decorations: ({ doc, selection }) => {
             const editor = this.editor;
-            const isEditable = editor?.view?.editable ?? true;
+            const isEditable = editor?.view.editable ?? true;
 
             if (!isEditable && this.options.showOnlyWhenEditable) {
               return DecorationSet.empty;

--- a/packages/core/src/extensions/Placeholder.ts
+++ b/packages/core/src/extensions/Placeholder.ts
@@ -70,7 +70,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
         props: {
           decorations: ({ doc, selection }) => {
             const editor = this.editor;
-            const isEditable = editor?.view.editable ?? true;
+            const isEditable = editor?.view?.editable ?? true;
 
             if (!isEditable && this.options.showOnlyWhenEditable) {
               return DecorationSet.empty;

--- a/packages/core/src/extensions/Placeholder.ts
+++ b/packages/core/src/extensions/Placeholder.ts
@@ -70,7 +70,8 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
         props: {
           decorations: ({ doc, selection }) => {
             const editor = this.editor;
-            const isEditable = editor?.view.editable ?? true;
+            if (!editor?.view) return DecorationSet.empty;
+            const isEditable = editor.view.editable;
 
             if (!isEditable && this.options.showOnlyWhenEditable) {
               return DecorationSet.empty;

--- a/packages/core/src/extensions/Placeholder.ts
+++ b/packages/core/src/extensions/Placeholder.ts
@@ -78,9 +78,9 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
             }
 
             const decorations: Decoration[] = [];
-            const currentNodePos = selection.$anchor.before(
-              selection.$anchor.depth
-            );
+            const currentNodePos = selection.$anchor.depth > 0
+              ? selection.$anchor.before(selection.$anchor.depth)
+              : -1;
 
             // Check if document is empty (for editor-level class)
             const isDocEmpty =

--- a/packages/core/src/extensions/Selection.test.ts
+++ b/packages/core/src/extensions/Selection.test.ts
@@ -119,11 +119,7 @@ describe('Selection', () => {
         });
 
         // Select "Hello"
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
+        editor.commands.setSelection(1, 6);
 
         const storage = editor.storage['selection'] as typeof Selection.storage;
         expect(storage.getText()).toBe('Hello');
@@ -148,11 +144,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
+        editor.commands.setSelection(1, 6);
 
         const storage = editor.storage['selection'] as typeof Selection.storage;
         expect(storage.isEmpty()).toBe(false);
@@ -166,11 +158,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
+        editor.commands.setSelection(1, 6);
 
         const storage = editor.storage['selection'] as typeof Selection.storage;
         const range = storage.getRange();
@@ -186,11 +174,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to?: number
-        ) => boolean;
-        setSelection(5);
+        editor.commands.setSelection(5);
 
         const storage = editor.storage['selection'] as typeof Selection.storage;
         expect(storage.getCursor()).toBe(5);
@@ -202,11 +186,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
+        editor.commands.setSelection(1, 6);
 
         const storage = editor.storage['selection'] as typeof Selection.storage;
         expect(storage.getCursor()).toBe(null);
@@ -220,11 +200,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        const result = setSelection(1, 6);
+        const result = editor.commands.setSelection(1, 6);
 
         expect(result).toBe(true);
         expect(editor.state.selection.from).toBe(1);
@@ -237,10 +213,7 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number
-        ) => boolean;
-        const result = setSelection(5);
+        const result = editor.commands.setSelection(5);
 
         expect(result).toBe(true);
         expect(editor.state.selection.from).toBe(5);
@@ -253,11 +226,7 @@ describe('Selection', () => {
           content: '<p>Hello</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        const result = setSelection(-1, 100);
+        const result = editor.commands.setSelection(-1, 100);
 
         expect(result).toBe(false);
       });
@@ -273,10 +242,7 @@ describe('Selection', () => {
         // Get position of image node
         const imagePos = editor.state.doc.child(0).nodeSize;
 
-        const selectNode = editor.commands['selectNode'] as (
-          pos: number
-        ) => boolean;
-        const result = selectNode(imagePos);
+        const result = editor.commands.selectNode(imagePos);
 
         expect(result).toBe(true);
       });
@@ -287,10 +253,7 @@ describe('Selection', () => {
           content: '<p>Hello</p>',
         });
 
-        const selectNode = editor.commands['selectNode'] as (
-          pos: number
-        ) => boolean;
-        const result = selectNode(1000);
+        const result = editor.commands.selectNode(1000);
 
         expect(result).toBe(false);
       });
@@ -303,16 +266,8 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(3, 6);
-
-        const extendSelection = editor.commands['extendSelection'] as (
-          direction: 'left' | 'right' | 'start' | 'end'
-        ) => boolean;
-        extendSelection('left');
+        editor.commands.setSelection(3, 6);
+        editor.commands.extendSelection('left');
 
         expect(editor.state.selection.from).toBe(2);
         expect(editor.state.selection.to).toBe(6);
@@ -324,16 +279,8 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
-
-        const extendSelection = editor.commands['extendSelection'] as (
-          direction: 'left' | 'right' | 'start' | 'end'
-        ) => boolean;
-        extendSelection('right');
+        editor.commands.setSelection(1, 6);
+        editor.commands.extendSelection('right');
 
         expect(editor.state.selection.from).toBe(1);
         expect(editor.state.selection.to).toBe(7);
@@ -345,16 +292,8 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(6, 11);
-
-        const extendSelection = editor.commands['extendSelection'] as (
-          direction: 'left' | 'right' | 'start' | 'end'
-        ) => boolean;
-        extendSelection('start');
+        editor.commands.setSelection(6, 11);
+        editor.commands.extendSelection('start');
 
         expect(editor.state.selection.from).toBe(0);
         expect(editor.state.selection.to).toBe(11);
@@ -366,16 +305,8 @@ describe('Selection', () => {
           content: '<p>Hello world</p>',
         });
 
-        const setSelection = editor.commands['setSelection'] as (
-          from: number,
-          to: number
-        ) => boolean;
-        setSelection(1, 6);
-
-        const extendSelection = editor.commands['extendSelection'] as (
-          direction: 'left' | 'right' | 'start' | 'end'
-        ) => boolean;
-        extendSelection('end');
+        editor.commands.setSelection(1, 6);
+        editor.commands.extendSelection('end');
 
         expect(editor.state.selection.from).toBe(1);
         expect(editor.state.selection.to).toBe(editor.state.doc.content.size);

--- a/packages/core/src/extensions/Selection.ts
+++ b/packages/core/src/extensions/Selection.ts
@@ -34,6 +34,16 @@ import { Extension } from '../Extension.js';
 import { NodeSelection, TextSelection } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import type { Editor } from '../Editor.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setSelection: CommandSpec<[from: number, to?: number]>;
+    selectNode: CommandSpec<[pos: number]>;
+    selectParentNode: CommandSpec;
+    extendSelection: CommandSpec<[direction: 'left' | 'right' | 'start' | 'end']>;
+  }
+}
 
 export interface SelectionOptions {
   /**

--- a/packages/core/src/extensions/TextAlign.ts
+++ b/packages/core/src/extensions/TextAlign.ts
@@ -5,6 +5,14 @@
  * Uses addGlobalAttributes to inject textAlign attribute into nodes.
  */
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setTextAlign: CommandSpec<[alignment: string]>;
+    unsetTextAlign: CommandSpec;
+  }
+}
 
 export interface TextAlignOptions {
   /**
@@ -68,26 +76,16 @@ export const TextAlign = Extension.create<TextAlignOptions>({
             return false;
           }
 
-          const cmds = commands as Record<
-            string,
-            (type: string, attrs: Record<string, unknown>) => boolean
-          >;
-
           return this.options.types.every((type) =>
-            cmds['updateAttributes']?.(type, { textAlign: alignment })
+            commands.updateAttributes(type, { textAlign: alignment })
           );
         },
 
       unsetTextAlign:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<
-            string,
-            (type: string, attr: string) => boolean
-          >;
-
           return this.options.types.every((type) =>
-            cmds['resetAttributes']?.(type, 'textAlign')
+            commands.resetAttributes(type, 'textAlign')
           );
         },
     };

--- a/packages/core/src/extensions/TextAlign.ts
+++ b/packages/core/src/extensions/TextAlign.ts
@@ -76,17 +76,17 @@ export const TextAlign = Extension.create<TextAlignOptions>({
             return false;
           }
 
-          return this.options.types.every((type) =>
-            commands.updateAttributes(type, { textAlign: alignment })
-          );
+          return this.options.types
+            .map((type) => commands.updateAttributes(type, { textAlign: alignment }))
+            .some(Boolean);
         },
 
       unsetTextAlign:
         () =>
         ({ commands }) => {
-          return this.options.types.every((type) =>
-            commands.resetAttributes(type, 'textAlign')
-          );
+          return this.options.types
+            .map((type) => commands.resetAttributes(type, 'textAlign'))
+            .some(Boolean);
         },
     };
   },

--- a/packages/core/src/extensions/TextColor.test.ts
+++ b/packages/core/src/extensions/TextColor.test.ts
@@ -153,8 +153,7 @@ describe('TextColor', () => {
       editor.focus('all');
 
       // Apply color
-      const setTextColor = editor.commands['setTextColor'] as ((color: string) => boolean) | undefined;
-      const result = setTextColor?.('#ff0000');
+      const result = editor.commands.setTextColor('#ff0000');
 
       expect(result).toBe(true);
     });

--- a/packages/core/src/extensions/TextColor.ts
+++ b/packages/core/src/extensions/TextColor.ts
@@ -23,6 +23,14 @@
  * ```
  */
 import { Extension } from '../Extension.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setTextColor: CommandSpec<[color: string]>;
+    unsetTextColor: CommandSpec;
+  }
+}
 
 export interface TextColorOptions {
   /**
@@ -84,19 +92,14 @@ export const TextColor = Extension.create<TextColorOptions>({
             return false;
           }
 
-          const cmd = commands as Record<
-            string,
-            (name: string, attrs?: Record<string, unknown>) => boolean
-          >;
-          return cmd['setMark']?.('textStyle', { color }) ?? false;
+          return commands.setMark('textStyle', { color });
         },
 
       unsetTextColor:
         () =>
         ({ commands }) => {
-          const cmd = commands as Record<string, (...args: unknown[]) => boolean>;
-          cmd['setMark']?.('textStyle', { color: null });
-          cmd['removeEmptyTextStyle']?.();
+          commands.setMark('textStyle', { color: null });
+          commands.removeEmptyTextStyle();
           return true;
         },
     };

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -20,7 +20,7 @@
  * ```
  */
 import { Extension } from '../Extension.js';
-import { Plugin, PluginKey } from 'prosemirror-state';
+import { Plugin, PluginKey, type Transaction } from 'prosemirror-state';
 import { Fragment, Slice } from 'prosemirror-model';
 import type { Node as PMNode } from 'prosemirror-model';
 import type { Editor } from '../Editor.js';
@@ -157,9 +157,34 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       );
     };
 
+    // Helper to assign IDs to nodes that lack them
+    const assignMissingIDs = (doc: PMNode, tr: Transaction): void => {
+      doc.descendants((node, pos) => {
+        if (!types.includes(node.type.name)) return;
+
+        const existingID = node.attrs[attributeName] as string | undefined;
+        if (!existingID) {
+          tr.setNodeMarkup(pos, undefined, {
+            ...node.attrs,
+            [attributeName]: generateID(),
+          });
+        }
+      });
+    };
+
     return [
       new Plugin({
         key: uniqueIDPluginKey,
+
+        // Apply initial IDs after the view is ready
+        view(editorView) {
+          const tr = editorView.state.tr;
+          assignMissingIDs(editorView.state.doc, tr);
+          if (tr.docChanged) {
+            setTimeout(() => { editorView.dispatch(tr); }, 0);
+          }
+          return {};
+        },
 
         // Ensure new nodes get IDs
         appendTransaction(transactions, _oldState, newState) {
@@ -167,18 +192,7 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
           if (!docChanged) return null;
 
           const tr = newState.tr;
-
-          newState.doc.descendants((node, pos) => {
-            if (!types.includes(node.type.name)) return;
-
-            const existingID = node.attrs[attributeName] as string | undefined;
-            if (!existingID) {
-              tr.setNodeMarkup(pos, undefined, {
-                ...node.attrs,
-                [attributeName]: generateID(),
-              });
-            }
-          });
+          assignMissingIDs(newState.doc, tr);
 
           return tr.docChanged ? tr : null;
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export type {
   CommandProps,
   Command,
   CommandSpec,
+  CommandMap,
   RawCommands,
   SingleCommands,
   ChainedCommands,

--- a/packages/core/src/marks/Bold.ts
+++ b/packages/core/src/marks/Bold.ts
@@ -91,22 +91,13 @@ export const Bold = Mark.create<BoldOptions>({
     return {
       setBold:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('bold') ?? false;
-        },
+        ({ commands }) => commands.setMark('bold'),
       unsetBold:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('bold') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('bold'),
       toggleBold:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('bold') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('bold'),
     };
   },
 
@@ -123,3 +114,11 @@ export const Bold = Mark.create<BoldOptions>({
     ];
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setBold: CommandSpec;
+    unsetBold: CommandSpec;
+    toggleBold: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Code.ts
+++ b/packages/core/src/marks/Code.ts
@@ -67,22 +67,13 @@ export const Code = Mark.create<CodeOptions>({
     return {
       setCode:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('code') ?? false;
-        },
+        ({ commands }) => commands.setMark('code'),
       unsetCode:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('code') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('code'),
       toggleCode:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('code') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('code'),
     };
   },
 
@@ -99,3 +90,11 @@ export const Code = Mark.create<CodeOptions>({
     ];
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setCode: CommandSpec;
+    unsetCode: CommandSpec;
+    toggleCode: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Highlight.ts
+++ b/packages/core/src/marks/Highlight.ts
@@ -100,22 +100,13 @@ export const Highlight = Mark.create<HighlightOptions>({
     return {
       setHighlight:
         (attributes?: { color?: string }) =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string, attrs?: unknown) => boolean>;
-          return cmd['setMark']?.('highlight', attributes) ?? false;
-        },
+        ({ commands }) => commands.setMark('highlight', attributes),
       unsetHighlight:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('highlight') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('highlight'),
       toggleHighlight:
         (attributes?: { color?: string }) =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string, attrs?: unknown) => boolean>;
-          return cmd['toggleMark']?.('highlight', attributes) ?? false;
-        },
+        ({ commands }) => commands.toggleMark('highlight', attributes),
     };
   },
 
@@ -132,3 +123,11 @@ export const Highlight = Mark.create<HighlightOptions>({
     ];
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setHighlight: CommandSpec<[attributes?: { color?: string }]>;
+    unsetHighlight: CommandSpec;
+    toggleHighlight: CommandSpec<[attributes?: { color?: string }]>;
+  }
+}

--- a/packages/core/src/marks/Italic.ts
+++ b/packages/core/src/marks/Italic.ts
@@ -83,22 +83,13 @@ export const Italic = Mark.create<ItalicOptions>({
     return {
       setItalic:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('italic') ?? false;
-        },
+        ({ commands }) => commands.setMark('italic'),
       unsetItalic:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('italic') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('italic'),
       toggleItalic:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('italic') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('italic'),
     };
   },
 
@@ -120,3 +111,11 @@ export const Italic = Mark.create<ItalicOptions>({
     ];
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setItalic: CommandSpec;
+    unsetItalic: CommandSpec;
+    toggleItalic: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Link.ts
+++ b/packages/core/src/marks/Link.ts
@@ -172,30 +172,21 @@ export const Link = Mark.create<LinkOptions>({
       setLink:
         (attributes: LinkAttributes) =>
         ({ commands }) => {
-          // Validate URL before setting
           if (!isValidUrl(attributes.href, { protocols: this.options.protocols })) {
             return false;
           }
-
-          const cmd = commands as Record<string, (name: string, attrs?: unknown) => boolean>;
-          return cmd['setMark']?.('link', attributes) ?? false;
+          return commands.setMark('link', attributes);
         },
       unsetLink:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('link') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('link'),
       toggleLink:
         (attributes: LinkAttributes) =>
         ({ commands }) => {
-          // Validate URL before toggling
           if (!isValidUrl(attributes.href, { protocols: this.options.protocols })) {
             return false;
           }
-
-          const cmd = commands as Record<string, (name: string, attrs?: unknown) => boolean>;
-          return cmd['toggleMark']?.('link', attributes) ?? false;
+          return commands.toggleMark('link', attributes);
         },
     };
   },
@@ -246,3 +237,11 @@ export const Link = Mark.create<LinkOptions>({
     return plugins;
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setLink: CommandSpec<[attributes: LinkAttributes]>;
+    unsetLink: CommandSpec;
+    toggleLink: CommandSpec<[attributes: LinkAttributes]>;
+  }
+}

--- a/packages/core/src/marks/Strike.ts
+++ b/packages/core/src/marks/Strike.ts
@@ -70,22 +70,13 @@ export const Strike = Mark.create<StrikeOptions>({
     return {
       setStrike:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('strike') ?? false;
-        },
+        ({ commands }) => commands.setMark('strike'),
       unsetStrike:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('strike') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('strike'),
       toggleStrike:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('strike') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('strike'),
     };
   },
 
@@ -102,3 +93,11 @@ export const Strike = Mark.create<StrikeOptions>({
     ];
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setStrike: CommandSpec;
+    unsetStrike: CommandSpec;
+    toggleStrike: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Subscript.ts
+++ b/packages/core/src/marks/Subscript.ts
@@ -68,22 +68,21 @@ export const Subscript = Mark.create<SubscriptOptions>({
     return {
       setSubscript:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('subscript') ?? false;
-        },
+        ({ commands }) => commands.setMark('subscript'),
       unsetSubscript:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('subscript') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('subscript'),
       toggleSubscript:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('subscript') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('subscript'),
     };
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setSubscript: CommandSpec;
+    unsetSubscript: CommandSpec;
+    toggleSubscript: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Superscript.ts
+++ b/packages/core/src/marks/Superscript.ts
@@ -69,21 +69,24 @@ export const Superscript = Mark.create<SuperscriptOptions>({
       setSuperscript:
         () =>
         ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('superscript') ?? false;
+          return commands.setMark('superscript');
         },
       unsetSuperscript:
         () =>
         ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('superscript') ?? false;
+          return commands.unsetMark('superscript');
         },
       toggleSuperscript:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('superscript') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('superscript'),
     };
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setSuperscript: CommandSpec;
+    unsetSuperscript: CommandSpec;
+    toggleSuperscript: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/TextStyle.ts
+++ b/packages/core/src/marks/TextStyle.ts
@@ -67,20 +67,11 @@ export const TextStyle = Mark.create<TextStyleOptions>({
     return {
       setTextStyle:
         (attributes: Record<string, unknown>) =>
-        ({ commands }) => {
-          const cmd = commands as Record<
-            string,
-            (name: string, attrs?: Record<string, unknown>) => boolean
-          >;
-          return cmd['setMark']?.('textStyle', attributes) ?? false;
-        },
+        ({ commands }) => commands.setMark('textStyle', attributes),
 
       removeTextStyle:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('textStyle') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('textStyle'),
 
       removeEmptyTextStyle:
         () =>
@@ -121,3 +112,11 @@ export const TextStyle = Mark.create<TextStyleOptions>({
     };
   },
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setTextStyle: CommandSpec<[attributes: Record<string, unknown>]>;
+    removeTextStyle: CommandSpec;
+    removeEmptyTextStyle: CommandSpec;
+  }
+}

--- a/packages/core/src/marks/Underline.ts
+++ b/packages/core/src/marks/Underline.ts
@@ -67,24 +67,23 @@ export const Underline = Mark.create<UnderlineOptions>({
     return {
       setUnderline:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['setMark']?.('underline') ?? false;
-        },
+        ({ commands }) => commands.setMark('underline'),
       unsetUnderline:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['unsetMark']?.('underline') ?? false;
-        },
+        ({ commands }) => commands.unsetMark('underline'),
       toggleUnderline:
         () =>
-        ({ commands }) => {
-          const cmd = commands as Record<string, (name: string) => boolean>;
-          return cmd['toggleMark']?.('underline') ?? false;
-        },
+        ({ commands }) => commands.toggleMark('underline'),
     };
   },
 
   // No input rules for underline (no common markdown syntax)
 });
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setUnderline: CommandSpec;
+    unsetUnderline: CommandSpec;
+    toggleUnderline: CommandSpec;
+  }
+}

--- a/packages/core/src/nodes/Blockquote.ts
+++ b/packages/core/src/nodes/Blockquote.ts
@@ -7,6 +7,15 @@
 
 import { Node } from '../Node.js';
 import { wrappingInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setBlockquote: CommandSpec;
+    toggleBlockquote: CommandSpec;
+    unsetBlockquote: CommandSpec;
+  }
+}
 
 export interface BlockquoteOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -38,20 +47,17 @@ export const Blockquote = Node.create<BlockquoteOptions>({
       setBlockquote:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string) => boolean>;
-          return cmds['wrapIn']?.(name) ?? false;
+          return commands.wrapIn(name);
         },
       toggleBlockquote:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string) => boolean>;
-          return cmds['toggleWrap']?.(name) ?? false;
+          return commands.toggleWrap(name);
         },
       unsetBlockquote:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, () => boolean>;
-          return cmds['lift']?.() ?? false;
+          return commands.lift();
         },
     };
   },

--- a/packages/core/src/nodes/BulletList.ts
+++ b/packages/core/src/nodes/BulletList.ts
@@ -7,6 +7,13 @@
 
 import { Node } from '../Node.js';
 import { wrappingInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    toggleBulletList: CommandSpec;
+  }
+}
 
 export interface BulletListOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -39,8 +46,7 @@ export const BulletList = Node.create<BulletListOptions>({
       toggleBulletList:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (listName: string, itemName: string) => boolean>;
-          return cmds['toggleList']?.(name, options.itemTypeName) ?? false;
+          return commands.toggleList(name, options.itemTypeName);
         },
     };
   },

--- a/packages/core/src/nodes/CodeBlock.ts
+++ b/packages/core/src/nodes/CodeBlock.ts
@@ -7,6 +7,14 @@
 
 import { Node } from '../Node.js';
 import { textblockTypeInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setCodeBlock: CommandSpec<[attributes?: { language?: string }]>;
+    toggleCodeBlock: CommandSpec<[attributes?: { language?: string }]>;
+  }
+}
 
 export interface CodeBlockOptions {
   languageClassPrefix: string;
@@ -88,14 +96,12 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
       setCodeBlock:
         (attributes?: { language?: string }) =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string, attrs?: Record<string, unknown>) => boolean>;
-          return cmds['setBlockType']?.(name, attributes) ?? false;
+          return commands.setBlockType(name, attributes);
         },
       toggleCodeBlock:
         (attributes?: { language?: string }) =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string, defaultName: string, attrs?: Record<string, unknown>) => boolean>;
-          return cmds['toggleBlockType']?.(name, 'paragraph', attributes) ?? false;
+          return commands.toggleBlockType(name, 'paragraph', attributes);
         },
     };
   },

--- a/packages/core/src/nodes/HardBreak.ts
+++ b/packages/core/src/nodes/HardBreak.ts
@@ -6,6 +6,13 @@
  */
 
 import { Node } from '../Node.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setHardBreak: CommandSpec;
+  }
+}
 
 export interface HardBreakOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -37,11 +44,7 @@ export const HardBreak = Node.create<HardBreakOptions>({
       setHardBreak:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<
-            string,
-            (content: { type: string }) => boolean
-          >;
-          return cmds['insertContent']?.({ type: name }) ?? false;
+          return commands.insertContent({ type: name });
         },
     };
   },

--- a/packages/core/src/nodes/Heading.ts
+++ b/packages/core/src/nodes/Heading.ts
@@ -7,6 +7,8 @@
 
 import { Node } from '../Node.js';
 import { textblockTypeInputRule } from 'prosemirror-inputrules';
+import { keymap } from 'prosemirror-keymap';
+import type { Command as PMCommand } from 'prosemirror-state';
 import type { CommandSpec } from '../types/Commands.js';
 
 declare module '../types/Commands.js' {
@@ -100,6 +102,31 @@ export const Heading = Node.create<HeadingOptions>({
     });
 
     return shortcuts;
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      keymap({
+        Backspace: ((state, dispatch) => {
+          const { selection } = state;
+          if (!selection.empty) return false;
+
+          const { $from } = selection;
+          if ($from.parentOffset !== 0) return false;
+          if ($from.parent.type.name !== 'heading') return false;
+
+          const paragraphType = state.schema.nodes['paragraph'];
+          if (!paragraphType) return false;
+
+          if (dispatch) {
+            dispatch(
+              state.tr.setNodeMarkup($from.before($from.depth), paragraphType).scrollIntoView()
+            );
+          }
+          return true;
+        }) as PMCommand,
+      }),
+    ];
   },
 
   addInputRules() {

--- a/packages/core/src/nodes/Heading.ts
+++ b/packages/core/src/nodes/Heading.ts
@@ -7,6 +7,14 @@
 
 import { Node } from '../Node.js';
 import { textblockTypeInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setHeading: CommandSpec<[attributes?: { level?: number }]>;
+    toggleHeading: CommandSpec<[attributes?: { level?: number }]>;
+  }
+}
 
 export interface HeadingOptions {
   levels: number[];
@@ -58,28 +66,25 @@ export const Heading = Node.create<HeadingOptions>({
   },
 
   addCommands() {
-    // Capture `this` in closure since command functions have their own `this`
     const { name, options } = this;
     return {
       setHeading:
         (attributes?: { level?: number }) =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string, attrs?: Record<string, unknown>) => boolean>;
           const level = attributes?.level ?? options.levels[0] ?? 1;
           if (!options.levels.includes(level)) {
             return false;
           }
-          return cmds['setBlockType']?.(name, { level }) ?? false;
+          return commands.setBlockType(name, { level });
         },
       toggleHeading:
         (attributes?: { level?: number }) =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string, defaultName: string, attrs?: Record<string, unknown>) => boolean>;
           const level = attributes?.level ?? options.levels[0] ?? 1;
           if (!options.levels.includes(level)) {
             return false;
           }
-          return cmds['toggleBlockType']?.(name, 'paragraph', { level }) ?? false;
+          return commands.toggleBlockType(name, 'paragraph', { level });
         },
     };
   },

--- a/packages/core/src/nodes/HorizontalRule.ts
+++ b/packages/core/src/nodes/HorizontalRule.ts
@@ -40,22 +40,44 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
   },
 
   addCommands() {
-    const { name } = this;
     return {
       setHorizontalRule:
         () =>
-        ({ commands, tr }) => {
-          // Insert horizontal rule
-          const result = commands.insertContent({ type: name });
-          if (!result) return false;
+        ({ state, tr, dispatch }) => {
+          if (!this.nodeType) return false;
 
-          // Try to move selection after the HR
-          const { $to } = tr.selection;
-          const posAfter = $to.end();
+          const { $from } = state.selection;
+          const parent = $from.parent;
 
-          if (posAfter < tr.doc.content.size) {
-            const newSelection = TextSelection.create(tr.doc, posAfter + 1);
-            tr.setSelection(newSelection);
+          if (dispatch) {
+            // If cursor is in an empty block, replace it with HR + new paragraph
+            if (parent.content.size === 0 && parent.type.name === 'paragraph') {
+              const from = $from.before();
+              const to = $from.after();
+              const paragraph = state.schema.nodes['paragraph']?.create();
+              const nodes = paragraph
+                ? [this.nodeType.create(), paragraph]
+                : [this.nodeType.create()];
+              tr.replaceWith(from, to, nodes);
+
+              // Move cursor into the new paragraph
+              const sel = TextSelection.findFrom(tr.doc.resolve(from + 1), 1);
+              if (sel) tr.setSelection(sel);
+            } else {
+              // Insert HR after current position
+              const end = $from.after();
+              const paragraph = state.schema.nodes['paragraph']?.create();
+              const nodes = paragraph
+                ? [this.nodeType.create(), paragraph]
+                : [this.nodeType.create()];
+              tr.insert(end, nodes);
+
+              // Move cursor into the new paragraph
+              const sel = TextSelection.findFrom(tr.doc.resolve(end + 1), 1);
+              if (sel) tr.setSelection(sel);
+            }
+
+            dispatch(tr);
           }
 
           return true;
@@ -73,18 +95,23 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
     return [
       new InputRule(
         /^(?:---|—-|___|\*\*\*)\s$/,
-        (state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
+        (state: EditorState, match: RegExpMatchArray, start: number) => {
           const { tr } = state;
 
           if (match[0]) {
-            tr.replaceWith(start - 1, end, nodeType.create());
+            const $start = state.doc.resolve(start);
+            // Replace the entire parent block (paragraph) with HR
+            const from = $start.before();
+            const to = $start.after();
+            tr.replaceWith(from, to, nodeType.create());
 
             // Move selection after the HR if possible
-            const resolvedPos = tr.doc.resolve(start);
-            const posAfter = resolvedPos.after();
-
-            if (posAfter < tr.doc.content.size) {
-              tr.setSelection(TextSelection.create(tr.doc, posAfter));
+            if (from + 1 < tr.doc.content.size) {
+              const $after = tr.doc.resolve(from + 1);
+              const sel = TextSelection.findFrom($after, 1);
+              if (sel) {
+                tr.setSelection(sel);
+              }
             }
           }
 

--- a/packages/core/src/nodes/HorizontalRule.ts
+++ b/packages/core/src/nodes/HorizontalRule.ts
@@ -9,6 +9,13 @@ import { Node } from '../Node.js';
 import { InputRule } from 'prosemirror-inputrules';
 import type { EditorState } from 'prosemirror-state';
 import { TextSelection } from 'prosemirror-state';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setHorizontalRule: CommandSpec;
+  }
+}
 
 export interface HorizontalRuleOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -38,13 +45,8 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
       setHorizontalRule:
         () =>
         ({ commands, tr }) => {
-          const cmds = commands as Record<
-            string,
-            (content: { type: string }) => boolean
-          >;
-
           // Insert horizontal rule
-          const result = cmds['insertContent']?.({ type: name });
+          const result = commands.insertContent({ type: name });
           if (!result) return false;
 
           // Try to move selection after the HR

--- a/packages/core/src/nodes/Image.ts
+++ b/packages/core/src/nodes/Image.ts
@@ -11,6 +11,13 @@
  */
 
 import { Node } from '../Node.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setImage: CommandSpec<[attributes?: Record<string, unknown>]>;
+  }
+}
 
 /**
  * Validates image src URL for XSS protection.
@@ -131,14 +138,7 @@ export const Image = Node.create<ImageOptions>({
             return false;
           }
 
-          const cmds = commands as Record<
-            string,
-            (content: { type: string; attrs?: Record<string, unknown> }) => boolean
-          >;
-          const content = attributes
-            ? { type: name, attrs: attributes }
-            : { type: name };
-          return cmds['insertContent']?.(content) ?? false;
+          return commands.insertContent({ type: name, ...attributes && { attrs: attributes } } as Parameters<typeof commands.insertContent>[0]);
         },
     };
   },

--- a/packages/core/src/nodes/ListItem.test.ts
+++ b/packages/core/src/nodes/ListItem.test.ts
@@ -75,10 +75,11 @@ describe('ListItem', () => {
   });
 
   describe('addKeyboardShortcuts', () => {
-    it('provides Enter shortcut', () => {
-      const shortcuts = ListItem.config.addKeyboardShortcuts?.call(ListItem);
+    it('provides Enter shortcut via ProseMirror plugin', () => {
+      const plugins = ListItem.config.addProseMirrorPlugins?.call(ListItem);
 
-      expect(shortcuts).toHaveProperty('Enter');
+      expect(plugins).toBeDefined();
+      expect(plugins!.length).toBeGreaterThan(0);
     });
 
     it('provides Tab shortcut', () => {

--- a/packages/core/src/nodes/ListItem.ts
+++ b/packages/core/src/nodes/ListItem.ts
@@ -12,8 +12,8 @@
 
 import { Node } from '../Node.js';
 import { splitListItem, liftListItem, sinkListItem } from 'prosemirror-schema-list';
-import type { EditorState } from 'prosemirror-state';
-import type { EditorView } from 'prosemirror-view';
+import { keymap } from 'prosemirror-keymap';
+import type { Command as PMCommand } from 'prosemirror-state';
 
 export interface ListItemOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -39,23 +39,28 @@ export const ListItem = Node.create<ListItemOptions>({
   },
 
   addKeyboardShortcuts() {
-    const { editor, nodeType } = this;
     return {
-      Enter: () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return splitListItem(nodeType)(state, view.dispatch);
-      },
+      // Enter is handled in addProseMirrorPlugins to avoid TaskItem override via Object.assign
       Tab: () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return sinkListItem(nodeType)(state, view.dispatch);
+        if (!this.editor || !this.nodeType) return false;
+        return sinkListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
       },
       'Shift-Tab': () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return liftListItem(nodeType)(state, view.dispatch);
+        if (!this.editor || !this.nodeType) return false;
+        return liftListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
       },
     };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      keymap({
+        Enter: ((state, dispatch) => {
+          const nodeType = state.schema.nodes['listItem'];
+          if (!nodeType) return false;
+          return splitListItem(nodeType)(state, dispatch);
+        }) as PMCommand,
+      }),
+    ];
   },
 });

--- a/packages/core/src/nodes/OrderedList.ts
+++ b/packages/core/src/nodes/OrderedList.ts
@@ -7,6 +7,13 @@
 
 import { Node } from '../Node.js';
 import { wrappingInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    toggleOrderedList: CommandSpec;
+  }
+}
 
 export interface OrderedListOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -65,8 +72,7 @@ export const OrderedList = Node.create<OrderedListOptions>({
       toggleOrderedList:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (listName: string, itemName: string) => boolean>;
-          return cmds['toggleList']?.(name, options.itemTypeName) ?? false;
+          return commands.toggleList(name, options.itemTypeName);
         },
     };
   },

--- a/packages/core/src/nodes/Paragraph.ts
+++ b/packages/core/src/nodes/Paragraph.ts
@@ -6,6 +6,13 @@
  */
 
 import { Node } from '../Node.js';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    setParagraph: CommandSpec;
+  }
+}
 
 export interface ParagraphOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -37,8 +44,7 @@ export const Paragraph = Node.create<ParagraphOptions>({
       setParagraph:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (name: string) => boolean>;
-          return cmds['setBlockType']?.(name) ?? false;
+          return commands.setBlockType(name);
         },
     };
   },

--- a/packages/core/src/nodes/TaskItem.test.ts
+++ b/packages/core/src/nodes/TaskItem.test.ts
@@ -281,8 +281,7 @@ describe('TaskItem', () => {
       editor.focus('start');
 
       // Toggle task
-      const toggleTask = editor.commands['toggleTask'] as (() => boolean) | undefined;
-      const result = toggleTask?.();
+      const result = editor.commands.toggleTask();
       expect(result).toBe(true);
 
       // Check that checked state changed

--- a/packages/core/src/nodes/TaskItem.ts
+++ b/packages/core/src/nodes/TaskItem.ts
@@ -15,6 +15,13 @@ import { Node } from '../Node.js';
 import { splitListItem, liftListItem, sinkListItem } from 'prosemirror-schema-list';
 import type { EditorState } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    toggleTask: CommandSpec;
+  }
+}
 
 export interface TaskItemOptions {
   HTMLAttributes: Record<string, unknown>;

--- a/packages/core/src/nodes/TaskItem.ts
+++ b/packages/core/src/nodes/TaskItem.ts
@@ -13,8 +13,6 @@
 
 import { Node } from '../Node.js';
 import { splitListItem, liftListItem, sinkListItem } from 'prosemirror-schema-list';
-import type { EditorState } from 'prosemirror-state';
-import type { EditorView } from 'prosemirror-view';
 import type { CommandSpec } from '../types/Commands.js';
 
 declare module '../types/Commands.js' {
@@ -128,25 +126,21 @@ export const TaskItem = Node.create<TaskItemOptions>({
   },
 
   addKeyboardShortcuts() {
-    const { editor, nodeType } = this;
     return {
       Enter: () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return splitListItem(nodeType)(state, view.dispatch);
+        if (!this.editor || !this.nodeType) return false;
+        return splitListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
       },
       Tab: () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return sinkListItem(nodeType)(state, view.dispatch);
+        if (!this.editor || !this.nodeType) return false;
+        return sinkListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
       },
       'Shift-Tab': () => {
-        if (!editor || !nodeType) return false;
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        return liftListItem(nodeType)(state, view.dispatch);
+        if (!this.editor || !this.nodeType) return false;
+        return liftListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
       },
       'Mod-Enter': () => {
-        return editor?.commands['toggleTask']?.() ?? false;
+        return this.editor?.commands['toggleTask']?.() ?? false;
       },
     };
   },

--- a/packages/core/src/nodes/TaskList.ts
+++ b/packages/core/src/nodes/TaskList.ts
@@ -7,6 +7,13 @@
 
 import { Node } from '../Node.js';
 import { wrappingInputRule } from 'prosemirror-inputrules';
+import type { CommandSpec } from '../types/Commands.js';
+
+declare module '../types/Commands.js' {
+  interface RawCommands {
+    toggleTaskList: CommandSpec;
+  }
+}
 
 export interface TaskListOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -52,8 +59,7 @@ export const TaskList = Node.create<TaskListOptions>({
       toggleTaskList:
         () =>
         ({ commands }) => {
-          const cmds = commands as Record<string, (listName: string, itemName: string) => boolean>;
-          return cmds['toggleList']?.(name, options.itemTypeName) ?? false;
+          return commands.toggleList(name, options.itemTypeName);
         },
     };
   },

--- a/packages/core/src/types/Commands.ts
+++ b/packages/core/src/types/Commands.ts
@@ -55,10 +55,29 @@ export type Command = (props: CommandProps) => boolean;
 export type CommandSpec<Args extends unknown[] = []> = (...args: Args) => Command;
 
 /**
- * Raw commands as returned by extensions
- * Keys are command names, values are command specs
+ * Internal command storage used by CommandManager and ExtensionManager.
+ * Holds commands as a generic record for dynamic runtime collection.
  */
-export type RawCommands = Record<string, CommandSpec<never[]>>;
+export type CommandMap = Record<string, CommandSpec<unknown[]>>;
+
+/**
+ * Typed command interface for the public API.
+ *
+ * Each extension augments this interface via `declare module` to register
+ * its commands with proper argument types. This gives full type safety
+ * on `editor.commands.*`, `editor.chain().*`, and `editor.can().*`.
+ *
+ * @example
+ * ```ts
+ * declare module '../types/Commands.js' {
+ *   interface RawCommands {
+ *     toggleBold: CommandSpec;
+ *     setHeading: CommandSpec<[attributes?: { level?: number }]>;
+ *   }
+ * }
+ * ```
+ */
+export interface RawCommands {}
 
 /**
  * Single commands that execute immediately

--- a/packages/core/src/types/ExtensionConfig.ts
+++ b/packages/core/src/types/ExtensionConfig.ts
@@ -5,7 +5,7 @@
  * Node.create(), and Mark.create() factory methods.
  */
 
-import type { Plugin, Transaction } from 'prosemirror-state';
+import type { Plugin, Transaction, EditorState } from 'prosemirror-state';
 import type { InputRule } from 'prosemirror-inputrules';
 import type { EditorView } from 'prosemirror-view';
 import type { Command, KeyboardShortcutCommand } from './Commands.js';
@@ -15,7 +15,7 @@ import type { Command, KeyboardShortcutCommand } from './Commands.js';
  * Will be properly typed when Extension class is implemented
  */
 export interface ExtensionEditor {
-  readonly state: unknown;
+  readonly state: EditorState;
   readonly view: EditorView;
   readonly schema: unknown;
   readonly commands: Record<string, (...args: unknown[]) => boolean>;

--- a/packages/core/src/types/MarkConfig.ts
+++ b/packages/core/src/types/MarkConfig.ts
@@ -6,6 +6,8 @@
  */
 
 import type { Mark as PMMark, DOMOutputSpec, MarkType } from 'prosemirror-model';
+import type { EditorState } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
 import type { ExtensionConfigBase, ExtensionContext } from './ExtensionConfig.js';
 import type { AttributeSpecs } from './AttributeSpec.js';
 
@@ -14,8 +16,8 @@ import type { AttributeSpecs } from './AttributeSpec.js';
  * Includes schema with marks for MarkType getter
  */
 export interface MarkEditorContext {
-  readonly state: unknown;
-  readonly view: unknown;
+  readonly state: EditorState;
+  readonly view: EditorView;
   readonly schema: {
     marks: Record<string, MarkType>;
   };

--- a/packages/core/src/types/NodeConfig.ts
+++ b/packages/core/src/types/NodeConfig.ts
@@ -6,7 +6,8 @@
  */
 
 import type { Node as PMNode, DOMOutputSpec, NodeType } from 'prosemirror-model';
-import type { NodeViewConstructor } from 'prosemirror-view';
+import type { EditorState } from 'prosemirror-state';
+import type { EditorView, NodeViewConstructor } from 'prosemirror-view';
 import type { ExtensionConfigBase, ExtensionContext } from './ExtensionConfig.js';
 import type { AttributeSpecs } from './AttributeSpec.js';
 
@@ -15,8 +16,8 @@ import type { AttributeSpecs } from './AttributeSpec.js';
  * Includes schema with nodes for NodeType getter
  */
 export interface NodeEditorContext {
-  readonly state: unknown;
-  readonly view: unknown;
+  readonly state: EditorState;
+  readonly view: EditorView;
   readonly schema: {
     nodes: Record<string, NodeType>;
   };

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -42,6 +42,7 @@ export type {
   CommandProps,
   Command,
   CommandSpec,
+  CommandMap,
   RawCommands,
   SingleCommands,
   ChainedCommands,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,18 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(jsdom@27.4.0)(yaml@2.8.2)
 
+  demo:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.1(yaml@2.8.2)
+
   packages/core:
     dependencies:
       prosemirror-commands:
@@ -702,16 +714,34 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -720,16 +750,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -738,10 +786,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -750,10 +810,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -762,10 +834,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -774,10 +858,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -786,10 +882,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -798,16 +906,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -816,10 +942,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -828,11 +966,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -840,16 +990,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -1120,6 +1288,11 @@ packages:
     resolution: {integrity: sha512-bFuJRKOscsDAEZ/a8BezcTMAe2BQ/OBRfuMLFUuINfTR5qGVcm4a3xBIrQVepBaPxFj16SJdRjGe05vDiwZmFw==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
@@ -1834,6 +2007,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -1970,6 +2148,11 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2413,6 +2596,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -2792,6 +2985,46 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -3732,79 +3965,157 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -4063,6 +4374,10 @@ snapshots:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.16.3':
     optional: true
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@remirror/core-constants@3.0.0': {}
 
@@ -4758,6 +5073,35 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.2
@@ -4924,6 +5268,9 @@ snapshots:
       js-yaml: 3.14.2
 
   fs-constants@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5413,6 +5760,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
@@ -5814,6 +6169,18 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vite@6.4.1(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+      yaml: 2.8.2
 
   vite@7.3.1(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- Refactored command type system to use module augmentation with `RawCommands` interface and `CommandMap`
- Fixed multiple extension bugs (Placeholder, TextAlign, LineHeight, UniqueID, HorizontalRule, keyboard shortcut chaining, setMark attribute merging)
- Added proper TypeScript types for editor context interfaces (replaced `as unknown as` casts)

## Changes

- **Command types**: Each extension now declares its commands via `declare module` augmentation on `RawCommands`, replacing the previous untyped approach
- **Placeholder**: Fixed crash during editor init when `editor.view` is not yet available
- **TextAlign/LineHeight**: Fixed `.every()` bug where command returned wrong boolean
- **toggleBlockType**: Fixed attribute comparison that prevented toggling off
- **UniqueID**: Added `view()` hook to assign IDs to initial content
- **HorizontalRule**: Rewrote `setHorizontalRule` to handle empty paragraphs correctly
- **setMark**: Now merges attributes with existing marks instead of replacing
- **ExtensionManager**: Keyboard shortcut handlers now chain instead of overwriting; `mergeHTMLAttrs` concatenates style/class values
- **Heading**: Added Backspace handler to convert heading to paragraph at cursor start