### PR TITLE
feat(image): add paste/drop upload, float/wrapping, inline mode, and input rules 

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -204,10 +204,10 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
   createNodeSpec(): NodeSpec {
     const spec: NodeSpec = {};
 
-    // Schema properties - copy directly if defined
-    if (this.config.group !== undefined) spec.group = this.config.group;
+    // Schema properties - use callOrReturn for group/inline to support dynamic values
+    if (this.config.group !== undefined) spec.group = callOrReturn(this.config.group, this) as string;
     if (this.config.content !== undefined) spec.content = this.config.content;
-    if (this.config.inline !== undefined) spec.inline = this.config.inline;
+    if (this.config.inline !== undefined) spec.inline = callOrReturn(this.config.inline, this) as boolean;
     if (this.config.atom !== undefined) spec.atom = this.config.atom;
     if (this.config.selectable !== undefined)
       spec.selectable = this.config.selectable;

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -205,9 +205,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
     const spec: NodeSpec = {};
 
     // Schema properties - use callOrReturn for group/inline to support dynamic values
-    if (this.config.group !== undefined) spec.group = callOrReturn(this.config.group, this) as string;
+    if (this.config.group !== undefined) spec.group = callOrReturn(this.config.group, this);
     if (this.config.content !== undefined) spec.content = this.config.content;
-    if (this.config.inline !== undefined) spec.inline = callOrReturn(this.config.inline, this) as boolean;
+    if (this.config.inline !== undefined) spec.inline = callOrReturn(this.config.inline, this);
     if (this.config.atom !== undefined) spec.atom = this.config.atom;
     if (this.config.selectable !== undefined)
       spec.selectable = this.config.selectable;

--- a/packages/core/src/types/NodeConfig.ts
+++ b/packages/core/src/types/NodeConfig.ts
@@ -123,8 +123,9 @@ interface NodeSchemaProperties {
    * Used in content expressions
    *
    * @example 'block', 'inline', 'block list'
+   * Can be a function that returns the group string (useful for dynamic group based on options)
    */
-  group?: string;
+  group?: string | (() => string);
 
   /**
    * Content expression defining allowed children
@@ -136,9 +137,10 @@ interface NodeSchemaProperties {
 
   /**
    * Whether this is an inline node
+   * Can be a function for dynamic inline based on options
    * @default false
    */
-  inline?: boolean;
+  inline?: boolean | (() => boolean);
 
   /**
    * Whether this node is an atom (no direct content editing)

--- a/packages/extension-details/src/Details.ts
+++ b/packages/extension-details/src/Details.ts
@@ -404,26 +404,58 @@ export const Details = Node.create<DetailsOptions>({
         }
 
         const isVisible = isNodeVisible($head.after() + 1, editor);
-        const above = isVisible ? state.doc.nodeAt($head.after()) : $head.node(-2);
+
+        // If content is hidden, open it first, then fall through to visible logic
+        if (!isVisible) {
+          const detailsPos = $head.before(-1);
+          const detailsDom = view.nodeDOM(detailsPos);
+
+          if (detailsDom instanceof HTMLElement) {
+            detailsDom.classList.add(this.options.openClassName);
+            const contentEl = detailsDom.querySelector('[data-type="detailsContent"]');
+            if (contentEl) {
+              contentEl.dispatchEvent(new Event('toggleDetailsContent'));
+            }
+          }
+
+          if (this.options.persist) {
+            const detailsNode = state.doc.nodeAt(detailsPos);
+            if (detailsNode) {
+              const { tr } = state;
+              tr.setNodeMarkup(detailsPos, undefined, {
+                ...detailsNode.attrs,
+                open: true,
+              });
+              const contentStartPos = $head.after() + 1;
+              tr.setSelection(Selection.near(tr.doc.resolve(contentStartPos), 1));
+              tr.scrollIntoView();
+              view.dispatch(tr);
+              return true;
+            }
+          }
+        }
+
+        // Content is (now) visible — create new block at start of detailsContent
+        const above = state.doc.nodeAt($head.after());
 
         if (!above) return false;
 
-        const after = isVisible ? 0 : $head.indexAfter(-1);
-        const type = defaultBlockAt(above.contentMatchAt(after));
+        const type = defaultBlockAt(above.contentMatchAt(0));
 
-        if (!type || !above.canReplaceWith(after, after, type)) {
+        if (!type || !above.canReplaceWith(0, 0, type)) {
           return false;
         }
 
         const node = type.createAndFill();
         if (!node) return false;
 
-        const pos = isVisible ? $head.after() + 1 : $head.after(-1);
+        const pos = $head.after() + 1;
         const tr = state.tr.replaceWith(pos, pos, node);
         const $pos = tr.doc.resolve(pos);
         const newSelection = Selection.near($pos, 1);
 
         tr.setSelection(newSelection);
+        tr.setMeta('detailsEnterOpen', true);
         tr.scrollIntoView();
         view.dispatch(tr);
 
@@ -460,6 +492,11 @@ export const Details = Node.create<DetailsOptions>({
 
           const selectionSet = transactions.some((t) => t.selectionSet);
           if (!selectionSet || !oldState.selection.empty || !newState.selection.empty) {
+            return;
+          }
+
+          // Skip when Enter handler intentionally placed cursor into just-opened content
+          if (transactions.some((t) => t.getMeta('detailsEnterOpen'))) {
             return;
           }
 

--- a/packages/extension-details/src/helpers/isNodeVisible.ts
+++ b/packages/extension-details/src/helpers/isNodeVisible.ts
@@ -9,6 +9,11 @@ interface EditorLike {
 }
 
 export const isNodeVisible = (position: number, editor: EditorLike): boolean => {
-  const node = editor.view.domAtPos(position).node as HTMLElement;
+  let node: Node | null = editor.view.domAtPos(position).node;
+  // Walk up from text nodes to the nearest HTMLElement (text nodes lack offsetParent)
+  while (node && !(node instanceof HTMLElement)) {
+    node = node.parentNode;
+  }
+  if (!node) return false;
   return node.offsetParent !== null;
 };

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -36,7 +36,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@domternal/core": "workspace:*"
+    "@domternal/core": "workspace:*",
+    "prosemirror-inputrules": "^1.5.1"
   },
   "devDependencies": {
     "jsdom": "^27.4.0",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -37,7 +37,10 @@
   },
   "dependencies": {
     "@domternal/core": "workspace:*",
-    "prosemirror-inputrules": "^1.5.1"
+    "prosemirror-inputrules": "^1.5.1",
+    "prosemirror-model": "^1.25.4",
+    "prosemirror-state": "^1.4.4",
+    "prosemirror-view": "^1.41.5"
   },
   "devDependencies": {
     "jsdom": "^27.4.0",

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -740,6 +740,175 @@ describe('Image', () => {
       expect(pluginState).toBeDefined();
     });
   });
+
+  describe('float attribute', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('has default value none', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('none');
+    });
+
+    it('parseHTML detects float: left from style', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="float: left;">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('left');
+    });
+
+    it('parseHTML detects float: right from style', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="float: right;">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('right');
+    });
+
+    it('parseHTML detects center from auto margins', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="margin-left: auto; margin-right: auto;">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('center');
+    });
+
+    it('parseHTML detects align="left" (legacy HTML)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" align="left">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('left');
+    });
+
+    it('parseHTML detects align="center" (legacy HTML)', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" align="center">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('center');
+    });
+
+    it('parseHTML returns none when no float style', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png">',
+      });
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('none');
+    });
+
+    it('renderHTML outputs float: left style', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="float: left;">',
+      });
+      const html = editor.getHTML();
+      expect(html).toContain('float: left');
+      // Browser normalizes `0` to `0px` in margin shorthand
+      expect(html).toMatch(/margin:.*1em.*1em/);
+    });
+
+    it('renderHTML outputs float: right style', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="float: right;">',
+      });
+      const html = editor.getHTML();
+      expect(html).toContain('float: right');
+      expect(html).toMatch(/margin:.*1em.*1em/);
+    });
+
+    it('renderHTML outputs center styles', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="margin-left: auto; margin-right: auto;">',
+      });
+      const html = editor.getHTML();
+      expect(html).toContain('margin-left: auto');
+      expect(html).toContain('margin-right: auto');
+    });
+
+    it('renderHTML outputs no style for float: none', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png">',
+      });
+      const html = editor.getHTML();
+      expect(html).not.toContain('float:');
+      expect(html).not.toContain('margin-left: auto');
+    });
+
+    it('setImage command accepts float option', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>test</p>',
+      });
+      editor.commands.setImage({ src: 'https://example.com/img.png', float: 'left' });
+      const image = editor.state.doc.child(0);
+      expect(image.type.name).toBe('image');
+      expect(image.attrs['float']).toBe('left');
+    });
+
+    it('setImageFloat command changes float attribute', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png">',
+      });
+      // Select the image node (position 0)
+      const { tr } = editor.state;
+      const nodeSelection = editor.state.selection.constructor;
+      tr.setSelection((nodeSelection as any).create(editor.state.doc, 0));
+      editor.view.dispatch(tr);
+
+      editor.commands.setImageFloat('right');
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('right');
+    });
+
+    it('setImageFloat returns false for invalid values', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png">',
+      });
+      const { tr } = editor.state;
+      const nodeSelection = editor.state.selection.constructor;
+      tr.setSelection((nodeSelection as any).create(editor.state.doc, 0));
+      editor.view.dispatch(tr);
+
+      const result = editor.commands.setImageFloat('invalid' as any);
+      expect(result).toBe(false);
+    });
+
+    it('float attribute round-trips through HTML', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" style="float: left; margin: 0 1em 1em 0;">',
+      });
+      const html = editor.getHTML();
+      expect(html).toContain('float: left');
+
+      // Parse the output back
+      editor.commands.setContent(html);
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['float']).toBe('left');
+    });
+  });
 });
 
 describe('imageUploadPlugin', () => {

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -49,6 +49,7 @@ describe('Image', () => {
           'image/avif',
         ],
         maxFileSize: 0,
+        onUploadStart: null,
         onUploadError: null,
       });
     });
@@ -670,6 +671,7 @@ describe('Image', () => {
         'image/avif',
       ]);
       expect(Image.options.maxFileSize).toBe(0);
+      expect(Image.options.onUploadStart).toBeNull();
       expect(Image.options.onUploadError).toBeNull();
     });
 
@@ -689,6 +691,13 @@ describe('Image', () => {
     it('can configure maxFileSize', () => {
       const CustomImage = Image.configure({ maxFileSize: 5_000_000 });
       expect(CustomImage.options.maxFileSize).toBe(5_000_000);
+    });
+
+    it('can configure onUploadStart', () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const startHandler = (): void => {};
+      const CustomImage = Image.configure({ onUploadStart: startHandler });
+      expect(CustomImage.options.onUploadStart).toBe(startHandler);
     });
 
     it('can configure onUploadError', () => {
@@ -778,6 +787,7 @@ describe('imageUploadPlugin', () => {
     opts?: {
       allowedMimeTypes?: string[];
       maxFileSize?: number;
+      onUploadStart?: ((file: File) => void) | null;
       onUploadError?: ((error: Error, file: File) => void) | null;
     },
   ): EditorView {
@@ -791,6 +801,7 @@ describe('imageUploadPlugin', () => {
         'image/webp',
       ],
       maxFileSize: opts?.maxFileSize ?? 0,
+      onUploadStart: opts?.onUploadStart ?? null,
       onUploadError: opts?.onUploadError ?? null,
     });
 
@@ -858,6 +869,7 @@ describe('imageUploadPlugin', () => {
         uploadHandler: handler,
         allowedMimeTypes: ['image/png'],
         maxFileSize: 0,
+        onUploadStart: null,
         onUploadError: null,
       });
       expect(plugin.props.handlePaste).toBeDefined();
@@ -947,6 +959,25 @@ describe('imageUploadPlugin', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(event.preventDefault).toHaveBeenCalled();
       expect(handler).toHaveBeenCalledWith(file);
+    });
+
+    it('calls onUploadStart before upload', () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/uploaded.png');
+      const onStart = vi.fn();
+      view = createUploadView(handler, { onUploadStart: onStart });
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const file = mockFile('photo.png', 'image/png');
+      const event = mockPasteEvent([file]);
+
+      handlePaste(view, event);
+      expect(onStart).toHaveBeenCalledWith(file);
     });
 
     it('inserts image after successful upload', async () => {

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -12,8 +12,10 @@ describe('Image', () => {
       expect(Image.type).toBe('node');
     });
 
-    it('belongs to block group', () => {
-      expect(Image.config.group).toBe('block');
+    it('belongs to block group by default', () => {
+      expect(typeof Image.config.group).toBe('function');
+      const group = (Image.config.group as Function).call(Image);
+      expect(group).toBe('block');
     });
 
     it('is draggable', () => {
@@ -26,6 +28,7 @@ describe('Image', () => {
 
     it('has default options', () => {
       expect(Image.options).toEqual({
+        inline: false,
         allowBase64: false,
         HTMLAttributes: {},
       });

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -116,6 +116,18 @@ describe('Image', () => {
       expect(attributes).toHaveProperty('height');
       expect(attributes?.['height']?.default).toBeNull();
     });
+
+    it('defines loading attribute', () => {
+      const attributes = Image.config.addAttributes?.call(Image);
+      expect(attributes).toHaveProperty('loading');
+      expect(attributes?.['loading']?.default).toBeNull();
+    });
+
+    it('defines crossorigin attribute', () => {
+      const attributes = Image.config.addAttributes?.call(Image);
+      expect(attributes).toHaveProperty('crossorigin');
+      expect(attributes?.['crossorigin']?.default).toBeNull();
+    });
   });
 
   describe('addCommands', () => {
@@ -336,6 +348,36 @@ describe('Image', () => {
         const html = editor.getHTML();
         expect(html).not.toContain('JaVaScRiPt');
       });
+
+      it('accepts absolute path URLs', () => {
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, Image],
+          content: '<img src="/uploads/photo.jpg">',
+        });
+
+        const html = editor.getHTML();
+        expect(html).toContain('src="/uploads/photo.jpg"');
+      });
+
+      it('accepts relative path URLs', () => {
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, Image],
+          content: '<img src="./images/photo.jpg">',
+        });
+
+        const html = editor.getHTML();
+        expect(html).toContain('src="./images/photo.jpg"');
+      });
+
+      it('accepts protocol-relative URLs', () => {
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, Image],
+          content: '<img src="//cdn.example.com/img.png">',
+        });
+
+        const html = editor.getHTML();
+        expect(html).toContain('src="//cdn.example.com/img.png"');
+      });
     });
   });
 
@@ -380,6 +422,54 @@ describe('Image', () => {
       const html = editor.getHTML();
       expect(html).toContain('width="200"');
       expect(html).toContain('height="100"');
+    });
+
+    it('setImage accepts loading option', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Text</p>',
+      });
+      editor.commands.setImage({
+        src: 'https://example.com/lazy.png',
+        loading: 'lazy',
+      });
+
+      const html = editor.getHTML();
+      expect(html).toContain('loading="lazy"');
+    });
+
+    it('setImage accepts crossorigin option', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Text</p>',
+      });
+      editor.commands.setImage({
+        src: 'https://cdn.example.com/img.png',
+        crossorigin: 'anonymous',
+      });
+
+      const html = editor.getHTML();
+      expect(html).toContain('crossorigin="anonymous"');
+    });
+
+    it('parses loading attribute from HTML', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" loading="lazy">',
+      });
+
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['loading']).toBe('lazy');
+    });
+
+    it('parses crossorigin attribute from HTML', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<img src="https://example.com/img.png" crossorigin="anonymous">',
+      });
+
+      const image = editor.state.doc.child(0);
+      expect(image.attrs['crossorigin']).toBe('anonymous');
     });
   });
 
@@ -467,7 +557,7 @@ describe('Image', () => {
     });
 
     // Regex pattern tests — verify the markdown image syntax pattern
-    const imageInputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
+    const imageInputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["']([^"']+)["'])?\))$/;
 
     it('regex matches ![alt](src)', () => {
       const match = imageInputRegex.exec('![My alt](https://example.com/input.png)');
@@ -507,6 +597,14 @@ describe('Image', () => {
       const match = imageInputRegex.exec("![alt](https://example.com/a.png 'title')");
       expect(match).not.toBeNull();
       expect(match![4]).toBe('title');
+    });
+
+    it('regex matches title with spaces', () => {
+      const match = imageInputRegex.exec('![alt](https://example.com/a.png "Hello World")');
+      expect(match).not.toBeNull();
+      expect(match![2]).toBe('alt');
+      expect(match![3]).toBe('https://example.com/a.png');
+      expect(match![4]).toBe('Hello World');
     });
   });
 });

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Image } from './Image.js';
 import { Document, Text, Paragraph, Editor } from '@domternal/core';
+import {
+  imageUploadPlugin,
+  imageUploadPluginKey,
+  _resetPlaceholderCounter,
+} from './imageUploadPlugin.js';
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
 
 describe('Image', () => {
   describe('configuration', () => {
@@ -31,6 +39,17 @@ describe('Image', () => {
         inline: false,
         allowBase64: false,
         HTMLAttributes: {},
+        uploadHandler: null,
+        allowedMimeTypes: [
+          'image/jpeg',
+          'image/png',
+          'image/gif',
+          'image/webp',
+          'image/svg+xml',
+          'image/avif',
+        ],
+        maxFileSize: 0,
+        onUploadError: null,
       });
     });
 
@@ -605,6 +624,500 @@ describe('Image', () => {
       expect(match![2]).toBe('alt');
       expect(match![3]).toBe('https://example.com/a.png');
       expect(match![4]).toBe('Hello World');
+    });
+  });
+
+  describe('leafText', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('returns alt text for getText()', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Before</p><img src="https://example.com/img.png" alt="My photo"><p>After</p>',
+      });
+
+      const text = editor.getText();
+      expect(text).toContain('My photo');
+    });
+
+    it('returns empty string when no alt attribute', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Before</p><img src="https://example.com/img.png"><p>After</p>',
+      });
+
+      const text = editor.getText();
+      expect(text).toContain('Before');
+      expect(text).toContain('After');
+    });
+  });
+
+  describe('upload options', () => {
+    it('has default upload options', () => {
+      expect(Image.options.uploadHandler).toBeNull();
+      expect(Image.options.allowedMimeTypes).toEqual([
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+        'image/avif',
+      ]);
+      expect(Image.options.maxFileSize).toBe(0);
+      expect(Image.options.onUploadError).toBeNull();
+    });
+
+    it('can configure uploadHandler', () => {
+      const handler = (): Promise<string> => Promise.resolve('https://example.com/uploaded.png');
+      const CustomImage = Image.configure({ uploadHandler: handler });
+      expect(CustomImage.options.uploadHandler).toBe(handler);
+    });
+
+    it('can configure allowedMimeTypes', () => {
+      const CustomImage = Image.configure({
+        allowedMimeTypes: ['image/png'],
+      });
+      expect(CustomImage.options.allowedMimeTypes).toEqual(['image/png']);
+    });
+
+    it('can configure maxFileSize', () => {
+      const CustomImage = Image.configure({ maxFileSize: 5_000_000 });
+      expect(CustomImage.options.maxFileSize).toBe(5_000_000);
+    });
+
+    it('can configure onUploadError', () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const errorHandler = (): void => {};
+      const CustomImage = Image.configure({ onUploadError: errorHandler });
+      expect(CustomImage.options.onUploadError).toBe(errorHandler);
+    });
+  });
+
+  describe('addProseMirrorPlugins', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('does not create upload plugin when uploadHandler is null', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p></p>',
+      });
+
+      const pluginState = imageUploadPluginKey.getState(editor.state);
+      expect(pluginState).toBeUndefined();
+    });
+
+    it('creates upload plugin when uploadHandler is provided', () => {
+      const UploadImage = Image.configure({
+        uploadHandler: (): Promise<string> => Promise.resolve('https://example.com/img.png'),
+      });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, UploadImage],
+        content: '<p></p>',
+      });
+
+      const pluginState = imageUploadPluginKey.getState(editor.state);
+      expect(pluginState).toBeDefined();
+    });
+  });
+});
+
+describe('imageUploadPlugin', () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: {
+        group: 'block',
+        content: 'inline*',
+        toDOM: () => ['p', 0] as const,
+        parseDOM: [{ tag: 'p' }],
+      },
+      image: {
+        group: 'block',
+        atom: true,
+        attrs: {
+          src: { default: null },
+          alt: { default: null },
+          title: { default: null },
+        },
+        toDOM: (node) =>
+          [
+            'img',
+            {
+              src: node.attrs['src'],
+              alt: node.attrs['alt'],
+              title: node.attrs['title'],
+            },
+          ] as const,
+        parseDOM: [{ tag: 'img[src]' }],
+      },
+      text: { group: 'inline' },
+    },
+  });
+
+  let view: EditorView | undefined;
+
+  afterEach(() => {
+    view?.destroy();
+    _resetPlaceholderCounter();
+  });
+
+  function createUploadView(
+    uploadHandler: (file: File) => Promise<string>,
+    opts?: {
+      allowedMimeTypes?: string[];
+      maxFileSize?: number;
+      onUploadError?: ((error: Error, file: File) => void) | null;
+    },
+  ): EditorView {
+    const plugin = imageUploadPlugin({
+      nodeType: schema.nodes.image,
+      uploadHandler,
+      allowedMimeTypes: opts?.allowedMimeTypes ?? [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ],
+      maxFileSize: opts?.maxFileSize ?? 0,
+      onUploadError: opts?.onUploadError ?? null,
+    });
+
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('hello')]),
+    ]);
+    const state = EditorState.create({ schema, doc, plugins: [plugin] });
+    const container = document.createElement('div');
+    return new EditorView(container, { state });
+  }
+
+  function mockFile(name: string, type: string, size = 1000): File {
+    const content = new Uint8Array(size);
+    return new File([content], name, { type });
+  }
+
+  function mockPasteEvent(files: File[]): ClipboardEvent {
+    const items = files.map((file) => ({
+      kind: 'file' as const,
+      type: file.type,
+      getAsFile: () => file,
+    }));
+
+    return {
+      clipboardData: {
+        items,
+        getData: () => '',
+      },
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+  }
+
+  function mockDropEvent(
+    files: File[],
+    clientX = 0,
+    clientY = 0,
+  ): DragEvent {
+    const fileList = Object.assign(files, {
+      item: (i: number) => files[i] ?? null,
+    }) as unknown as FileList;
+
+    return {
+      dataTransfer: { files: fileList },
+      clientX,
+      clientY,
+      preventDefault: vi.fn(),
+    } as unknown as DragEvent;
+  }
+
+  describe('plugin creation', () => {
+    it('creates a plugin with imageUploadPluginKey', () => {
+      const handler = vi.fn().mockResolvedValue('https://example.com/img.png');
+      view = createUploadView(handler);
+
+      const pluginState = imageUploadPluginKey.getState(view.state);
+      expect(pluginState).toBeDefined();
+    });
+
+    it('has handlePaste and handleDrop props', () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/img.png');
+      const plugin = imageUploadPlugin({
+        nodeType: schema.nodes.image,
+        uploadHandler: handler,
+        allowedMimeTypes: ['image/png'],
+        maxFileSize: 0,
+        onUploadError: null,
+      });
+      expect(plugin.props.handlePaste).toBeDefined();
+      expect(plugin.props.handleDrop).toBeDefined();
+    });
+  });
+
+  describe('handlePaste', () => {
+    it('ignores paste without files', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const event = {
+        clipboardData: {
+          items: [
+            {
+              kind: 'string',
+              type: 'text/plain',
+              getAsFile: () => null,
+            },
+          ],
+          getData: () => 'just text',
+        },
+        preventDefault: vi.fn(),
+      } as unknown as ClipboardEvent;
+
+      const result = handlePaste(view, event);
+      expect(result).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-image files', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const txtFile = mockFile('doc.txt', 'text/plain');
+      const event = mockPasteEvent([txtFile]);
+
+      const result = handlePaste(view, event);
+      expect(result).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('rejects files exceeding maxFileSize', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler, { maxFileSize: 500 });
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const bigFile = mockFile('big.png', 'image/png', 1000);
+      const event = mockPasteEvent([bigFile]);
+
+      const result = handlePaste(view, event);
+      expect(result).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid image file and calls uploadHandler', () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/uploaded.png');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const file = mockFile('photo.png', 'image/png');
+      const event = mockPasteEvent([file]);
+
+      const result = handlePaste(view, event);
+      expect(result).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledWith(file);
+    });
+
+    it('inserts image after successful upload', async () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/uploaded.png');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const file = mockFile('photo.png', 'image/png');
+      const event = mockPasteEvent([file]);
+
+      handlePaste(view, event);
+
+      // Wait for async upload to complete
+      await vi.waitFor(() => {
+        let hasImage = false;
+        view!.state.doc.descendants((node) => {
+          if (node.type.name === 'image') hasImage = true;
+        });
+        expect(hasImage).toBe(true);
+      });
+
+      // Verify inserted image has correct src
+      let imgSrc: string | null = null;
+      view.state.doc.descendants((node) => {
+        if (node.type.name === 'image') {
+          imgSrc = node.attrs['src'] as string;
+        }
+      });
+      expect(imgSrc).toBe('https://example.com/uploaded.png');
+    });
+
+    it('removes placeholder on upload error', async () => {
+      const handler = vi
+        .fn()
+        .mockRejectedValue(new Error('Upload failed'));
+      const onError = vi.fn();
+      view = createUploadView(handler, { onUploadError: onError });
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const file = mockFile('photo.png', 'image/png');
+      const event = mockPasteEvent([file]);
+
+      handlePaste(view, event);
+
+      // Wait for error handling
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error), file);
+      expect((onError.mock.calls[0] as [Error, File])[0].message).toBe('Upload failed');
+
+      // No image should be in the document
+      let hasImage = false;
+      view.state.doc.descendants((node) => {
+        if (node.type.name === 'image') hasImage = true;
+      });
+      expect(hasImage).toBe(false);
+    });
+
+    it('handles multiple files in single paste', () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/img.png');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      const file1 = mockFile('a.png', 'image/png');
+      const file2 = mockFile('b.jpg', 'image/jpeg');
+      const event = mockPasteEvent([file1, file2]);
+
+      const result = handlePaste(view, event);
+      expect(result).toBe(true);
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenCalledWith(file1);
+      expect(handler).toHaveBeenCalledWith(file2);
+    });
+
+    it('validates allowedMimeTypes correctly', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler, { allowedMimeTypes: ['image/png'] });
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handlePaste = plugin!.props.handlePaste as any;
+
+      // JPEG should be rejected when only PNG is allowed
+      const jpegFile = mockFile('photo.jpg', 'image/jpeg');
+      const event1 = mockPasteEvent([jpegFile]);
+      expect(handlePaste(view, event1)).toBe(false);
+
+      // PNG should be accepted
+      const pngFile = mockFile('photo.png', 'image/png');
+      const event2 = mockPasteEvent([pngFile]);
+      expect(handlePaste(view, event2)).toBe(true);
+    });
+  });
+
+  describe('handleDrop', () => {
+    it('accepts valid image file on drop', () => {
+      const handler = vi
+        .fn()
+        .mockResolvedValue('https://example.com/dropped.png');
+      view = createUploadView(handler);
+
+      // Mock posAtCoords since jsdom doesn't support elementFromPoint
+      vi.spyOn(view, 'posAtCoords').mockReturnValue({ pos: 1, inside: -1 });
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handleDrop = plugin!.props.handleDrop as any;
+
+      const file = mockFile('dropped.png', 'image/png');
+      const event = mockDropEvent([file], 10, 10);
+
+      const result = handleDrop(view, event);
+      expect(result).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledWith(file);
+    });
+
+    it('ignores drop without image files', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handleDrop = plugin!.props.handleDrop as any;
+
+      const txtFile = mockFile('doc.txt', 'text/plain');
+      const event = mockDropEvent([txtFile]);
+
+      const result = handleDrop(view, event);
+      expect(result).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('ignores drop with no dataTransfer', () => {
+      const handler = vi.fn().mockResolvedValue('url');
+      view = createUploadView(handler);
+
+      const plugin = view.state.plugins.find(
+        (p) => p.spec.key === imageUploadPluginKey,
+      );
+      const handleDrop = plugin!.props.handleDrop as any;
+
+      const event = {
+        dataTransfer: null,
+        preventDefault: vi.fn(),
+      } as unknown as DragEvent;
+
+      const result = handleDrop(view, event);
+      expect(result).toBe(false);
     });
   });
 });

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -338,4 +338,175 @@ describe('Image', () => {
       });
     });
   });
+
+  describe('SetImageOptions typed interface', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('setImage accepts typed options with src, alt, title', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Text</p>',
+      });
+      const result = editor.commands.setImage({
+        src: 'https://example.com/typed.png',
+        alt: 'Typed alt',
+        title: 'Typed title',
+      });
+      expect(result).toBe(true);
+
+      const html = editor.getHTML();
+      expect(html).toContain('src="https://example.com/typed.png"');
+      expect(html).toContain('alt="Typed alt"');
+      expect(html).toContain('title="Typed title"');
+    });
+
+    it('setImage accepts width and height options', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Text</p>',
+      });
+      editor.commands.setImage({
+        src: 'https://example.com/sized.png',
+        width: '200',
+        height: '100',
+      });
+
+      const html = editor.getHTML();
+      expect(html).toContain('width="200"');
+      expect(html).toContain('height="100"');
+    });
+  });
+
+  describe('inline mode', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('inline: true changes group to inline', () => {
+      const InlineImage = Image.configure({ inline: true });
+      const group = (InlineImage.config.group as Function).call(InlineImage);
+      expect(group).toBe('inline');
+    });
+
+    it('inline: true sets inline to true', () => {
+      const InlineImage = Image.configure({ inline: true });
+      const inline = (InlineImage.config.inline as Function).call(InlineImage);
+      expect(inline).toBe(true);
+    });
+
+    it('inline: false (default) keeps block group', () => {
+      const group = (Image.config.group as Function).call(Image);
+      expect(group).toBe('block');
+    });
+
+    it('inline image can exist inside paragraph', () => {
+      const InlineImage = Image.configure({ inline: true });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, InlineImage],
+        content: '<p>Before <img src="https://example.com/inline.png"> after</p>',
+      });
+
+      const doc = editor.state.doc;
+      // Should be a single paragraph containing text + inline image + text
+      expect(doc.childCount).toBe(1);
+      expect(doc.child(0).type.name).toBe('paragraph');
+
+      let hasImage = false;
+      doc.child(0).forEach((node) => {
+        if (node.type.name === 'image') hasImage = true;
+      });
+      expect(hasImage).toBe(true);
+    });
+
+    it('block image (default) is a separate block', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p>Before</p><img src="https://example.com/block.png"><p>After</p>',
+      });
+
+      const doc = editor.state.doc;
+      expect(doc.childCount).toBe(3);
+      expect(doc.child(1).type.name).toBe('image');
+    });
+  });
+
+  describe('input rules', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.destroy();
+      }
+    });
+
+    it('provides addInputRules', () => {
+      expect(typeof Image.config.addInputRules).toBe('function');
+    });
+
+    it('returns one input rule when editor is initialized', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Image],
+        content: '<p></p>',
+      });
+
+      const imageExt = editor.extensionManager.extensions.find(
+        (e) => e.name === 'image'
+      );
+      const rules = imageExt?.config.addInputRules?.call(imageExt);
+      expect(rules).toHaveLength(1);
+    });
+
+    // Regex pattern tests — verify the markdown image syntax pattern
+    const imageInputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
+
+    it('regex matches ![alt](src)', () => {
+      const match = '![My alt](https://example.com/input.png)'.match(imageInputRegex);
+      expect(match).not.toBeNull();
+      expect(match![2]).toBe('My alt');
+      expect(match![3]).toBe('https://example.com/input.png');
+      expect(match![4]).toBeUndefined();
+    });
+
+    it('regex matches ![alt](src "title")', () => {
+      const match = '![Photo](https://example.com/photo.jpg "My-title")'.match(imageInputRegex);
+      expect(match).not.toBeNull();
+      expect(match![2]).toBe('Photo');
+      expect(match![3]).toBe('https://example.com/photo.jpg');
+      expect(match![4]).toBe('My-title');
+    });
+
+    it('regex matches after whitespace', () => {
+      const match = 'some text ![img](https://example.com/a.png)'.match(imageInputRegex);
+      expect(match).not.toBeNull();
+      expect(match![3]).toBe('https://example.com/a.png');
+    });
+
+    it('regex does not match without !', () => {
+      const match = '[alt](https://example.com/a.png)'.match(imageInputRegex);
+      // Without !, this is a link syntax, not image
+      expect(match).toBeNull();
+    });
+
+    it('regex does not match without src', () => {
+      const match = '![alt]()'.match(imageInputRegex);
+      // \S+ requires at least one non-whitespace char in src
+      expect(match).toBeNull();
+    });
+
+    it('regex matches with single-quoted title', () => {
+      const match = "![alt](https://example.com/a.png 'title')".match(imageInputRegex);
+      expect(match).not.toBeNull();
+      expect(match![4]).toBe('title');
+    });
+  });
 });

--- a/packages/extension-image/src/Image.test.ts
+++ b/packages/extension-image/src/Image.test.ts
@@ -14,7 +14,7 @@ describe('Image', () => {
 
     it('belongs to block group by default', () => {
       expect(typeof Image.config.group).toBe('function');
-      const group = (Image.config.group as Function).call(Image);
+      const group = (Image.config.group as (...args: unknown[]) => unknown).call(Image);
       expect(group).toBe('block');
     });
 
@@ -394,18 +394,18 @@ describe('Image', () => {
 
     it('inline: true changes group to inline', () => {
       const InlineImage = Image.configure({ inline: true });
-      const group = (InlineImage.config.group as Function).call(InlineImage);
+      const group = (InlineImage.config.group as (...args: unknown[]) => unknown).call(InlineImage);
       expect(group).toBe('inline');
     });
 
     it('inline: true sets inline to true', () => {
       const InlineImage = Image.configure({ inline: true });
-      const inline = (InlineImage.config.inline as Function).call(InlineImage);
+      const inline = (InlineImage.config.inline as (...args: unknown[]) => unknown).call(InlineImage);
       expect(inline).toBe(true);
     });
 
     it('inline: false (default) keeps block group', () => {
-      const group = (Image.config.group as Function).call(Image);
+      const group = (Image.config.group as (...args: unknown[]) => unknown).call(Image);
       expect(group).toBe('block');
     });
 
@@ -470,7 +470,7 @@ describe('Image', () => {
     const imageInputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
 
     it('regex matches ![alt](src)', () => {
-      const match = '![My alt](https://example.com/input.png)'.match(imageInputRegex);
+      const match = imageInputRegex.exec('![My alt](https://example.com/input.png)');
       expect(match).not.toBeNull();
       expect(match![2]).toBe('My alt');
       expect(match![3]).toBe('https://example.com/input.png');
@@ -478,7 +478,7 @@ describe('Image', () => {
     });
 
     it('regex matches ![alt](src "title")', () => {
-      const match = '![Photo](https://example.com/photo.jpg "My-title")'.match(imageInputRegex);
+      const match = imageInputRegex.exec('![Photo](https://example.com/photo.jpg "My-title")');
       expect(match).not.toBeNull();
       expect(match![2]).toBe('Photo');
       expect(match![3]).toBe('https://example.com/photo.jpg');
@@ -486,25 +486,25 @@ describe('Image', () => {
     });
 
     it('regex matches after whitespace', () => {
-      const match = 'some text ![img](https://example.com/a.png)'.match(imageInputRegex);
+      const match = imageInputRegex.exec('some text ![img](https://example.com/a.png)');
       expect(match).not.toBeNull();
       expect(match![3]).toBe('https://example.com/a.png');
     });
 
     it('regex does not match without !', () => {
-      const match = '[alt](https://example.com/a.png)'.match(imageInputRegex);
+      const match = imageInputRegex.exec('[alt](https://example.com/a.png)');
       // Without !, this is a link syntax, not image
       expect(match).toBeNull();
     });
 
     it('regex does not match without src', () => {
-      const match = '![alt]()'.match(imageInputRegex);
+      const match = imageInputRegex.exec('![alt]()');
       // \S+ requires at least one non-whitespace char in src
       expect(match).toBeNull();
     });
 
     it('regex matches with single-quoted title', () => {
-      const match = "![alt](https://example.com/a.png 'title')".match(imageInputRegex);
+      const match = imageInputRegex.exec("![alt](https://example.com/a.png 'title')");
       expect(match).not.toBeNull();
       expect(match![4]).toBe('title');
     });

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -2,16 +2,17 @@
  * Image Node
  *
  * Block-level (default) or inline image element.
- * Supports src, alt, title, width, height attributes.
+ * Supports src, alt, title, width, height, loading, crossorigin attributes.
  *
  * Options:
  * - inline: false (default) — block-level image | true — inline image within paragraphs
  * - allowBase64: false (default) — only http/https URLs | true — also allow data:image/ URLs
  *
- * XSS Protection:
- * - Schema-level validation rejects javascript:, data: (unless allowBase64), and other dangerous URLs
- * - Only allows http://, https://, and optionally data:image/ URLs
- * - Double-checked in renderHTML as defense in depth
+ * XSS Protection (blocklist approach):
+ * - Blocks javascript:, vbscript:, file: protocols
+ * - Blocks data: URLs unless allowBase64 AND specifically data:image/
+ * - Allows http(s), relative paths, protocol-relative URLs
+ * - Defense in depth: validated in parseHTML, renderHTML, setImage command, and input rule
  */
 
 import { Node } from '@domternal/core';
@@ -28,6 +29,8 @@ export interface SetImageOptions {
   title?: string;
   width?: string | number;
   height?: string | number;
+  loading?: 'lazy' | 'eager';
+  crossorigin?: 'anonymous' | 'use-credentials';
 }
 
 declare module '@domternal/core' {
@@ -46,11 +49,16 @@ function isValidImageSrc(value: unknown, allowBase64: boolean): boolean {
   if (typeof value !== 'string') return false;
   if (value === '') return true; // empty string is valid
 
-  // Check for valid URL patterns
-  if (/^https?:\/\//i.test(value)) return true;
-  if (allowBase64 && /^data:image\//i.test(value)) return true;
+  // Block dangerous protocols
+  if (/^(javascript|vbscript|file):/i.test(value)) return false;
 
-  return false;
+  // Block data: URLs unless allowBase64 AND specifically data:image/
+  if (/^data:/i.test(value)) {
+    return allowBase64 && /^data:image\//i.test(value);
+  }
+
+  // Allow everything else: http(s), relative paths, protocol-relative, etc.
+  return true;
 }
 
 export interface ImageOptions {
@@ -136,6 +144,22 @@ export const Image = Node.create<ImageOptions>({
           return { height: attributes['height'] as string };
         },
       },
+      loading: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('loading'),
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes['loading']) return {};
+          return { loading: attributes['loading'] as string };
+        },
+      },
+      crossorigin: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('crossorigin'),
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes['crossorigin']) return {};
+          return { crossorigin: attributes['crossorigin'] as string };
+        },
+      },
     };
   },
 
