### PR TITLE
fix(core): handle AllSelection in toggle commands for TrailingNode compatibility

### DIFF
--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -173,6 +173,76 @@ describe('Editor', () => {
         expect(html).toContain('<p>');
         expect(html).toContain('Initial content');
       });
+
+      it('converts rgb() colors to hex in style attributes', () => {
+        const schemaWithStyle = new Schema({
+          nodes: {
+            doc: { content: 'paragraph+' },
+            paragraph: {
+              content: 'inline*',
+              toDOM() { return ['p', 0]; },
+              parseDOM: [{ tag: 'p' }],
+            },
+            text: { group: 'inline', inline: true },
+          },
+          marks: {
+            textStyle: {
+              attrs: { style: { default: null } },
+              toDOM(mark) { return ['span', { style: mark.attrs['style'] }, 0]; },
+              parseDOM: [{ tag: 'span[style]', getAttrs: (dom: HTMLElement) => ({ style: dom.getAttribute('style') }) }],
+            },
+          },
+        });
+
+        const colorEditor = new Editor({
+          schema: schemaWithStyle,
+          content: '<p><span style="color: rgb(255, 0, 0)">red</span></p>',
+        });
+
+        const html = colorEditor.getHTML();
+        expect(html).toContain('#ff0000');
+        expect(html).not.toContain('rgb(');
+        colorEditor.destroy();
+      });
+
+      it('converts multiple rgb() values in one style attribute', () => {
+        const schemaWithStyle = new Schema({
+          nodes: {
+            doc: { content: 'paragraph+' },
+            paragraph: {
+              content: 'inline*',
+              toDOM() { return ['p', 0]; },
+              parseDOM: [{ tag: 'p' }],
+            },
+            text: { group: 'inline', inline: true },
+          },
+          marks: {
+            textStyle: {
+              attrs: { style: { default: null } },
+              toDOM(mark) { return ['span', { style: mark.attrs['style'] }, 0]; },
+              parseDOM: [{ tag: 'span[style]', getAttrs: (dom: HTMLElement) => ({ style: dom.getAttribute('style') }) }],
+            },
+          },
+        });
+
+        const colorEditor = new Editor({
+          schema: schemaWithStyle,
+          content: '<p><span style="color: rgb(0, 0, 255); background-color: rgb(255, 255, 0)">text</span></p>',
+        });
+
+        const html = colorEditor.getHTML();
+        expect(html).toContain('#0000ff');
+        expect(html).toContain('#ffff00');
+        expect(html).not.toContain('rgb(');
+        colorEditor.destroy();
+      });
+
+      it('does not alter text content containing rgb()', () => {
+        const html = editor.getHTML();
+        // The basic editor has no rgb() in style attrs, so this just verifies
+        // getHTML works normally without style attrs
+        expect(html).toContain('Initial content');
+      });
     });
 
     describe('getText', () => {

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -377,7 +377,16 @@ export class Editor extends EventEmitter<EditorEvents> {
     const div = document.createElement('div');
     div.appendChild(fragment);
 
-    return div.innerHTML;
+    // Browser DOM normalizes hex colors to rgb() — convert back to hex within style attrs
+    return div.innerHTML.replace(/style="([^"]*)"/g, (_match, style: string) =>
+      'style="' +
+        style.replace(
+          /rgb\((\d+),\s*(\d+),\s*(\d+)\)/g,
+          (_, r: string, g: string, b: string) =>
+            '#' + [r, g, b].map(c => Number(c).toString(16).padStart(2, '0')).join(''),
+        ) +
+        '"',
+    );
   }
 
   /**

--- a/packages/core/src/commands/builtIn.test.ts
+++ b/packages/core/src/commands/builtIn.test.ts
@@ -2,7 +2,7 @@
  * Tests for built-in commands
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { TextSelection } from 'prosemirror-state';
+import { TextSelection, AllSelection } from 'prosemirror-state';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
 import { Paragraph } from '../nodes/Paragraph.js';
@@ -437,6 +437,59 @@ describe('builtIn commands', () => {
       const result = editor.commands.toggleBlockType('heading', 'nonexistent');
       expect(result).toBe(false);
     });
+
+    it('toggles heading OFF with AllSelection when empty trailing paragraph exists', () => {
+      // Simulates TrailingNode scenario: heading + empty trailing paragraph
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Heading],
+        content: '<h2>Hello</h2><p></p>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      expect(editor.state.doc.childCount).toBe(2);
+
+      // AllSelection + toggleHeading should toggle OFF despite empty paragraph
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleBlockType('heading', 'paragraph', { level: 2 });
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<h2>');
+      expect(editor.getHTML()).toContain('<p>');
+    });
+
+    it('toggles heading ON with AllSelection when content is paragraph + empty trailing', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Heading],
+        content: '<p>Hello</p><p></p>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleBlockType('heading', 'paragraph', { level: 2 });
+      expect(result).toBe(true);
+      expect(editor.getHTML()).toContain('<h2>');
+    });
+
+    it('toggles OFF with AllSelection when all content blocks match', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Heading],
+        content: '<h1>Title</h1><h1>Subtitle</h1>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleBlockType('heading', 'paragraph', { level: 1 });
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<h1>');
+    });
   });
 
   describe('wrapIn', () => {
@@ -497,6 +550,40 @@ describe('builtIn commands', () => {
       const result = editor.commands.toggleWrap('nonexistent');
       expect(result).toBe(false);
     });
+
+    it('unwraps blockquote with AllSelection when empty trailing paragraph exists', () => {
+      // Simulates TrailingNode scenario: blockquote + empty trailing paragraph
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Blockquote],
+        content: '<blockquote><p>Hello</p></blockquote><p></p>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleWrap('blockquote');
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<blockquote>');
+      expect(editor.getHTML()).toContain('Hello');
+    });
+
+    it('unwraps with AllSelection when all content blocks are wrapped', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Blockquote],
+        content: '<blockquote><p>Hello</p></blockquote>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleWrap('blockquote');
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<blockquote>');
+    });
   });
 
   describe('lift', () => {
@@ -534,6 +621,58 @@ describe('builtIn commands', () => {
 
       const result = editor.commands.toggleList('nonexistent', 'listItem');
       expect(result).toBe(false);
+    });
+
+    it('lifts bullet list with AllSelection when empty trailing paragraph exists', () => {
+      // Simulates TrailingNode scenario: list + empty trailing paragraph
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, BulletList, OrderedList, ListItem],
+        content: '<ul><li><p>Item</p></li></ul><p></p>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleList('bulletList', 'listItem');
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<ul>');
+      expect(editor.getHTML()).toContain('Item');
+    });
+
+    it('lifts list with AllSelection when all content is in target list', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, BulletList, OrderedList, ListItem],
+        content: '<ul><li><p>Item</p></li></ul>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleList('bulletList', 'listItem');
+      expect(result).toBe(true);
+      expect(editor.getHTML()).not.toContain('<ul>');
+    });
+
+    it('converts list type with AllSelection when empty trailing paragraph exists', () => {
+      // Simulates TrailingNode scenario: bullet list + empty trailing paragraph → ordered list
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, BulletList, OrderedList, ListItem],
+        content: '<ul><li><p>Item</p></li></ul><p></p>',
+      });
+      document.body.appendChild(editor.view.dom);
+
+      const { state } = editor;
+      const tr = state.tr.setSelection(new AllSelection(state.doc));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.toggleList('orderedList', 'listItem');
+      expect(result).toBe(true);
+      expect(editor.getHTML()).toContain('<ol>');
+      expect(editor.getHTML()).not.toContain('<ul>');
     });
   });
 

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -540,17 +540,26 @@ export const toggleBlockType: CommandSpec<[nodeName: string, defaultNodeName: st
       return false;
     }
 
-    // Use tr.selection for chain compatibility - prior commands may have changed selection
-    const { $from } = tr.selection;
-    const currentNode = $from.parent;
+    // Collect non-empty textblocks in the selection. Empty textblocks
+    // (e.g., trailing node from TrailingNode extension) are excluded so they
+    // don't affect toggle direction. This handles AllSelection correctly.
+    const { from, to } = tr.selection;
+    const contentBlocks: { node: PMNode }[] = [];
+    tr.doc.nodesBetween(from, to, (node) => {
+      if (node.isTextblock && node.content.size > 0) {
+        contentBlocks.push({ node });
+      }
+    });
 
-    // If current block matches target type AND attributes, toggle to default
-    const typeMatches = currentNode.type === nodeType;
-    const attrsMatch = !attributes || Object.keys(attributes).every(
-      (key) => currentNode.attrs[key] === attributes[key]
-    );
+    const allMatch = contentBlocks.length > 0 && contentBlocks.every(({ node }) => {
+      const typeMatches = node.type === nodeType;
+      const attrsMatch = !attributes || Object.keys(attributes).every(
+        (key) => node.attrs[key] === attributes[key]
+      );
+      return typeMatches && attrsMatch;
+    });
 
-    if (typeMatches && attrsMatch) {
+    if (allMatch) {
       // Toggle OFF → switch to default type, preserving global attrs
       return setBlockType(defaultNodeName)(props);
     }
@@ -609,19 +618,31 @@ export const toggleWrap: CommandSpec<[nodeName: string, attributes?: Attrs]> =
       return false;
     }
 
-    // Use tr.selection for chain compatibility - prior commands may have changed selection
-    const { $from } = tr.selection;
-    let isWrapped = false;
-
-    for (let depth = $from.depth; depth > 0; depth--) {
-      if ($from.node(depth).type === nodeType) {
-        isWrapped = true;
-        break;
+    // Collect non-empty textblocks in the selection with their positions.
+    // Empty textblocks (e.g., trailing node) are excluded so they don't
+    // affect toggle direction. This handles AllSelection correctly.
+    const { from, to } = tr.selection;
+    const contentBlocks: { pos: number }[] = [];
+    tr.doc.nodesBetween(from, to, (node, pos) => {
+      if (node.isTextblock && node.content.size > 0) {
+        contentBlocks.push({ pos });
       }
-    }
+    });
 
-    // If wrapped, lift out; otherwise wrap
-    if (isWrapped) {
+    const allWrapped = contentBlocks.length > 0 && contentBlocks.every(({ pos }) => {
+      const $pos = tr.doc.resolve(pos);
+      for (let d = $pos.depth; d > 0; d--) {
+        if ($pos.node(d).type === nodeType) return true;
+      }
+      return false;
+    });
+
+    if (allWrapped) {
+      // Narrow selection to the first non-empty textblock so lift() operates
+      // within the wrapper rather than at doc level.
+      const first = contentBlocks[0];
+      if (!first) return false;
+      tr.setSelection(TextSelection.create(tr.doc, first.pos + 1));
       return lift()(props);
     }
 
@@ -679,39 +700,66 @@ export const toggleList: CommandSpec<[listNodeName: string, listItemNodeName: st
       return false;
     }
 
-    // Use tr.selection for chain compatibility - prior commands may have changed selection
-    const { $from } = tr.selection;
+    // Collect non-empty textblocks with their list context.
+    // Empty textblocks (e.g., trailing node) are excluded so they don't
+    // affect toggle direction. This handles AllSelection correctly.
+    const { from, to } = tr.selection;
+    const contentBlocks: { pos: number; inTargetList: boolean; inSomeList: boolean; otherListPos: number | null }[] = [];
 
-    // Find if we're already in a list and get details
-    let listDepth: number | null = null;
-    let currentListType: typeof listType | null = null;
+    tr.doc.nodesBetween(from, to, (node, pos) => {
+      if (!node.isTextblock || node.content.size === 0) return;
 
-    for (let depth = $from.depth; depth >= 0; depth--) {
-      const node = $from.node(depth);
-      // Check if this node is the target list type or any kind of list
-      // Split by whitespace for exact group match (avoids 'playlist' matching 'list')
-      const groups = (node.type.spec.group ?? '').split(/\s+/);
-      if (node.type === listType || groups.includes('list')) {
-        listDepth = depth;
-        currentListType = node.type;
-        break;
+      const $pos = tr.doc.resolve(pos);
+      let inTargetList = false;
+      let inSomeList = false;
+      let otherListPos: number | null = null;
+
+      for (let d = $pos.depth; d >= 0; d--) {
+        const n = $pos.node(d);
+        if (n.type === listType) {
+          inTargetList = true;
+          inSomeList = true;
+          break;
+        }
+        const groups = (n.type.spec.group ?? '').split(/\s+/);
+        if (groups.includes('list')) {
+          inSomeList = true;
+          otherListPos = $pos.before(d);
+          break;
+        }
       }
+
+      contentBlocks.push({ pos, inTargetList, inSomeList, otherListPos });
+    });
+
+    const allInTargetList = contentBlocks.length > 0 && contentBlocks.every((b) => b.inTargetList);
+    const allInSomeList = contentBlocks.length > 0 && contentBlocks.every((b) => b.inSomeList);
+
+    // Case 1: All non-empty textblocks are in the target list type → lift items out
+    if (allInTargetList) {
+      // liftListItem reads state.selection directly. When that's AllSelection
+      // (doc level), it can't find list items. Create a state with narrowed
+      // selection inside the list so liftListItem works correctly.
+      const first = contentBlocks[0];
+      const last = contentBlocks[contentBlocks.length - 1];
+      if (!first || !last) return false;
+      const narrowTr = state.tr.setSelection(
+        TextSelection.create(state.doc, first.pos + 1, last.pos + 1)
+      );
+      const narrowState = state.apply(narrowTr);
+      return liftListItem(listItemType)(narrowState, dispatch);
     }
 
-    // Case 1: We're in the same list type → lift items out
-    if (currentListType === listType) {
-      return liftListItem(listItemType)(state, dispatch);
-    }
-
-    // Case 2: We're in a different list type → convert by changing node type in-place
-    if (listDepth !== null && currentListType !== null && currentListType !== listType) {
-      const pos = $from.before(listDepth);
+    // Case 2: All non-empty textblocks are in some list but not target → convert
+    if (allInSomeList) {
+      const otherPos = contentBlocks.find((b) => b.otherListPos !== null)?.otherListPos;
+      if (otherPos === undefined || otherPos === null) return false;
 
       if (!dispatch) {
         return true; // Can convert
       }
 
-      const listNode = tr.doc.nodeAt(pos);
+      const listNode = tr.doc.nodeAt(otherPos);
       if (!listNode) return false;
 
       // If item types differ (e.g., taskItem ↔ listItem), replace entire list
@@ -723,10 +771,10 @@ export const toggleList: CommandSpec<[listNodeName: string, listItemNodeName: st
           newItems.push(listItemType.create(child.attrs, child.content, child.marks));
         });
         const newList = listType.create(attributes, newItems);
-        tr.replaceWith(pos, pos + listNode.nodeSize, newList);
+        tr.replaceWith(otherPos, otherPos + listNode.nodeSize, newList);
       } else {
         // Same item type, just change the wrapper
-        tr.setNodeMarkup(pos, listType, attributes);
+        tr.setNodeMarkup(otherPos, listType, attributes);
       }
 
       dispatch(tr);


### PR DESCRIPTION
## Summary

- Fix toggle commands (toggleBlockType, toggleWrap, toggleList) failing with AllSelection when a TrailingNode empty paragraph exists — empty textblocks no longer affect toggle direction
- Normalize rgb() colors to hex in `getHTML()` output to prevent browser DOM color format inconsistencies

## Changes

- **builtIn.ts** — `toggleBlockType`, `toggleWrap`, `toggleList` now collect non-empty textblocks across the selection to determine toggle direction instead of only checking `$from.parent`; narrow selection before delegating to `lift`/`liftListItem` so they operate within the correct context
- **Editor.ts** — `getHTML()` post-processes style attributes to convert browser-normalized `rgb()` back to hex
- **builtIn.test.ts** — Added AllSelection + TrailingNode scenario tests for toggleBlockType, toggleWrap, toggleList
- **Editor.test.ts** — Added tests for rgb→hex normalization in `getHTML()`
