### PR TITLE
feat(core): refactor Link mark with exitable, keepOnSplit, linkifyjs autolink, and getMarkRange helper

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "linkifyjs": "^4.3.2",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-gapcursor": "^1.4.0",

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -209,7 +209,7 @@ export class Mark<Options = unknown, Storage = unknown> extends Extension<
 
     // Schema properties - copy directly if defined
     if (this.config.inclusive !== undefined)
-      spec.inclusive = this.config.inclusive;
+      spec.inclusive = callOrReturn(this.config.inclusive, this);
     if (this.config.excludes !== undefined)
       spec.excludes = this.config.excludes;
     if (this.config.group !== undefined) spec.group = this.config.group;

--- a/packages/core/src/helpers/getMarkRange.test.ts
+++ b/packages/core/src/helpers/getMarkRange.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getMarkRange } from './getMarkRange.js';
+import { Editor } from '../Editor.js';
+import { Document } from '../nodes/Document.js';
+import { Text } from '../nodes/Text.js';
+import { Paragraph } from '../nodes/Paragraph.js';
+import { Link } from '../marks/Link.js';
+import { Bold } from '../marks/Bold.js';
+
+describe('getMarkRange', () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    if (editor && !editor.isDestroyed) editor.destroy();
+  });
+
+  it('returns the full range of a link mark around cursor', () => {
+    editor = new Editor({
+      extensions: [Document, Text, Paragraph, Link],
+      content: '<p><a href="https://example.com">hello world</a></p>',
+    });
+
+    // Cursor in middle of "hello world" (pos 6)
+    const $pos = editor.state.doc.resolve(6);
+    const linkType = editor.state.schema.marks['link']!;
+    const range = getMarkRange($pos, linkType);
+
+    expect(range).toBeDefined();
+    // "hello world" starts at pos 1, ends at pos 12
+    expect(range!.from).toBe(1);
+    expect(range!.to).toBe(12);
+  });
+
+  it('returns undefined when mark is not present at position', () => {
+    editor = new Editor({
+      extensions: [Document, Text, Paragraph, Link],
+      content: '<p>plain text</p>',
+    });
+
+    const $pos = editor.state.doc.resolve(3);
+    const linkType = editor.state.schema.marks['link']!;
+    const range = getMarkRange($pos, linkType);
+
+    expect(range).toBeUndefined();
+  });
+
+  it('returns correct range when link is part of larger text', () => {
+    editor = new Editor({
+      extensions: [Document, Text, Paragraph, Link],
+      content: '<p>before <a href="https://example.com">link</a> after</p>',
+    });
+
+    // Cursor inside "link" text
+    const $pos = editor.state.doc.resolve(9);
+    const linkType = editor.state.schema.marks['link']!;
+    const range = getMarkRange($pos, linkType);
+
+    expect(range).toBeDefined();
+    // "before " = 7 chars, so "link" starts at pos 8, ends at pos 12
+    expect(range!.from).toBe(8);
+    expect(range!.to).toBe(12);
+  });
+
+  it('returns range at the start boundary of a mark', () => {
+    editor = new Editor({
+      extensions: [Document, Text, Paragraph, Link],
+      content: '<p>before <a href="https://example.com">link</a> after</p>',
+    });
+
+    // Cursor at the start of the link
+    const $pos = editor.state.doc.resolve(8);
+    const linkType = editor.state.schema.marks['link']!;
+    const range = getMarkRange($pos, linkType);
+
+    expect(range).toBeDefined();
+    expect(range!.from).toBe(8);
+    expect(range!.to).toBe(12);
+  });
+
+  it('does not find a different mark type', () => {
+    editor = new Editor({
+      extensions: [Document, Text, Paragraph, Link, Bold],
+      content: '<p><strong>bold text</strong></p>',
+    });
+
+    const $pos = editor.state.doc.resolve(3);
+    const linkType = editor.state.schema.marks['link']!;
+    const range = getMarkRange($pos, linkType);
+
+    expect(range).toBeUndefined();
+  });
+});