@@ -161,7 +185,7 @@ export const Image = Node.create<ImageOptions>({
 
     return [
       new InputRule(
-        /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/,
+        /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["']([^"']+)["'])?\))$/,
         (state, match, start, end) => {
           const [fullMatch, wrapper, alt, src, title] = match;
           if (!src || !wrapper) return null;
@@ -188,21 +212,19 @@ export const Image = Node.create<ImageOptions>({
   },
 
   addCommands() {
-    const { name, options } = this;
     return {
       setImage:
         (attributes: SetImageOptions) =>
         ({ tr, dispatch }) => {
           // XSS protection: validate src URL before inserting
-          if (!isValidImageSrc(attributes.src, options.allowBase64)) {
+          if (!isValidImageSrc(attributes.src, this.options.allowBase64)) {
             return false;
           }
 
-          const nodeType = tr.doc.type.schema.nodes[name];
-          if (!nodeType) return false;
+          if (!this.nodeType) return false;
 
           if (dispatch) {
-            const node = nodeType.create(attributes);
+            const node = this.nodeType.create(attributes);
             tr.replaceSelectionWith(node);
             dispatch(tr);
           }

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -16,6 +16,7 @@
 
 import { Node } from '@domternal/core';
 import type { CommandSpec } from '@domternal/core';
+import { InputRule } from 'prosemirror-inputrules';
 
 /**
  * Typed options for the setImage command.
@@ -152,6 +153,38 @@ export const Image = Node.create<ImageOptions>({
     }
 
     return ['img', { ...this.options.HTMLAttributes, ...HTMLAttributes }];
+  },
+
+  addInputRules() {
+    const { nodeType, options } = this;
+    if (!nodeType) return [];
+
+    return [
+      new InputRule(
+        /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/,
+        (state, match, start, end) => {
+          const [fullMatch, wrapper, alt, src, title] = match;
+          if (!src || !wrapper) return null;
+
+          // XSS validation: reject dangerous URLs in markdown syntax too
+          if (!isValidImageSrc(src, options.allowBase64)) return null;
+
+          const { tr } = state;
+          const attrs: Record<string, unknown> = {
+            src,
+            alt: alt || null,
+            title: title || null,
+          };
+
+          // Adjust start for leading whitespace before ![
+          const offset = fullMatch!.length - wrapper.length;
+          const from = start + offset;
+
+          tr.replaceWith(from, end, nodeType.create(attrs));
+          return tr;
+        }
+      ),
+    ];
   },
 
   addCommands() {

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -18,6 +18,7 @@
 import { Node } from '@domternal/core';
 import type { CommandSpec } from '@domternal/core';
 import { InputRule } from 'prosemirror-inputrules';
+import { imageUploadPlugin } from './imageUploadPlugin.js';
 
 /**
  * Typed options for the setImage command.
@@ -41,8 +42,8 @@ declare module '@domternal/core' {
 
 /**
  * Validates image src URL for XSS protection.
- * Allows: http://, https://, and optionally data:image/
- * Blocks: javascript:, data: (non-image), vbscript:, file://, etc.
+ * Blocks: javascript:, vbscript:, file:, and data: (unless allowBase64 AND data:image/).
+ * Allows everything else: http(s), relative paths, protocol-relative URLs, etc.
  */
 function isValidImageSrc(value: unknown, allowBase64: boolean): boolean {
   if (value === null || value === undefined) return true; // null is valid (no src)
@@ -73,6 +74,26 @@ export interface ImageOptions {
    */
   allowBase64: boolean;
   HTMLAttributes: Record<string, unknown>;
+  /**
+   * Async function that uploads a file and returns the URL.
+   * When provided, enables paste/drop image upload.
+   * When null (default), paste/drop is not handled.
+   */
+  uploadHandler: ((file: File) => Promise<string>) | null;
+  /**
+   * Allowed MIME types for upload.
+   * @default ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml', 'image/avif']
+   */
+  allowedMimeTypes: string[];
+  /**
+   * Maximum file size in bytes. 0 = unlimited.
+   * @default 0
+   */
+  maxFileSize: number;
+  /**
+   * Called when upload fails. Receives the error and the file.
+   */
+  onUploadError: ((error: Error, file: File) => void) | null;
 }
 
 export const Image = Node.create<ImageOptions>({
@@ -91,6 +112,17 @@ export const Image = Node.create<ImageOptions>({
       inline: false,
       allowBase64: false,
       HTMLAttributes: {},
+      uploadHandler: null,
+      allowedMimeTypes: [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+        'image/avif',
+      ],
+      maxFileSize: 0,
+      onUploadError: null,
     };
   },
 
@@ -179,6 +211,10 @@ export const Image = Node.create<ImageOptions>({
     return ['img', { ...this.options.HTMLAttributes, ...HTMLAttributes }];
   },
 
+  leafText(node) {
+    return (node.attrs['alt'] as string | null) ?? '';
+  },
+
   addInputRules() {
     const { nodeType, options } = this;
     if (!nodeType) return [];
@@ -232,5 +268,19 @@ export const Image = Node.create<ImageOptions>({
           return true;
         },
     };
+  },
+
+  addProseMirrorPlugins() {
+    if (!this.options.uploadHandler || !this.nodeType) return [];
+
+    return [
+      imageUploadPlugin({
+        nodeType: this.nodeType,
+        uploadHandler: this.options.uploadHandler,
+        allowedMimeTypes: this.options.allowedMimeTypes,
+        maxFileSize: this.options.maxFileSize,
+        onUploadError: this.options.onUploadError,
+      }),
+    ];
   },
 });

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -13,9 +13,21 @@
 import { Node } from '@domternal/core';
 import type { CommandSpec } from '@domternal/core';
 
+/**
+ * Typed options for the setImage command.
+ * src is required — it makes no sense to insert an image without a source URL.
+ */
+export interface SetImageOptions {
+  src: string;
+  alt?: string;
+  title?: string;
+  width?: string | number;
+  height?: string | number;
+}
+
 declare module '@domternal/core' {
   interface RawCommands {
-    setImage: CommandSpec<[attributes?: Record<string, unknown>]>;
+    setImage: CommandSpec<[attributes: SetImageOptions]>;
   }
 }
 
@@ -131,10 +143,10 @@ export const Image = Node.create<ImageOptions>({
     const { name, options } = this;
     return {
       setImage:
-        (attributes?: Record<string, unknown>) =>
+        (attributes: SetImageOptions) =>
         ({ tr, dispatch }) => {
           // XSS protection: validate src URL before inserting
-          if (attributes?.['src'] && !isValidImageSrc(attributes['src'], options.allowBase64)) {
+          if (!isValidImageSrc(attributes.src, options.allowBase64)) {
             return false;
           }
 
@@ -142,7 +154,7 @@ export const Image = Node.create<ImageOptions>({
           if (!nodeType) return false;
 
           if (dispatch) {
-            const node = nodeType.create(attributes ?? {});
+            const node = nodeType.create(attributes);
             tr.replaceSelectionWith(node);
             dispatch(tr);
           }

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -2,7 +2,7 @@
  * Image Node
  *
  * Block-level (default) or inline image element.
- * Supports src, alt, title, width, height, loading, crossorigin attributes.
+ * Supports src, alt, title, width, height, loading, crossorigin, float attributes.
  *
  * Options:
  * - inline: false (default) — block-level image | true — inline image within paragraphs
@@ -20,6 +20,9 @@ import type { CommandSpec } from '@domternal/core';
 import { InputRule } from 'prosemirror-inputrules';
 import { imageUploadPlugin } from './imageUploadPlugin.js';
 
+/** Float values for image text wrapping. */
+export type ImageFloat = 'none' | 'left' | 'right' | 'center';
+
 /**
  * Typed options for the setImage command.
  * src is required — it makes no sense to insert an image without a source URL.
@@ -32,11 +35,13 @@ export interface SetImageOptions {
   height?: string | number;
   loading?: 'lazy' | 'eager';
   crossorigin?: 'anonymous' | 'use-credentials';
+  float?: ImageFloat;
 }
 
 declare module '@domternal/core' {
   interface RawCommands {
     setImage: CommandSpec<[attributes: SetImageOptions]>;
+    setImageFloat: CommandSpec<[float: ImageFloat]>;
   }
 }
 
@@ -197,6 +202,28 @@ export const Image = Node.create<ImageOptions>({
           return { crossorigin: attributes['crossorigin'] as string };
         },
       },
+      float: {
+        default: 'none',
+        parseHTML: (element: HTMLElement) => {
+          const style = element.style;
+          if (style.float === 'left') return 'left';
+          if (style.float === 'right') return 'right';
+          if (style.marginLeft === 'auto' && style.marginRight === 'auto') return 'center';
+          const align = element.getAttribute('align');
+          if (align === 'left') return 'left';
+          if (align === 'right') return 'right';
+          if (align === 'center' || align === 'middle') return 'center';
+          return 'none';
+        },
+        renderHTML: (attributes: Record<string, unknown>) => {
+          const float = attributes['float'] as string;
+          if (!float || float === 'none') return {};
+          if (float === 'left') return { style: 'float: left; margin: 0 1em 1em 0;' };
+          if (float === 'right') return { style: 'float: right; margin: 0 0 1em 1em;' };
+          if (float === 'center') return { style: 'display: block; margin-left: auto; margin-right: auto;' };
+          return {};
+        },
+      },
     };
   },
 
@@ -226,7 +253,7 @@ export const Image = Node.create<ImageOptions>({
 
     return [
       new InputRule(
-        /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["']([^"']+)["'])?\))$/,
+        /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'\u201C\u201D\u2018\u2019]([^"'\u201C\u201D\u2018\u2019]+)["'\u201C\u201D\u2018\u2019])?\))$/,
         (state, match, start, end) => {
           const [fullMatch, wrapper, alt, src, title] = match;
           if (!src || !wrapper) return null;
@@ -270,6 +297,25 @@ export const Image = Node.create<ImageOptions>({
             dispatch(tr);
           }
 
+          return true;
+        },
+
+      setImageFloat:
+        (float: ImageFloat) =>
+        ({ tr, state, dispatch }) => {
+          if (!['none', 'left', 'right', 'center'].includes(float)) return false;
+
+          const { selection } = state;
+          const node = state.doc.nodeAt(selection.from);
+          if (node?.type.name !== 'image') return false;
+
+          if (dispatch) {
+            tr.setNodeMarkup(selection.from, undefined, {
+              ...node.attrs,
+              float,
+            });
+            dispatch(tr);
+          }
           return true;
         },
     };

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -172,12 +172,12 @@ export const Image = Node.create<ImageOptions>({
           const { tr } = state;
           const attrs: Record<string, unknown> = {
             src,
-            alt: alt || null,
-            title: title || null,
+            alt: alt ?? null,
+            title: title ?? null,
           };
 
           // Adjust start for leading whitespace before ![
-          const offset = fullMatch!.length - wrapper.length;
+          const offset = fullMatch.length - wrapper.length;
           const from = start + offset;
 
           tr.replaceWith(from, end, nodeType.create(attrs));

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -91,6 +91,10 @@ export interface ImageOptions {
    */
   maxFileSize: number;
   /**
+   * Called when upload starts for a file.
+   */
+  onUploadStart: ((file: File) => void) | null;
+  /**
    * Called when upload fails. Receives the error and the file.
    */
   onUploadError: ((error: Error, file: File) => void) | null;
@@ -122,6 +126,7 @@ export const Image = Node.create<ImageOptions>({
         'image/avif',
       ],
       maxFileSize: 0,
+      onUploadStart: null,
       onUploadError: null,
     };
   },
@@ -279,6 +284,7 @@ export const Image = Node.create<ImageOptions>({
         uploadHandler: this.options.uploadHandler,
         allowedMimeTypes: this.options.allowedMimeTypes,
         maxFileSize: this.options.maxFileSize,
+        onUploadStart: this.options.onUploadStart,
         onUploadError: this.options.onUploadError,
       }),
     ];

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -1,8 +1,12 @@
 /**
  * Image Node
  *
- * Block-level image element.
+ * Block-level (default) or inline image element.
  * Supports src, alt, title, width, height attributes.
+ *
+ * Options:
+ * - inline: false (default) — block-level image | true — inline image within paragraphs
+ * - allowBase64: false (default) — only http/https URLs | true — also allow data:image/ URLs
  *
  * XSS Protection:
  * - Schema-level validation rejects javascript:, data: (unless allowBase64), and other dangerous URLs
@@ -50,6 +54,11 @@ function isValidImageSrc(value: unknown, allowBase64: boolean): boolean {
 
 export interface ImageOptions {
   /**
+   * Whether images are inline (within paragraphs) or block-level (default: false)
+   * When true, images can appear alongside text within a paragraph.
+   */
+  inline: boolean;
+  /**
    * Allow base64 data:image/ URLs (default: false)
    * When false, only http:// and https:// URLs are allowed
    */
@@ -59,12 +68,18 @@ export interface ImageOptions {
 
 export const Image = Node.create<ImageOptions>({
   name: 'image',
-  group: 'block',
+  group() {
+    return this.options.inline ? 'inline' : 'block';
+  },
+  inline() {
+    return this.options.inline;
+  },
   draggable: true,
   atom: true,
 
   addOptions() {
     return {
+      inline: false,
       allowBase64: false,
       HTMLAttributes: {},
     };

--- a/packages/extension-image/src/imageUploadPlugin.ts
+++ b/packages/extension-image/src/imageUploadPlugin.ts
@@ -1,0 +1,211 @@
+/**
+ * Image Upload Plugin
+ *
+ * Handles paste/drop of image files with decoration-based placeholders.
+ * The document never contains temporary data — a widget decoration shows
+ * a loading indicator while the upload is in progress.
+ *
+ * On success: placeholder removed, real image node inserted.
+ * On error: placeholder removed, onUploadError called.
+ */
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import type { EditorView } from 'prosemirror-view';
+import type { NodeType } from 'prosemirror-model';
+
+export const imageUploadPluginKey = new PluginKey('imageUpload');
+
+export interface ImageUploadPluginOptions {
+  /** The image node type from schema */
+  nodeType: NodeType;
+  /** Upload handler — must return URL string */
+  uploadHandler: (file: File) => Promise<string>;
+  /** Allowed MIME types */
+  allowedMimeTypes: string[];
+  /** Max file size in bytes (0 = unlimited) */
+  maxFileSize: number;
+  /** Error callback */
+  onUploadError: ((error: Error, file: File) => void) | null;
+}
+
+/** Validate file before upload */
+function isValidImageFile(
+  file: File,
+  allowedMimeTypes: string[],
+  maxFileSize: number,
+): boolean {
+  if (!allowedMimeTypes.includes(file.type)) return false;
+  if (maxFileSize > 0 && file.size > maxFileSize) return false;
+  return true;
+}
+
+/** Generate unique placeholder ID */
+let placeholderCounter = 0;
+function createPlaceholderId(): string {
+  return `image-upload-${String(++placeholderCounter)}`;
+}
+
+/** Reset placeholder counter (for testing) */
+export function _resetPlaceholderCounter(): void {
+  placeholderCounter = 0;
+}
+
+/** Create placeholder DOM element */
+function createPlaceholderElement(): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'domternal-image-uploading';
+  return div;
+}
+
+export function imageUploadPlugin(options: ImageUploadPluginOptions): Plugin {
+  const {
+    nodeType,
+    uploadHandler,
+    allowedMimeTypes,
+    maxFileSize,
+    onUploadError,
+  } = options;
+
+  function handleFiles(view: EditorView, files: File[], pos: number): void {
+    for (const file of files) {
+      const id = createPlaceholderId();
+
+      // Add placeholder decoration
+      const tr = view.state.tr;
+      tr.setMeta(imageUploadPluginKey, { type: 'add', id, pos });
+      view.dispatch(tr);
+
+      // Start upload
+      uploadHandler(file)
+        .then((url) => {
+          // Find placeholder position (may have shifted due to edits)
+          const decos = imageUploadPluginKey.getState(
+            view.state,
+          ) as DecorationSet | null;
+          const found = decos?.find(
+            undefined,
+            undefined,
+            (spec: Record<string, unknown>) => spec['id'] === id,
+          );
+          const placeholderPos = found?.[0]?.from;
+
+          if (placeholderPos === undefined) return; // placeholder was removed (editor destroyed?)
+
+          // Remove placeholder + insert image node
+          const insertTr = view.state.tr;
+          insertTr.setMeta(imageUploadPluginKey, { type: 'remove', id });
+          insertTr.insert(placeholderPos, nodeType.create({ src: url }));
+          view.dispatch(insertTr);
+        })
+        .catch((error: unknown) => {
+          // Remove placeholder on error
+          const removeTr = view.state.tr;
+          removeTr.setMeta(imageUploadPluginKey, { type: 'remove', id });
+          view.dispatch(removeTr);
+
+          if (onUploadError) {
+            onUploadError(
+              error instanceof Error ? error : new Error(String(error)),
+              file,
+            );
+          }
+        });
+    }
+  }
+
+  return new Plugin({
+    key: imageUploadPluginKey,
+
+    state: {
+      init() {
+        return DecorationSet.empty;
+      },
+      apply(tr, decorations) {
+        // Map decorations through document changes
+        decorations = decorations.map(tr.mapping, tr.doc);
+
+        const action = tr.getMeta(imageUploadPluginKey) as
+          | { type: 'add'; id: string; pos: number }
+          | { type: 'remove'; id: string }
+          | undefined;
+
+        if (action?.type === 'add') {
+          const widget = Decoration.widget(
+            action.pos,
+            createPlaceholderElement(),
+            { id: action.id },
+          );
+          return decorations.add(tr.doc, [widget]);
+        }
+
+        if (action?.type === 'remove') {
+          const found = decorations.find(
+            undefined,
+            undefined,
+            (spec: Record<string, unknown>) => spec['id'] === action.id,
+          );
+          return decorations.remove(found);
+        }
+
+        return decorations;
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return imageUploadPluginKey.getState(state) as DecorationSet;
+      },
+
+      handlePaste(view, event) {
+        const items = event.clipboardData?.items;
+        if (!items) return false;
+
+        const files: File[] = [];
+        for (const item of Array.from(items)) {
+          if (item.kind === 'file') {
+            const file = item.getAsFile();
+            if (
+              file &&
+              isValidImageFile(file, allowedMimeTypes, maxFileSize)
+            ) {
+              files.push(file);
+            }
+          }
+        }
+
+        if (files.length === 0) return false;
+
+        event.preventDefault();
+        handleFiles(view, files, view.state.selection.from);
+        return true;
+      },
+
+      handleDrop(view, event) {
+        const dataTransfer = event.dataTransfer;
+        if (!dataTransfer?.files || dataTransfer.files.length === 0)
+          return false;
+
+        const imageFiles: File[] = [];
+        for (const file of Array.from(dataTransfer.files)) {
+          if (isValidImageFile(file, allowedMimeTypes, maxFileSize)) {
+            imageFiles.push(file);
+          }
+        }
+
+        if (imageFiles.length === 0) return false;
+
+        event.preventDefault();
+
+        // Get drop position
+        const pos = view.posAtCoords({
+          left: event.clientX,
+          top: event.clientY,
+        });
+        if (!pos) return false;
+
+        handleFiles(view, imageFiles, pos.pos);
+        return true;
+      },
+    },
+  });
+}

--- a/packages/extension-image/src/imageUploadPlugin.ts
+++ b/packages/extension-image/src/imageUploadPlugin.ts
@@ -24,6 +24,8 @@ export interface ImageUploadPluginOptions {
   allowedMimeTypes: string[];
   /** Max file size in bytes (0 = unlimited) */
   maxFileSize: number;
+  /** Called when upload starts for a file */
+  onUploadStart: ((file: File) => void) | null;
   /** Error callback */
   onUploadError: ((error: Error, file: File) => void) | null;
 }
@@ -63,6 +65,7 @@ export function imageUploadPlugin(options: ImageUploadPluginOptions): Plugin {
     uploadHandler,
     allowedMimeTypes,
     maxFileSize,
+    onUploadStart,
     onUploadError,
   } = options;
 
@@ -74,6 +77,8 @@ export function imageUploadPlugin(options: ImageUploadPluginOptions): Plugin {
       const tr = view.state.tr;
       tr.setMeta(imageUploadPluginKey, { type: 'add', id, pos });
       view.dispatch(tr);
+
+      if (onUploadStart) onUploadStart(file);
 
       // Start upload
       uploadHandler(file)

--- a/packages/extension-image/src/index.ts
+++ b/packages/extension-image/src/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { Image, type ImageOptions, type SetImageOptions } from './Image.js';
+export { imageUploadPluginKey } from './imageUploadPlugin.js';

--- a/packages/extension-image/src/index.ts
+++ b/packages/extension-image/src/index.ts
@@ -3,4 +3,4 @@
  * Image node extension for Domternal editor
  */
 
-export { Image, type ImageOptions } from './Image.js';
+export { Image, type ImageOptions, type SetImageOptions } from './Image.js';

--- a/packages/extension-image/src/index.ts
+++ b/packages/extension-image/src/index.ts
@@ -3,5 +3,5 @@
  * Image node extension for Domternal editor
  */
 
-export { Image, type ImageOptions, type SetImageOptions } from './Image.js';
+export { Image, type ImageOptions, type SetImageOptions, type ImageFloat } from './Image.js';
 export { imageUploadPluginKey } from './imageUploadPlugin.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,109 +51,6 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(jsdom@27.4.0)(yaml@2.8.2)
 
-  demo:
-    dependencies:
-      '@tiptap/core':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-bubble-menu':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-character-count':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-code-block-lowlight':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(highlight.js@11.11.1)(lowlight@3.3.0)
-      '@tiptap/extension-color':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
-      '@tiptap/extension-details':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-details-content':
-        specifier: ^2.26.2
-        version: 2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
-      '@tiptap/extension-details-summary':
-        specifier: ^2.26.2
-        version: 2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
-      '@tiptap/extension-emoji':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(emojibase@17.0.0)
-      '@tiptap/extension-floating-menu':
-        specifier: ^3.19.0
-        version: 3.19.0(@floating-ui/dom@1.7.5)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-focus':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-font-family':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
-      '@tiptap/extension-highlight':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-image':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-link':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-mention':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-placeholder':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-subscript':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-superscript':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-task-item':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-task-list':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-text-align':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-text-style':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-typography':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-underline':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/pm':
-        specifier: ^3.19.0
-        version: 3.19.0
-      '@tiptap/starter-kit':
-        specifier: ^3.19.0
-        version: 3.19.0
-      '@tiptap/suggestion':
-        specifier: ^3.19.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      highlight.js:
-        specifier: ^11.11.1
-        version: 11.11.1
-      lowlight:
-        specifier: ^3.3.0
-        version: 3.3.0
-    devDependencies:
-      '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
-      typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
-      vite:
-        specifier: ^6.1.0
-        version: 6.4.1(yaml@2.8.2)
-
   packages/core:
     dependencies:
       linkifyjs:
@@ -304,6 +201,9 @@ importers:
       '@domternal/core':
         specifier: workspace:*
         version: link:../core
+      prosemirror-inputrules:
+        specifier: ^1.5.1
+        version: 1.5.1
     devDependencies:
       jsdom:
         specifier: ^27.4.0
@@ -936,34 +836,16 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -972,34 +854,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -1008,22 +872,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -1032,22 +884,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -1056,22 +896,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -1080,22 +908,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -1104,22 +920,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -1128,34 +932,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -1164,22 +950,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -1188,23 +962,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -1212,34 +974,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -1294,15 +1038,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@floating-ui/core@1.7.4':
-    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
-
-  '@floating-ui/dom@1.7.5':
-    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
-
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1519,11 +1254,6 @@ packages:
     resolution: {integrity: sha512-bFuJRKOscsDAEZ/a8BezcTMAe2BQ/OBRfuMLFUuINfTR5qGVcm4a3xBIrQVepBaPxFj16SJdRjGe05vDiwZmFw==}
     cpu: [x64]
     os: [win32]
-
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
@@ -1753,265 +1483,6 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
-  '@tiptap/core@3.19.0':
-    resolution: {integrity: sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==}
-    peerDependencies:
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-blockquote@3.19.0':
-    resolution: {integrity: sha512-y3UfqY9KD5XwWz3ndiiJ089Ij2QKeiXy/g1/tlAN/F1AaWsnkHEHMLxCP1BIqmMpwsX7rZjMLN7G5Lp7c9682A==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-bold@3.19.0':
-    resolution: {integrity: sha512-UZgb1d0XK4J/JRIZ7jW+s4S6KjuEDT2z1PPM6ugcgofgJkWQvRZelCPbmtSFd3kwsD+zr9UPVgTh9YIuGQ8t+Q==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-bubble-menu@3.19.0':
-    resolution: {integrity: sha512-klNVIYGCdznhFkrRokzGd6cwzoi8J7E5KbuOfZBwFwhMKZhlz/gJfKmYg9TJopeUhrr2Z9yHgWTk8dh/YIJCdQ==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-bullet-list@3.19.0':
-    resolution: {integrity: sha512-F9uNnqd0xkJbMmRxVI5RuVxwB9JaCH/xtRqOUNQZnRBt7IdAElCY+Dvb4hMCtiNv+enGM/RFGJuFHR9TxmI7rw==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-character-count@3.19.0':
-    resolution: {integrity: sha512-ElmlJkSD2tx7f2Hw12qQu4PD8GHfOQfY999EbJENQBtaz+uszUE19Grc1GNs5X+0T757OprM1A9EBPnMX667WQ==}
-    peerDependencies:
-      '@tiptap/extensions': ^3.19.0
-
-  '@tiptap/extension-code-block-lowlight@3.19.0':
-    resolution: {integrity: sha512-P8O8i1J+XozEVA7bF/Ijwf/r1rVqrh1DBQ7dXxBcrUvLpIGyVjtxX228jBF/kD4kf2xOlphvjDhV2fLa8XOVsg==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/extension-code-block': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-      highlight.js: ^11
-      lowlight: ^2 || ^3
-
-  '@tiptap/extension-code-block@3.19.0':
-    resolution: {integrity: sha512-b/2qR+tMn8MQb+eaFYgVk4qXnLNkkRYmwELQ8LEtEDQPxa5Vl7J3eu8+4OyoIFhZrNDZvvoEp80kHMCP8sI6rg==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-code@3.19.0':
-    resolution: {integrity: sha512-2kqqQIXBXj2Or+4qeY3WoE7msK+XaHKL6EKOcKlOP2BW8eYqNTPzNSL+PfBDQ3snA7ljZQkTs/j4GYDj90vR1A==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-color@3.19.0':
-    resolution: {integrity: sha512-SemOrEEnmbKshhbTeKIvffwMlgqDAUDuOYyizfKqYM2dd5fRjohp+oszExO7scVhDtHtvtP/l3UmkBGBYfl4Tg==}
-    peerDependencies:
-      '@tiptap/extension-text-style': ^3.19.0
-
-  '@tiptap/extension-details-content@2.26.2':
-    resolution: {integrity: sha512-2Ia2KqwYucuv7dcTpA/PhytUuDhotzi8uZPXBHlGJLHVI9rAmJsSvID9cX/YWRTvCvAxyNqDp0sBH+Qx8QcloQ==}
-    peerDependencies:
-      '@tiptap/core': ^2.7.0
-      '@tiptap/extension-text-style': ^2.7.0
-
-  '@tiptap/extension-details-summary@2.26.2':
-    resolution: {integrity: sha512-rbRq6f56HKvzIuSpPHt513Ubglq728pz8Jx7WBRVqjpYF5/sTpYu9hZpbrIfLfjb2UakXI/LVU8vS50VwTwCnw==}
-    peerDependencies:
-      '@tiptap/core': ^2.7.0
-      '@tiptap/extension-text-style': ^2.7.0
-
-  '@tiptap/extension-details@3.19.0':
-    resolution: {integrity: sha512-BUc9N8UVl/orzXoDSh9YCB+G1csNDAKm4EeKAQpGotbgv32nnTPKv50BvPx+a5pZfVQHaiJlb98Xmi7dMZs1Ug==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/extension-text-style': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-document@3.19.0':
-    resolution: {integrity: sha512-AOf0kHKSFO0ymjVgYSYDncRXTITdTcrj1tqxVazrmO60KNl1Rc2dAggDvIVTEBy5NvceF0scc7q3sE/5ZtVV7A==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-dropcursor@3.19.0':
-    resolution: {integrity: sha512-sf3dEZXiLvsGqVK2maUIzXY6qtYYCvBumag7+VPTMGQ0D4hiZ1X/4ukt4+6VXDg5R2WP1CoIt/QvUetUjWNhbQ==}
-    peerDependencies:
-      '@tiptap/extensions': ^3.19.0
-
-  '@tiptap/extension-emoji@3.19.0':
-    resolution: {integrity: sha512-sMpMUuVKaMqmOdIwFotuRSIw5LgBSECSQJKdC6HUUlETvtcRkUgf6SmrKefixXyir2CQPbA3ioDZTNTI2rs1Wg==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-      '@tiptap/suggestion': ^3.19.0
-
-  '@tiptap/extension-floating-menu@3.19.0':
-    resolution: {integrity: sha512-JaoEkVRkt+Slq3tySlIsxnMnCjS0L5n1CA1hctjLy0iah8edetj3XD5mVv5iKqDzE+LIjF4nwLRRVKJPc8hFBg==}
-    peerDependencies:
-      '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-focus@3.19.0':
-    resolution: {integrity: sha512-XARmebegMrRvrvGPICJVJr1D6MOry8FbsaCKfI2t7C/WqE5dofe+uoiCrOAz9Uz0DMYHGGYZtr2GDM6FKIdPGw==}
-    peerDependencies:
-      '@tiptap/extensions': ^3.19.0
-
-  '@tiptap/extension-font-family@3.19.0':
-    resolution: {integrity: sha512-sUMvgETZkhEUts7arczK+mBz2wnokgGCf3TxRwR2Wy6cx4f9+TTAPT+pm0a7GAvPfra6OzoCWnkcVDVcTJA9/Q==}
-    peerDependencies:
-      '@tiptap/extension-text-style': ^3.19.0
-
-  '@tiptap/extension-gapcursor@3.19.0':
-    resolution: {integrity: sha512-w7DACS4oSZaDWjz7gropZHPc9oXqC9yERZTcjWxyORuuIh1JFf0TRYspleK+OK28plK/IftojD/yUDn1MTRhvA==}
-    peerDependencies:
-      '@tiptap/extensions': ^3.19.0
-
-  '@tiptap/extension-hard-break@3.19.0':
-    resolution: {integrity: sha512-lAmQraYhPS5hafvCl74xDB5+bLuNwBKIEsVoim35I0sDJj5nTrfhaZgMJ91VamMvT+6FF5f1dvBlxBxAWa8jew==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-heading@3.19.0':
-    resolution: {integrity: sha512-uLpLlfyp086WYNOc0ekm1gIZNlEDfmzOhKzB0Hbyi6jDagTS+p9mxUNYeYOn9jPUxpFov43+Wm/4E24oY6B+TQ==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-highlight@3.19.0':
-    resolution: {integrity: sha512-MYwSDCh/aG12KXw30XmHwrruElBRB8b7Ou0jd8n8H2oXb+QexVqnMa2+ylkuTAl+2D5PR7zdIIOeeHRSTmkPPw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-horizontal-rule@3.19.0':
-    resolution: {integrity: sha512-iqUHmgMGhMgYGwG6L/4JdelVQ5Mstb4qHcgTGd/4dkcUOepILvhdxajPle7OEdf9sRgjQO6uoAU5BVZVC26+ng==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-image@3.19.0':
-    resolution: {integrity: sha512-/rGl8nBziBPVJJ/9639eQWFDKcI3RQsDM3s+cqYQMFQfMqc7sQB9h4o4sHCBpmKxk3Y0FV/0NjnjLbBVm8OKdQ==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-italic@3.19.0':
-    resolution: {integrity: sha512-6GffxOnS/tWyCbDkirWNZITiXRta9wrCmrfa4rh+v32wfaOL1RRQNyqo9qN6Wjyl1R42Js+yXTzTTzZsOaLMYA==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-link@3.19.0':
-    resolution: {integrity: sha512-HEGDJnnCPfr7KWu7Dsq+eRRe/mBCsv6DuI+7fhOCLDJjjKzNgrX2abbo/zG3D/4lCVFaVb+qawgJubgqXR/Smw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-list-item@3.19.0':
-    resolution: {integrity: sha512-VsSKuJz4/Tb6ZmFkXqWpDYkRzmaLTyE6dNSEpNmUpmZ32sMqo58mt11/huADNwfBFB0Ve7siH/VnFNIJYY3xvg==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-list-keymap@3.19.0':
-    resolution: {integrity: sha512-bxgmAgA3RzBGA0GyTwS2CC1c+QjkJJq9hC+S6PSOWELGRiTbwDN3MANksFXLjntkTa0N5fOnL27vBHtMStURqw==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-list@3.19.0':
-    resolution: {integrity: sha512-N6nKbFB2VwMsPlCw67RlAtYSK48TAsAUgjnD+vd3ieSlIufdQnLXDFUP6hFKx9mwoUVUgZGz02RA6bkxOdYyTw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-mention@3.19.0':
-    resolution: {integrity: sha512-iBWX6mUouvDe9F75C2fJnFzvBFYVF8fcOa7UvzqWHRSCt8WxqSIp6C1B9Y0npP4TbIZySHzPV4NQQJhtmWwKww==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-      '@tiptap/suggestion': ^3.19.0
-
-  '@tiptap/extension-ordered-list@3.19.0':
-    resolution: {integrity: sha512-cxGsINquwHYE1kmhAcLNLHAofmoDEG6jbesR5ybl7tU5JwtKVO7S/xZatll2DU1dsDAXWPWEeeMl4e/9svYjCg==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-paragraph@3.19.0':
-    resolution: {integrity: sha512-xWa6gj82l5+AzdYyrSk9P4ynySaDzg/SlR1FarXE5yPXibYzpS95IWaVR0m2Qaz7Rrk+IiYOTGxGRxcHLOelNg==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-placeholder@3.19.0':
-    resolution: {integrity: sha512-i15OfgyI4IDCYAcYSKUMnuZkYuUInfanjf9zquH8J2BETiomf/jZldVCp/QycMJ8DOXZ38fXDc99wOygnSNySg==}
-    peerDependencies:
-      '@tiptap/extensions': ^3.19.0
-
-  '@tiptap/extension-strike@3.19.0':
-    resolution: {integrity: sha512-xYpabHsv7PccLUBQaP8AYiFCnYbx6P93RHPd0lgNwhdOjYFd931Zy38RyoxPHAgbYVmhf1iyx7lpuLtBnhS5dA==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-subscript@3.19.0':
-    resolution: {integrity: sha512-RchUOSIDprlnuzmA/znZIBKMONIlCAXHuR6XkoNX2jFJ/9OHk/si+jEeY8jJfpPDpVqZ3KrwS/zJrqhU/pT+hQ==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-superscript@3.19.0':
-    resolution: {integrity: sha512-PjLUGjM23/7hqFP5HS1DbdywRm63GhjJ5SD6KqNgyZQwcwDZeJTAW2b/LYTHAP+k07OxOLPdj/k4ntQKtgKNow==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/extension-task-item@3.19.0':
-    resolution: {integrity: sha512-1il70SoaoEA5jKr2QS30CpZoB7EzdSLugROMBPRUPc0feIBKAf6yUPhxlFyU4ez/uT4Pazsf1HAgHI3AOr+MtQ==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-task-list@3.19.0':
-    resolution: {integrity: sha512-Slb6YZi7XpVT966oAJhqzZu4LVuHtUeZgMxA0bdc8FSZBxntcr8OQWmPbqvR437RAR/Xd7b5quXS3JmSeksyvA==}
-    peerDependencies:
-      '@tiptap/extension-list': ^3.19.0
-
-  '@tiptap/extension-text-align@3.19.0':
-    resolution: {integrity: sha512-cY8bHWYojLTHXZb2j2srdh7ltmDgnwXYvSxbPL4HK4j7XxQOGnOsTakgM/BNhxymOfEj2414i5Otyy8hlgviFA==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-text-style@3.19.0':
-    resolution: {integrity: sha512-R55V6iUfRq03SGt/R2KvaeN+XGFiKJHx1jFJhZzvnWhMV7YqjHSG2r4BLvpTq1HBqteMbEjI+EOnb4t9AKd6aQ==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-text@3.19.0':
-    resolution: {integrity: sha512-K95+SnbZy0h6hNFtfy23n8t/nOcTFEf69In9TSFVVmwn/Nwlke+IfiESAkqbt1/7sKJeegRXYO7WzFEmFl9Q/g==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-typography@3.19.0':
-    resolution: {integrity: sha512-2Rwwz1ErNhqUcXPzPX2u4frdyrK4Yj6ZMvCLPxLt5lQXj9Eq9YEoD9isw8abR105ko3BCidvfElQYSFu6dWPSw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extension-underline@3.19.0':
-    resolution: {integrity: sha512-800MGEWfG49j10wQzAFiW/ele1HT04MamcL8iyuPNu7ZbjbGN2yknvdrJlRy7hZlzIrVkZMr/1tz62KN33VHIw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-
-  '@tiptap/extensions@3.19.0':
-    resolution: {integrity: sha512-ZmGUhLbMWaGqnJh2Bry+6V4M6gMpUDYo4D1xNux5Gng/E/eYtc+PMxMZ/6F7tNTAuujLBOQKj6D+4SsSm457jw==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
-  '@tiptap/pm@3.19.0':
-    resolution: {integrity: sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==}
-
-  '@tiptap/starter-kit@3.19.0':
-    resolution: {integrity: sha512-dTCkHEz+Y8ADxX7h+xvl6caAj+3nII/wMB1rTQchSuNKqJTOrzyUsCWm094+IoZmLT738wANE0fRIgziNHs/ug==}
-
-  '@tiptap/suggestion@3.19.0':
-    resolution: {integrity: sha512-tUZwMRFqTVPIo566ZmHNRteyZxJy2EE4FA+S3IeIUOOvY6AW0h1imhbpBO7sXV8CeEQvpa+2DWwLvy7L3vmstA==}
-    peerDependencies:
-      '@tiptap/core': ^3.19.0
-      '@tiptap/pm': ^3.19.0
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -2033,17 +1504,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/linkify-it@5.0.0':
-    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
-
-  '@types/markdown-it@14.1.2':
-    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
-  '@types/mdurl@2.0.0':
-    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2396,9 +1858,6 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
-  crelt@1.0.6:
-    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2496,20 +1955,8 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emojibase-data@15.3.2:
-    resolution: {integrity: sha512-TpDyTDDTdqWIJixV5sTA6OQ0P0JfIIeK2tFRR3q56G9LK65ylAZ7z3KyBXokpvTTJ+mLUXQXbLNyVkjvnTLE+A==}
-    peerDependencies:
-      emojibase: '*'
-
-  emojibase@17.0.0:
-    resolution: {integrity: sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==}
-    engines: {node: '>=18.12.0'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2551,11 +1998,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -2694,11 +2136,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2822,9 +2259,6 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
-
-  is-emoji-supported@0.0.5:
-    resolution: {integrity: sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2956,9 +2390,6 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
-
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
@@ -3000,10 +2431,6 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
-    hasBin: true
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3013,9 +2440,6 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
-
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -3191,16 +2615,6 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -3239,12 +2653,6 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  prosemirror-changeset@2.4.0:
-    resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
-
-  prosemirror-collab@1.3.1:
-    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
-
   prosemirror-commands@1.7.1:
     resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
@@ -3263,17 +2671,8 @@ packages:
   prosemirror-keymap@1.2.3:
     resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
 
-  prosemirror-markdown@1.13.4:
-    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
-
-  prosemirror-menu@1.2.5:
-    resolution: {integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==}
-
   prosemirror-model@1.25.4:
     resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
-
-  prosemirror-schema-basic@1.2.4:
-    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
 
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
@@ -3299,10 +2698,6 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  punycode.js@2.3.1:
-    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3578,9 +2973,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uc.micro@2.1.0:
-    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
-
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -3635,46 +3027,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -4618,157 +3970,79 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
   '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
   '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -4821,17 +4095,6 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.9.0': {}
-
-  '@floating-ui/core@1.7.4':
-    dependencies:
-      '@floating-ui/utils': 0.2.10
-
-  '@floating-ui/dom@1.7.5':
-    dependencies:
-      '@floating-ui/core': 1.7.4
-      '@floating-ui/utils': 0.2.10
-
-  '@floating-ui/utils@0.2.10': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5039,10 +4302,6 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.16.3':
     optional: true
 
-  '@playwright/test@1.58.2':
-    dependencies:
-      playwright: 1.58.2
-
   '@remirror/core-constants@3.0.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
@@ -5206,268 +4465,6 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tiptap/core@3.19.0(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-blockquote@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-bold@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-bubble-menu@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@floating-ui/dom': 1.7.5
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-bullet-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-character-count@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-code-block-lowlight@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(highlight.js@11.11.1)(lowlight@3.3.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-code-block': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-      highlight.js: 11.11.1
-      lowlight: 3.3.0
-
-  '@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-code@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-color@3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
-    dependencies:
-      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-
-  '@tiptap/extension-details-content@2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-
-  '@tiptap/extension-details-summary@2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-
-  '@tiptap/extension-details@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-document@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-dropcursor@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-emoji@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(emojibase@17.0.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      emoji-regex: 10.6.0
-      emojibase-data: 15.3.2(emojibase@17.0.0)
-      is-emoji-supported: 0.0.5
-    transitivePeerDependencies:
-      - emojibase
-
-  '@tiptap/extension-floating-menu@3.19.0(@floating-ui/dom@1.7.5)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@floating-ui/dom': 1.7.5
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-focus@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-font-family@3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
-    dependencies:
-      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-
-  '@tiptap/extension-gapcursor@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-hard-break@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-heading@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-highlight@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-horizontal-rule@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-image@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-italic@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-link@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-      linkifyjs: 4.3.2
-
-  '@tiptap/extension-list-item@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-list-keymap@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-mention@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-ordered-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-paragraph@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-placeholder@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-strike@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-subscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-superscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/extension-task-item@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-task-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-text-align@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-text@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-typography@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extension-underline@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-
-  '@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/pm@3.19.0':
-    dependencies:
-      prosemirror-changeset: 2.4.0
-      prosemirror-collab: 1.3.1
-      prosemirror-commands: 1.7.1
-      prosemirror-dropcursor: 1.8.2
-      prosemirror-gapcursor: 1.4.0
-      prosemirror-history: 1.5.0
-      prosemirror-inputrules: 1.5.1
-      prosemirror-keymap: 1.2.3
-      prosemirror-markdown: 1.13.4
-      prosemirror-menu: 1.2.5
-      prosemirror-model: 1.25.4
-      prosemirror-schema-basic: 1.2.4
-      prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.4
-      prosemirror-tables: 1.8.5
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)
-      prosemirror-transform: 1.10.5
-      prosemirror-view: 1.41.5
-
-  '@tiptap/starter-kit@3.19.0':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/extension-blockquote': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-bold': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-bullet-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-code': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-code-block': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-document': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-dropcursor': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-gapcursor': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-hard-break': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-heading': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-horizontal-rule': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-italic': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-link': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-list-item': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-list-keymap': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-ordered-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-paragraph': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-strike': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-text': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extension-underline': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
-      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
-  '@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
-    dependencies:
-      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
-      '@tiptap/pm': 3.19.0
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -5492,18 +4489,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/linkify-it@5.0.0': {}
-
-  '@types/markdown-it@14.1.2':
-    dependencies:
-      '@types/linkify-it': 5.0.0
-      '@types/mdurl': 2.0.0
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/mdurl@2.0.0': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -5897,8 +4885,6 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  crelt@1.0.6: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5999,15 +4985,7 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
-
-  emojibase-data@15.3.2(emojibase@17.0.0):
-    dependencies:
-      emojibase: 17.0.0
-
-  emojibase@17.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6043,35 +5021,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -6240,9 +5189,6 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fsevents@2.3.2:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
 
@@ -6367,8 +5313,6 @@ snapshots:
       hasown: 2.0.2
 
   is-docker@2.2.1: {}
-
-  is-emoji-supported@0.0.5: {}
 
   is-extglob@2.1.1: {}
 
@@ -6496,10 +5440,6 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.0:
-    dependencies:
-      uc.micro: 2.1.0
-
   linkifyjs@4.3.2: {}
 
   load-tsconfig@0.2.5: {}
@@ -6543,15 +5483,6 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  markdown-it@14.1.1:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.0
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.1:
@@ -6567,8 +5498,6 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.12.2: {}
-
-  mdurl@2.0.0: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -6807,14 +5736,6 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
-
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
-
   postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
@@ -6839,14 +5760,6 @@ snapshots:
       react-is: 18.3.1
 
   property-information@7.1.0: {}
-
-  prosemirror-changeset@2.4.0:
-    dependencies:
-      prosemirror-transform: 1.10.5
-
-  prosemirror-collab@1.3.1:
-    dependencies:
-      prosemirror-state: 1.4.4
 
   prosemirror-commands@1.7.1:
     dependencies:
@@ -6884,26 +5797,9 @@ snapshots:
       prosemirror-state: 1.4.4
       w3c-keyname: 2.2.8
 
-  prosemirror-markdown@1.13.4:
-    dependencies:
-      '@types/markdown-it': 14.1.2
-      markdown-it: 14.1.1
-      prosemirror-model: 1.25.4
-
-  prosemirror-menu@1.2.5:
-    dependencies:
-      crelt: 1.0.6
-      prosemirror-commands: 1.7.1
-      prosemirror-history: 1.5.0
-      prosemirror-state: 1.4.4
-
   prosemirror-model@1.25.4:
     dependencies:
       orderedmap: 2.1.1
-
-  prosemirror-schema-basic@1.2.4:
-    dependencies:
-      prosemirror-model: 1.25.4
 
   prosemirror-schema-list@1.5.1:
     dependencies:
@@ -6944,8 +5840,6 @@ snapshots:
       prosemirror-transform: 1.10.5
 
   proxy-from-env@1.1.0: {}
-
-  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -7228,8 +6122,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uc.micro@2.1.0: {}
-
   ufo@1.6.3: {}
 
   uhyphen@0.2.0: {}
@@ -7289,18 +6181,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite@6.4.1(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      fsevents: 2.3.3
-      yaml: 2.8.2
 
   vite@7.3.1(yaml@2.8.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,15 @@ importers:
       prosemirror-inputrules:
         specifier: ^1.5.1
         version: 1.5.1
+      prosemirror-model:
+        specifier: ^1.25.4
+        version: 1.25.4
+      prosemirror-state:
+        specifier: ^1.4.4
+        version: 1.4.4
+      prosemirror-view:
+        specifier: ^1.41.5
+        version: 1.41.5
     devDependencies:
       jsdom:
         specifier: ^27.4.0


### PR DESCRIPTION
## Summary
- Add image paste/drop upload with progress placeholder and configurable upload handler
- Add float (left/center/right) and text wrapping support for images
- Add inline image mode via `Image.configure({ inline: true })`
- Add markdown input rule `![alt](src "title")` with XSS validation
- Fix details Enter handler to open collapsed content instead of exiting

## Features
- **Paste/drop upload**: `onDrop`/`onPaste` hooks with `imageUploadPlugin` — shows loading placeholder during upload, replaces with final image on success
- **Float & wrapping**: `float` and `textWrap` attributes with `setImageFloat` / `setImageTextWrap` commands
- **Inline mode**: `Image.configure({ inline: true })` renders images as inline elements via dynamic `group`/`inline` support in core
- **Input rule**: `![alt](src "title")` markdown syntax with URL blocklist XSS validation
- **Details fix**: Enter in collapsed summary now opens content and moves cursor inside (instead of exiting details)

## Changes
- `extension-image`: upload plugin, float/wrap attrs, inline option, input rule, typed `SetImageOptions`
- `core`: `callOrReturn` support for dynamic `group`/`inline` in `createNodeSpec`
- `extension-details`: refactored Enter handler with `detailsEnterOpen` meta flag to prevent `appendTransaction` interference
- `isNodeVisible`: fixed text node handling (walk up to nearest `HTMLElement`)

## Test plan
- 99 image unit tests (upload, float, inline, input rules, XSS validation)
- 74 details unit tests
- 1380 Playwright E2E + comparison tests (60/60 stable on Enter-in-collapsed-summary)