--- a/packages/core/src/helpers/getMarkRange.ts
+++ b/packages/core/src/helpers/getMarkRange.ts
@@ -1,0 +1,53 @@
+/**
+ * Get the range of a mark at a resolved position.
+ *
+ * Walks backward and forward from the position to find contiguous
+ * text nodes that share the same mark type, returning the full range.
+ */
+import type { MarkType, ResolvedPos } from 'prosemirror-model';
+
+export interface MarkRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * Returns the contiguous range of a mark around the given resolved position.
+ * Returns undefined if the mark is not present at the position.
+ */
+export function getMarkRange(
+  $pos: ResolvedPos,
+  type: MarkType,
+): MarkRange | undefined {
+  const parent = $pos.parent;
+
+  // Try the node at/after cursor first, then the node before
+  let start = parent.childAfter($pos.parentOffset);
+
+  if (!start.node || !type.isInSet(start.node.marks)) {
+    start = parent.childBefore($pos.parentOffset);
+  }
+
+  if (!start.node || !type.isInSet(start.node.marks)) {
+    return undefined;
+  }
+
+  let startIndex = start.index;
+  let startPos = $pos.start() + start.offset;
+  let endIndex = startIndex + 1;
+  let endPos = startPos + start.node.nodeSize;
+
+  // Walk backward
+  while (startIndex > 0 && type.isInSet(parent.child(startIndex - 1).marks)) {
+    startIndex -= 1;
+    startPos -= parent.child(startIndex).nodeSize;
+  }
+
+  // Walk forward
+  while (endIndex < parent.childCount && type.isInSet(parent.child(endIndex).marks)) {
+    endPos += parent.child(endIndex).nodeSize;
+    endIndex += 1;
+  }
+
+  return { from: startPos, to: endPos };
+}

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -27,3 +27,4 @@ export {
   type GenerateJSONOptions,
   type GenerateTextOptions,
 } from './ssr.js';
+export { getMarkRange, type MarkRange } from './getMarkRange.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,8 @@ export {
   type GenerateHTMLOptions,
   type GenerateJSONOptions,
   type GenerateTextOptions,
+  getMarkRange,
+  type MarkRange,
 } from './helpers/index.js';
 
 // === Extension System ===

--- a/packages/core/src/marks/Link.test.ts
+++ b/packages/core/src/marks/Link.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { TextSelection } from 'prosemirror-state';
+import { splitBlock } from 'prosemirror-commands';
 import { Link } from './Link.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
@@ -33,6 +34,7 @@ describe('Link', () => {
         autolink: true,
         linkOnPaste: true,
         defaultProtocol: 'https',
+        enableClickSelection: false,
       });
     });
 
@@ -48,14 +50,18 @@ describe('Link', () => {
   });
 
   describe('addAttributes', () => {
-    it('defines href, target, rel attributes', () => {
+    it('defines href, target, rel, title, class attributes', () => {
       const attrs = Link.config.addAttributes?.call(Link);
       expect(attrs).toHaveProperty('href');
       expect(attrs).toHaveProperty('target');
       expect(attrs).toHaveProperty('rel');
+      expect(attrs).toHaveProperty('title');
+      expect(attrs).toHaveProperty('class');
       expect(attrs?.['href']?.default).toBeNull();
       expect(attrs?.['target']?.default).toBeNull();
       expect(attrs?.['rel']?.default).toBeNull();
+      expect(attrs?.['title']?.default).toBeNull();
+      expect(attrs?.['class']?.default).toBeNull();
     });
   });
 
@@ -76,6 +82,8 @@ describe('Link', () => {
         href: 'https://example.com',
         target: null,
         rel: null,
+        title: null,
+        class: null,
       });
     });
 
@@ -182,9 +190,10 @@ describe('Link', () => {
         extensions: [Document, Text, Paragraph, Link],
         content: '<p>test</p>',
       });
-      // Should have linkClick, linkPaste, and autolink plugins
+      // Should have linkClick, linkExit, linkPaste, and autolink plugins
       const pluginKeys = editor.state.plugins.map((p) => (p.spec.key as { key?: string } | undefined)?.key ?? '');
       expect(pluginKeys.some((k) => k.includes('linkClick'))).toBe(true);
+      expect(pluginKeys.some((k) => k.includes('linkExit'))).toBe(true);
       expect(pluginKeys.some((k) => k.includes('linkPaste'))).toBe(true);
       expect(pluginKeys.some((k) => k.includes('autolink'))).toBe(true);
     });
@@ -294,6 +303,31 @@ describe('Link', () => {
       expect(result[0]).toBe('a');
       expect(result[1]).not.toHaveProperty('href');
       expect(result[1]).toHaveProperty('target', '_blank');
+    });
+
+    it('does not inherit link mark on split (keepOnSplit: false via inclusive: false)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Link],
+        content: '<p><a href="https://example.com">hello world</a></p>',
+      });
+      // Place cursor at end of link text
+      const { state } = editor;
+      const endPos = state.doc.child(0).nodeSize - 1; // end of paragraph content
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, endPos)));
+
+      // Simulate Enter (splitBlock) via prosemirror command
+      splitBlock(editor.state, editor.view.dispatch);
+
+      // The new (second) paragraph should not have link marks
+      const secondPara = editor.state.doc.child(1);
+      if (secondPara.childCount > 0) {
+        const firstChild = secondPara.child(0);
+        const hasLink = firstChild.marks.some((m) => m.type.name === 'link');
+        expect(hasLink).toBe(false);
+      }
+      // storedMarks should not include link
+      const stored = editor.state.storedMarks ?? [];
+      expect(stored.some((m) => m.type.name === 'link')).toBe(false);
     });
 
     it('parseHTML getAttrs handles string argument', () => {

--- a/packages/core/src/marks/Link.test.ts
+++ b/packages/core/src/marks/Link.test.ts
@@ -335,5 +335,53 @@ describe('Link', () => {
       const getAttrs = rules?.[0]?.getAttrs;
       expect(getAttrs?.('test')).toBe(false);
     });
+
+    it('unsetLink removes link from full mark range when cursor is inside link (empty selection)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Link],
+        content: '<p><a href="https://example.com">hello world</a></p>',
+      });
+      // Place cursor in the middle of the link text (no selection)
+      const { state } = editor;
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 6)));
+
+      editor.commands.unsetLink();
+
+      // Link should be removed from the entire text
+      const para = editor.state.doc.child(0);
+      para.forEach((child) => {
+        expect(child.marks.some((m) => m.type.name === 'link')).toBe(false);
+      });
+    });
+
+    it('toggleLink removes link from full mark range when cursor is inside link (empty selection)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Link],
+        content: '<p><a href="https://example.com">hello world</a></p>',
+      });
+      // Place cursor in the middle of the link text (no selection)
+      const { state } = editor;
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 6)));
+
+      editor.commands.toggleLink({ href: 'https://example.com' });
+
+      // Link should be removed from the entire text
+      const para = editor.state.doc.child(0);
+      para.forEach((child) => {
+        expect(child.marks.some((m) => m.type.name === 'link')).toBe(false);
+      });
+    });
+
+    it('unsetLink returns false when cursor is not inside a link (empty selection)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Link],
+        content: '<p>plain text</p>',
+      });
+      const { state } = editor;
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 3)));
+
+      const result = editor.commands.unsetLink();
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/core/src/marks/Link.test.ts
+++ b/packages/core/src/marks/Link.test.ts
@@ -21,8 +21,8 @@ describe('Link', () => {
       expect(Link.config.priority).toBe(1000);
     });
 
-    it('is not inclusive', () => {
-      expect(Link.config.inclusive).toBe(false);
+    it('inclusive is a function that returns autolink option', () => {
+      expect(typeof Link.config.inclusive).toBe('function');
     });
 
     it('has default options', () => {
@@ -305,7 +305,7 @@ describe('Link', () => {
       expect(result[1]).toHaveProperty('target', '_blank');
     });
 
-    it('does not inherit link mark on split (keepOnSplit: false via inclusive: false)', () => {
+    it('does not inherit link mark on split (keepOnSplit plugin)', () => {
       editor = new Editor({
         extensions: [Document, Text, Paragraph, Link],
         content: '<p><a href="https://example.com">hello world</a></p>',

--- a/packages/core/src/marks/Link.ts
+++ b/packages/core/src/marks/Link.ts
@@ -18,6 +18,7 @@
  * editor.commands.unsetLink();
  * ```
  */
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { Mark } from '../Mark.js';
 import { isValidUrl } from '../helpers/isValidUrl.js';
 import { linkClickPlugin } from './helpers/linkClickPlugin.js';
@@ -98,8 +99,13 @@ export const Link = Mark.create<LinkOptions>({
   // Links have lower priority than other marks
   priority: 1000,
 
-  // Links can contain other marks
-  inclusive: false,
+  // When autolink is enabled, the mark is inclusive so that typing at
+  // the end of a link naturally extends it (e.g. adding path segments
+  // to an autolinked URL). When autolink is off, links are set manually
+  // and should not extend on typing.
+  inclusive() {
+    return this.options.autolink;
+  },
 
   addOptions(): LinkOptions {
     return {
@@ -241,6 +247,32 @@ export const Link = Mark.create<LinkOptions>({
 
     // Exit plugin - ArrowRight at end of link exits the mark
     plugins.push(linkExitPlugin({ type: markType }));
+
+    // keepOnSplit: strip link from storedMarks after a block split so that
+    // pressing Enter at the end of a link does not carry it to the new line.
+    plugins.push(
+      new Plugin({
+        key: new PluginKey('linkKeepOnSplit'),
+        appendTransaction(transactions, _oldState, newState) {
+          const docChanged = transactions.some((tr) => tr.docChanged);
+          if (!docChanged) return null;
+
+          const { selection } = newState;
+          if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+          const $cursor = selection.$cursor;
+          if ($cursor?.parentOffset !== 0) return null;
+
+          const stored = newState.storedMarks;
+          if (!stored) return null;
+
+          const hasLink = stored.some((m) => m.type === markType);
+          if (!hasLink) return null;
+
+          return newState.tr.setStoredMarks(stored.filter((m) => m.type !== markType));
+        },
+      })
+    );
 
     // Autolink plugin - converts typed URLs to links
     if (this.options.autolink) {

--- a/packages/core/src/marks/Link.ts
+++ b/packages/core/src/marks/Link.ts
@@ -21,6 +21,7 @@
 import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { Mark } from '../Mark.js';
 import { isValidUrl } from '../helpers/isValidUrl.js';
+import { getMarkRange } from '../helpers/getMarkRange.js';
 import { linkClickPlugin } from './helpers/linkClickPlugin.js';
 import { linkPastePlugin } from './helpers/linkPastePlugin.js';
 import { autolinkPlugin } from './helpers/autolinkPlugin.js';
@@ -202,14 +203,69 @@ export const Link = Mark.create<LinkOptions>({
         },
       unsetLink:
         () =>
-        ({ commands }) => commands.unsetMark('link'),
+        ({ tr, state, dispatch }) => {
+          const markType = state.schema.marks['link'];
+          if (!markType) return false;
+
+          const { from, to, empty } = tr.selection;
+
+          if (empty) {
+            // Extend to full link range around cursor
+            const $pos = tr.doc.resolve(from);
+            const range = getMarkRange($pos, markType);
+            if (!range) return false;
+            if (!dispatch) return true;
+            tr.removeMark(range.from, range.to, markType);
+          } else {
+            if (!dispatch) return true;
+            tr.removeMark(from, to, markType);
+          }
+
+          dispatch(tr);
+          return true;
+        },
       toggleLink:
         (attributes: LinkAttributes) =>
-        ({ commands }) => {
+        ({ tr, state, dispatch }) => {
           if (!isValidUrl(attributes.href, { protocols: this.options.protocols })) {
             return false;
           }
-          return commands.toggleMark('link', attributes);
+
+          const markType = state.schema.marks['link'];
+          if (!markType) return false;
+
+          const { from, to, empty } = tr.selection;
+
+          if (empty) {
+            // Extend to full link range around cursor
+            const $pos = tr.doc.resolve(from);
+            const range = getMarkRange($pos, markType);
+
+            if (range && tr.doc.rangeHasMark(range.from, range.to, markType)) {
+              // Has link — remove it from the full range
+              if (!dispatch) return true;
+              tr.removeMark(range.from, range.to, markType);
+            } else {
+              // No link — toggle stored mark for cursor
+              if (!dispatch) return true;
+              const cursorMarks = tr.storedMarks ?? state.storedMarks ?? $pos.marks();
+              if (markType.isInSet(cursorMarks)) {
+                tr.removeStoredMark(markType);
+              } else {
+                tr.addStoredMark(markType.create(attributes));
+              }
+            }
+          } else {
+            if (!dispatch) return true;
+            if (tr.doc.rangeHasMark(from, to, markType)) {
+              tr.removeMark(from, to, markType);
+            } else {
+              tr.addMark(from, to, markType.create(attributes));
+            }
+          }
+
+          dispatch(tr);
+          return true;
         },
     };
   },

--- a/packages/core/src/marks/Link.ts
+++ b/packages/core/src/marks/Link.ts
@@ -23,6 +23,7 @@ import { isValidUrl } from '../helpers/isValidUrl.js';
 import { linkClickPlugin } from './helpers/linkClickPlugin.js';
 import { linkPastePlugin } from './helpers/linkPastePlugin.js';
 import { autolinkPlugin } from './helpers/autolinkPlugin.js';
+import { linkExitPlugin } from './helpers/linkExitPlugin.js';
 
 /**
  * Options for the Link mark
@@ -70,6 +71,11 @@ export interface LinkOptions {
    * Return false to prevent auto-linking specific URLs
    */
   shouldAutoLink?: (url: string) => boolean;
+  /**
+   * Select the full link text range when clicking a link
+   * @default false
+   */
+  enableClickSelection: boolean;
 }
 
 /**
@@ -79,6 +85,8 @@ export interface LinkAttributes {
   href: string;
   target?: string | null;
   rel?: string | null;
+  title?: string | null;
+  class?: string | null;
 }
 
 /**
@@ -102,6 +110,7 @@ export const Link = Mark.create<LinkOptions>({
       autolink: true,
       linkOnPaste: true,
       defaultProtocol: 'https',
+      enableClickSelection: false,
     };
   },
 
@@ -114,6 +123,12 @@ export const Link = Mark.create<LinkOptions>({
         default: null,
       },
       rel: {
+        default: null,
+      },
+      title: {
+        default: null,
+      },
+      class: {
         default: null,
       },
     };
@@ -136,6 +151,8 @@ export const Link = Mark.create<LinkOptions>({
             href,
             target: node.getAttribute('target'),
             rel: node.getAttribute('rel'),
+            title: node.getAttribute('title'),
+            class: node.getAttribute('class'),
           };
         },
       },
@@ -208,6 +225,7 @@ export const Link = Mark.create<LinkOptions>({
         openOnClick: this.options.openOnClick === 'whenNotEditable'
           ? true
           : this.options.openOnClick,
+        enableClickSelection: this.options.enableClickSelection,
       })
     );
 
@@ -220,6 +238,9 @@ export const Link = Mark.create<LinkOptions>({
         })
       );
     }
+
+    // Exit plugin - ArrowRight at end of link exits the mark
+    plugins.push(linkExitPlugin({ type: markType }));
 
     // Autolink plugin - converts typed URLs to links
     if (this.options.autolink) {

--- a/packages/core/src/marks/helpers/autolinkPlugin.ts
+++ b/packages/core/src/marks/helpers/autolinkPlugin.ts
@@ -3,9 +3,11 @@
  *
  * Automatically converts typed URLs into clickable links.
  * Triggers when user types a space, punctuation, or presses Enter after a URL.
+ * Uses linkifyjs for robust URL detection.
  */
 import { Plugin, PluginKey } from 'prosemirror-state';
 import type { MarkType } from 'prosemirror-model';
+import { find } from 'linkifyjs';
 
 /**
  * Options for the autolink plugin
@@ -39,17 +41,6 @@ export interface AutolinkPluginOptions {
  * Plugin key for autolink plugin
  */
 export const autolinkPluginKey = new PluginKey('autolink');
-
-/**
- * Regex to detect URLs in text.
- * Matches:
- * - http://example.com
- * - https://example.com
- * - www.example.com
- * - example.com (with common TLDs)
- */
-const URL_REGEX =
-  /(?:https?:\/\/|www\.)[^\s<>[\](){}'"]+|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+(?:com|org|net|edu|gov|io|co|dev|app|me|info|biz|xyz)(?:\/[^\s<>[\](){}'"]*)?/gi;
 
 /**
  * Characters that trigger autolink detection
@@ -94,24 +85,19 @@ export function autolinkPlugin(options: AutolinkPluginOptions): Plugin {
           '\ufffc'
         );
 
-        // Find URLs in the text before cursor
-        const matches: { start: number; end: number; url: string }[] = [];
-        let match: RegExpExecArray | null;
-
-        // Reset regex
-        URL_REGEX.lastIndex = 0;
-
-        while ((match = URL_REGEX.exec(textBefore)) !== null) {
-          matches.push({
-            start: match.index,
-            end: match.index + match[0].length,
-            url: match[0],
-          });
-        }
+        // Use linkifyjs to find URLs in the text
+        const matches = find(textBefore, {
+          defaultProtocol: defaultProtocol as 'http' | 'https',
+        });
 
         // Get the last match (most recent URL)
         const lastMatch = matches[matches.length - 1];
         if (!lastMatch) {
+          return false;
+        }
+
+        // Only process URL types (not email, etc.)
+        if (lastMatch.type !== 'url') {
           return false;
         }
 
@@ -120,13 +106,7 @@ export function autolinkPlugin(options: AutolinkPluginOptions): Plugin {
           return false;
         }
 
-        // Build full URL with protocol if needed
-        let href = lastMatch.url;
-        if (href.startsWith('www.')) {
-          href = `${defaultProtocol}://${href}`;
-        } else if (!href.startsWith('http://') && !href.startsWith('https://')) {
-          href = `${defaultProtocol}://${href}`;
-        }
+        const href = lastMatch.href;
 
         // Validate protocol
         try {

--- a/packages/core/src/marks/helpers/linkClickPlugin.test.ts
+++ b/packages/core/src/marks/helpers/linkClickPlugin.test.ts
@@ -262,5 +262,47 @@ describe('linkClickPlugin', () => {
         '_blank'
       );
     });
+
+    it('selects full link range when enableClickSelection is true', () => {
+      view = createView(
+        { text: 'click me', linked: true },
+        { enableClickSelection: true, openOnClick: false }
+      );
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      const link = findLinkElement(view)!;
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === linkClickPluginKey
+      );
+
+      const handler = plugin!.props.handleClick as any;
+      const event = mockClickEvent({ target: link });
+
+      const result = handler(view, 2, event);
+      expect(result).toBe(true);
+      expect(openSpy).not.toHaveBeenCalled();
+
+      // Selection should span the full link text "click me" (pos 1-9)
+      const { from, to } = view.state.selection;
+      expect(to - from).toBe('click me'.length);
+    });
+
+    it('does not select when enableClickSelection is false', () => {
+      view = createView(
+        { text: 'click me', linked: true },
+        { enableClickSelection: false, openOnClick: false }
+      );
+
+      const link = findLinkElement(view)!;
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === linkClickPluginKey
+      );
+
+      const handler = plugin!.props.handleClick as any;
+      const event = mockClickEvent({ target: link });
+
+      const result = handler(view, 2, event);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/core/src/marks/helpers/linkClickPlugin.ts
+++ b/packages/core/src/marks/helpers/linkClickPlugin.ts
@@ -5,7 +5,7 @@
  * When editable: opens on click.
  * When read-only: browser handles link clicks natively.
  */
-import { Plugin, PluginKey } from 'prosemirror-state';
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import type { MarkType } from 'prosemirror-model';
 
 /**
@@ -25,6 +25,12 @@ export interface LinkClickPluginOptions {
    * @default true
    */
   openOnClick?: boolean | 'whenNotEditable';
+
+  /**
+   * Select the full link text range when clicking a link
+   * @default false
+   */
+  enableClickSelection?: boolean;
 }
 
 /**
@@ -39,7 +45,7 @@ export const linkClickPluginKey = new PluginKey('linkClick');
  * @returns ProseMirror Plugin
  */
 export function linkClickPlugin(options: LinkClickPluginOptions): Plugin {
-  const { type, openOnClick = true } = options;
+  const { type, openOnClick = true, enableClickSelection = false } = options;
 
   return new Plugin({
     key: linkClickPluginKey,
@@ -74,6 +80,35 @@ export function linkClickPlugin(options: LinkClickPluginOptions): Plugin {
 
         if (!link) {
           return false;
+        }
+
+        // Select full link range on click
+        if (enableClickSelection) {
+          const pos = view.posAtDOM(link, 0);
+          const $pos = view.state.doc.resolve(pos);
+
+          if ($pos.marks().some((m) => m.type === type)) {
+            // Find contiguous mark range within the parent text block
+            const parent = $pos.parent;
+            const blockStart = pos - $pos.parentOffset;
+            let rangeStart = pos;
+            let rangeEnd = pos;
+
+            parent.forEach((child, childOffset) => {
+              const childStart = blockStart + childOffset;
+              const childEnd = childStart + child.nodeSize;
+              if (type.isInSet(child.marks) && childStart <= rangeEnd && childEnd >= rangeStart) {
+                rangeStart = Math.min(rangeStart, childStart);
+                rangeEnd = Math.max(rangeEnd, childEnd);
+              }
+            });
+
+            const tr = view.state.tr.setSelection(
+              TextSelection.create(view.state.doc, rangeStart, rangeEnd)
+            );
+            view.dispatch(tr);
+            return true;
+          }
         }
 
         if (openOnClick) {

--- a/packages/core/src/marks/helpers/linkExitPlugin.test.ts
+++ b/packages/core/src/marks/helpers/linkExitPlugin.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { linkExitPlugin, linkExitPluginKey } from './linkExitPlugin.js';
+import { Schema } from 'prosemirror-model';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      toDOM: () => ['p', 0],
+      parseDOM: [{ tag: 'p' }],
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    link: {
+      attrs: { href: { default: null } },
+      inclusive: false,
+      toDOM: (mark) => ['a', { href: mark.attrs['href'] }, 0],
+      parseDOM: [{ tag: 'a[href]' }],
+    },
+    bold: {
+      toDOM: () => ['strong', 0],
+      parseDOM: [{ tag: 'strong' }],
+    },
+  },
+});
+
+function createView(
+  nodes: { text: string; linked?: boolean; href?: string }[]
+): EditorView {
+  const plugin = linkExitPlugin({ type: schema.marks.link });
+
+  const inlineNodes = nodes.map((n) => {
+    if (n.linked) {
+      const linkMark = schema.marks.link.create({
+        href: n.href ?? 'https://example.com',
+      });
+      return schema.text(n.text, [linkMark]);
+    }
+    return schema.text(n.text);
+  });
+
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, inlineNodes),
+  ]);
+
+  const state = EditorState.create({ schema, doc, plugins: [plugin] });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  return new EditorView(container, { state });
+}
+
+function setCursorAt(view: EditorView, pos: number): void {
+  const tr = view.state.tr.setSelection(
+    TextSelection.create(view.state.doc, pos)
+  );
+  view.dispatch(tr);
+}
+
+function simulateArrowRight(view: EditorView): boolean {
+  const plugin = view.state.plugins.find(
+    (p) => p.spec.key === linkExitPluginKey
+  );
+  const handler = plugin!.props.handleKeyDown as (
+    view: EditorView,
+    event: KeyboardEvent
+  ) => boolean;
+  const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+  return handler(view, event);
+}
+
+describe('linkExitPlugin', () => {
+  let view: EditorView | undefined;
+
+  afterEach(() => {
+    if (view) {
+      const container = view.dom.parentElement;
+      view.destroy();
+      container?.remove();
+    }
+  });
+
+  describe('plugin creation', () => {
+    it('creates a plugin', () => {
+      const plugin = linkExitPlugin({ type: schema.marks.link });
+      expect(plugin).toBeDefined();
+    });
+
+    it('uses linkExitPluginKey', () => {
+      expect(linkExitPluginKey).toBeDefined();
+    });
+
+    it('has handleKeyDown prop', () => {
+      const plugin = linkExitPlugin({ type: schema.marks.link });
+      expect(plugin.props.handleKeyDown).toBeDefined();
+    });
+  });
+
+  describe('handleKeyDown', () => {
+    it('strips link from storedMarks at end of link', () => {
+      // "hello" is linked, cursor at end of "hello" (pos 6)
+      view = createView([{ text: 'hello', linked: true }]);
+      setCursorAt(view, 6); // end of "hello" (after last char)
+
+      const result = simulateArrowRight(view);
+      expect(result).toBe(false); // doesn't prevent default
+
+      // storedMarks should be set without the link mark
+      const stored = view.state.storedMarks;
+      expect(stored).not.toBeNull();
+      expect(stored!.some((m) => m.type === schema.marks.link)).toBe(false);
+    });
+
+    it('strips link from storedMarks at boundary between linked and unlinked text', () => {
+      // "hello" is linked, " world" is not linked
+      view = createView([
+        { text: 'hello', linked: true },
+        { text: ' world', linked: false },
+      ]);
+      setCursorAt(view, 6); // end of "hello", before " world"
+
+      simulateArrowRight(view);
+
+      const stored = view.state.storedMarks;
+      expect(stored).not.toBeNull();
+      expect(stored!.some((m) => m.type === schema.marks.link)).toBe(false);
+    });
+
+    it('does nothing when cursor is in the middle of a link', () => {
+      view = createView([{ text: 'hello', linked: true }]);
+      setCursorAt(view, 3); // middle of "hello"
+
+      simulateArrowRight(view);
+
+      // storedMarks should NOT be set (cursor is still inside the link)
+      const stored = view.state.storedMarks;
+      expect(stored).toBeNull();
+    });
+
+    it('does nothing when cursor is not in a link', () => {
+      view = createView([{ text: 'hello', linked: false }]);
+      setCursorAt(view, 3);
+
+      simulateArrowRight(view);
+
+      const stored = view.state.storedMarks;
+      expect(stored).toBeNull();
+    });
+
+    it('ignores non-ArrowRight keys', () => {
+      view = createView([{ text: 'hello', linked: true }]);
+      setCursorAt(view, 6);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === linkExitPluginKey
+      );
+      const handler = plugin!.props.handleKeyDown as (
+        view: EditorView,
+        event: KeyboardEvent
+      ) => boolean;
+      const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+      const result = handler(view, event);
+      expect(result).toBe(false);
+
+      const stored = view.state.storedMarks;
+      expect(stored).toBeNull();
+    });
+
+    it('ignores non-empty selections', () => {
+      view = createView([{ text: 'hello', linked: true }]);
+      // Set a range selection instead of cursor
+      const tr = view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, 1, 4)
+      );
+      view.dispatch(tr);
+
+      simulateArrowRight(view);
+
+      const stored = view.state.storedMarks;
+      expect(stored).toBeNull();
+    });
+
+    it('preserves other marks when stripping link', () => {
+      // Create text with both link and bold marks
+      const linkMark = schema.marks.link.create({ href: 'https://example.com' });
+      const boldMark = schema.marks.bold.create();
+      const doc = schema.node('doc', null, [
+        schema.node('paragraph', null, [
+          schema.text('hello', [boldMark, linkMark]),
+        ]),
+      ]);
+
+      const plugin = linkExitPlugin({ type: schema.marks.link });
+      const state = EditorState.create({ schema, doc, plugins: [plugin] });
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      view = new EditorView(container, { state });
+
+      setCursorAt(view, 6); // end of "hello"
+      simulateArrowRight(view);
+
+      const stored = view.state.storedMarks;
+      expect(stored).not.toBeNull();
+      expect(stored!.some((m) => m.type === schema.marks.link)).toBe(false);
+      expect(stored!.some((m) => m.type === schema.marks.bold)).toBe(true);
+    });
+
+    it('always returns false (never prevents default)', () => {
+      view = createView([{ text: 'hello', linked: true }]);
+
+      // At boundary
+      setCursorAt(view, 6);
+      expect(simulateArrowRight(view)).toBe(false);
+
+      // In middle
+      setCursorAt(view, 3);
+      expect(simulateArrowRight(view)).toBe(false);
+
+      // On unlinked text
+      view.destroy();
+      view.dom.parentElement?.remove();
+      view = createView([{ text: 'hello', linked: false }]);
+      setCursorAt(view, 3);
+      expect(simulateArrowRight(view)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/marks/helpers/linkExitPlugin.ts
+++ b/packages/core/src/marks/helpers/linkExitPlugin.ts
@@ -58,9 +58,9 @@ export function linkExitPlugin(options: LinkExitPluginOptions): Plugin {
         if (!$cursor) return false;
 
         // Check the node before cursor for the link mark.
-        // We use nodeBefore instead of $cursor.marks() because marks()
-        // filters out non-inclusive marks at boundaries, and Link uses
-        // inclusive: false.
+        // We use nodeBefore.marks instead of $cursor.marks() because
+        // nodeBefore always reflects the actual marks on the text node,
+        // regardless of the mark's inclusive setting.
         const nodeBefore = $cursor.nodeBefore;
         if (!nodeBefore) return false;
 

--- a/packages/core/src/marks/helpers/linkExitPlugin.ts
+++ b/packages/core/src/marks/helpers/linkExitPlugin.ts
@@ -1,0 +1,89 @@
+/**
+ * Link Exit Plugin
+ *
+ * Allows users to "exit" a link mark by pressing ArrowRight at the
+ * end of the link. After exiting, newly typed text will not have
+ * the link mark applied.
+ *
+ * This matches Tiptap's `exitable: true` behavior on the Link mark.
+ */
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+import type { MarkType } from 'prosemirror-model';
+
+/**
+ * Options for the link exit plugin
+ */
+export interface LinkExitPluginOptions {
+  /**
+   * The link mark type
+   */
+  type: MarkType;
+}
+
+/**
+ * Plugin key for link exit plugin
+ */
+export const linkExitPluginKey = new PluginKey('linkExit');
+
+/**
+ * Creates a plugin that allows exiting a link mark with ArrowRight.
+ *
+ * When the cursor is at the end boundary of a link mark (the next
+ * character has no link mark, or there is no next character), pressing
+ * ArrowRight will set storedMarks to exclude the link mark. This means
+ * any text typed after will not be linked.
+ *
+ * @param options - Plugin options
+ * @returns ProseMirror Plugin
+ */
+export function linkExitPlugin(options: LinkExitPluginOptions): Plugin {
+  const { type } = options;
+
+  return new Plugin({
+    key: linkExitPluginKey,
+
+    props: {
+      handleKeyDown(view, event) {
+        if (event.key !== 'ArrowRight') return false;
+
+        const { state } = view;
+        const { selection } = state;
+
+        // Only handle cursor (collapsed) selections
+        if (!(selection instanceof TextSelection) || !selection.empty) {
+          return false;
+        }
+
+        const $cursor = selection.$cursor;
+        if (!$cursor) return false;
+
+        // Check the node before cursor for the link mark.
+        // We use nodeBefore instead of $cursor.marks() because marks()
+        // filters out non-inclusive marks at boundaries, and Link uses
+        // inclusive: false.
+        const nodeBefore = $cursor.nodeBefore;
+        if (!nodeBefore) return false;
+
+        const marksOnNode = nodeBefore.marks;
+        const hasLink = marksOnNode.some((m) => m.type === type);
+        if (!hasLink) return false;
+
+        // Check if we're at the end of the mark range:
+        // The next character either doesn't exist or doesn't have the link mark
+        const after = $cursor.nodeAfter;
+        const afterHasLink = after?.marks.some((m) => m.type === type) ?? false;
+
+        if (!afterHasLink) {
+          // We're at the boundary — strip link from storedMarks
+          const marksWithoutLink = marksOnNode.filter((m) => m.type !== type);
+          const tr = state.tr.setStoredMarks(marksWithoutLink);
+          view.dispatch(tr);
+          // Don't prevent default — let ArrowRight move cursor normally
+          return false;
+        }
+
+        return false;
+      },
+    },
+  });
+}

--- a/packages/core/src/types/MarkConfig.ts
+++ b/packages/core/src/types/MarkConfig.ts
@@ -114,7 +114,7 @@ interface MarkSchemaProperties {
    *
    * @default true
    */
-  inclusive?: boolean;
+  inclusive?: boolean | (() => boolean);
 
   /**
    * Marks that this mark excludes (cannot coexist with)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   packages/core:
     dependencies:
+      linkifyjs:
+        specifier: ^4.3.2
+        version: 4.3.2
       prosemirror-commands:
         specifier: ^1.7.1
         version: 1.7.1
@@ -2227,6 +2230,9 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -5169,6 +5175,8 @@ snapshots:
       html-escaper: 3.0.3
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
+
+  linkifyjs@4.3.2: {}
 
   load-tsconfig@0.2.5: {}
 


### PR DESCRIPTION
## Summary

- Add `linkExitPlugin` — ArrowRight at end of link exits the mark (exitable behavior)
- Add `linkKeepOnSplit` plugin — Enter inside a link does not carry the mark to the new line
- Switch autolink from custom regex to `linkifyjs` for robust URL detection
- Make Link `inclusive` dynamic — inclusive when autolink is on (extends URL on typing), non-inclusive when off
- Add `enableClickSelection` option — clicking a link selects the full link text range
- Add `title` and `class` attributes to Link mark
- Add `getMarkRange` helper — finds full mark range around a resolved position
- Extend `unsetLink` and `toggleLink` to operate on full mark range when cursor is inside a link (empty selection)

## Features

- **Exitable links**: ArrowRight at the end of a link clears the mark from storedMarks so new text is unlinked
- **keepOnSplit**: pressing Enter inside a link strips the link from the new line's storedMarks
- **linkifyjs autolink**: replaces brittle custom URL regex with linkifyjs `find()` for accurate detection
- **Dynamic inclusive**: `inclusive()` returns `this.options.autolink` — autolinked URLs extend naturally, manual links don't
- **enableClickSelection**: optional click-to-select-link behavior via `linkClickPlugin`
- **getMarkRange**: reusable helper exported from `@domternal/core`, used by `unsetLink`/`toggleLink` for extendEmptyMarkRange
- **Extra attributes**: `title` and `class` on Link mark (Tiptap v3 does not preserve `title`)
