### PR TITLE
fix(core): harden UniqueID, Selection, CharacterCount, and menu positioning

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -1,8 +1,7 @@
 /**
  * Editor - Main editor class wrapping ProseMirror
  *
- * Step 1.3: Basic editor with schema-based initialization
- * Step 2: Will support extensions for schema building
+ * Manages extensions, schema, commands, and the ProseMirror EditorView/State.
  */
 import type { Transaction } from 'prosemirror-state';
 import { EditorState } from 'prosemirror-state';
@@ -282,19 +281,24 @@ export class Editor extends EventEmitter<EditorEvents> {
     // Check if it's a node
     const nodeType = schema.nodes[name];
     if (nodeType) {
-      // Check if any node in selection path matches
-      // For block nodes, check parents of selection
-      for (let depth = $from.depth; depth >= 0; depth--) {
-        const node = $from.node(depth);
-        if (node.type === nodeType) {
-          // Check attributes if specified
-          if (attrs) {
-            return this.matchAttributes(node.attrs, attrs);
+      // Check both $from and $to paths — the node must be an ancestor
+      // of both ends of the selection for it to be considered active.
+      const { $to } = selection;
+
+      const findInPath = ($pos: typeof $from): boolean => {
+        for (let depth = $pos.depth; depth >= 0; depth--) {
+          const node = $pos.node(depth);
+          if (node.type === nodeType) {
+            if (attrs) {
+              return this.matchAttributes(node.attrs, attrs);
+            }
+            return true;
           }
-          return true;
         }
-      }
-      return false;
+        return false;
+      };
+
+      return findInPath($from) && findInPath($to);
     }
 
     return false;

--- a/packages/core/src/Extension.ts
+++ b/packages/core/src/Extension.ts
@@ -25,6 +25,7 @@
  */
 
 import type { ExtensionConfig, ExtensionConfigBase, ExtensionContext } from './types/ExtensionConfig.js';
+import type { SingleCommands } from './types/Commands.js';
 import type { EditorState } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import { callOrReturn } from './helpers/callOrReturn.js';
@@ -79,6 +80,7 @@ export interface ExtensionEditorInterface {
   readonly state: EditorState;
   readonly view: EditorView;
   readonly schema: unknown;
+  readonly commands: SingleCommands;
 }
 
 /**

--- a/packages/core/src/commands/builtIn.ts
+++ b/packages/core/src/commands/builtIn.ts
@@ -4,7 +4,7 @@
  * These commands are merged with extension commands
  * to provide a unified command API.
  */
-import { TextSelection, AllSelection } from 'prosemirror-state';
+import { TextSelection, AllSelection, EditorState } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import { selectNodeBackward as pmSelectNodeBackward } from 'prosemirror-commands';
 import { wrapRangeInList, liftListItem } from 'prosemirror-schema-list';
@@ -740,13 +740,16 @@ export const toggleList: CommandSpec<[listNodeName: string, listItemNodeName: st
       // liftListItem reads state.selection directly. When that's AllSelection
       // (doc level), it can't find list items. Create a state with narrowed
       // selection inside the list so liftListItem works correctly.
+      // Use tr.doc (not state.doc) for chain compatibility — prior commands
+      // in a chain may have modified the document.
       const first = contentBlocks[0];
       const last = contentBlocks[contentBlocks.length - 1];
       if (!first || !last) return false;
-      const narrowTr = state.tr.setSelection(
-        TextSelection.create(state.doc, first.pos + 1, last.pos + 1)
-      );
-      const narrowState = state.apply(narrowTr);
+      const narrowSel = TextSelection.create(tr.doc, first.pos + 1, last.pos + 1);
+      const narrowState = EditorState.create({
+        doc: tr.doc,
+        selection: narrowSel,
+      });
       return liftListItem(listItemType)(narrowState, dispatch);
     }
 

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -115,17 +115,20 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
     let updateTimeout: ReturnType<typeof setTimeout> | null = null;
 
     const updatePosition = (view: EditorView, from: number, to: number): void => {
-      // Get selection coordinates
+      // coordsAtPos returns viewport-relative (screen) coordinates
       const start = view.coordsAtPos(from);
       const end = view.coordsAtPos(to);
 
-      // Calculate center of selection
       const centerX = (start.left + end.left) / 2;
-
-      // Get menu dimensions
       const menuRect = element.getBoundingClientRect();
 
-      // Calculate position
+      // Compute offset from the element's offsetParent so positioning
+      // works for both position:fixed and position:absolute elements.
+      const offsetParent = element.offsetParent;
+      const parentRect = offsetParent
+        ? offsetParent.getBoundingClientRect()
+        : { top: 0, left: 0 };
+
       let top: number;
       let left: number;
 
@@ -137,11 +140,10 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
 
       left = centerX - menuRect.width / 2 + offset[0];
 
-      // Viewport boundary checks
+      // Viewport boundary checks (in screen coordinates)
       const viewportWidth = window.innerWidth;
       const viewportHeight = window.innerHeight;
 
-      // Keep menu within horizontal bounds
       if (left < 10) left = 10;
       if (left + menuRect.width > viewportWidth - 10) {
         left = viewportWidth - menuRect.width - 10;
@@ -157,9 +159,9 @@ export const BubbleMenu = Extension.create<BubbleMenuOptions>({
         top = start.top - menuRect.height - offset[1];
       }
 
-      // Apply position
-      element.style.top = `${String(top)}px`;
-      element.style.left = `${String(left)}px`;
+      // Convert viewport coordinates to offsetParent-relative coordinates
+      element.style.top = `${String(top - parentRect.top)}px`;
+      element.style.left = `${String(left - parentRect.left)}px`;
       element.setAttribute('data-show', '');
     };
 

--- a/packages/core/src/extensions/CharacterCount.ts
+++ b/packages/core/src/extensions/CharacterCount.ts
@@ -129,7 +129,7 @@ export const CharacterCount = Extension.create<
   },
 
   addProseMirrorPlugins() {
-    const { limit, wordLimit } = this.options;
+    const { limit, wordLimit, mode } = this.options;
 
     // If no limits, no need for filtering plugin
     if (limit === null && wordLimit === null) return [];
@@ -142,16 +142,18 @@ export const CharacterCount = Extension.create<
           if (!transaction.docChanged) return true;
 
           const newDoc = transaction.doc;
-          const text = newDoc.textContent;
 
-          // Character limit check
-          if (limit !== null && text.length > limit) {
-            return false;
+          // Character limit check — use same counting mode as characters()
+          if (limit !== null) {
+            const count = mode === 'nodeSize'
+              ? newDoc.nodeSize
+              : newDoc.textContent.length;
+            if (count > limit) return false;
           }
 
           // Word limit check
           if (wordLimit !== null) {
-            const words = text.split(/\s+/).filter((w) => w.length > 0);
+            const words = newDoc.textContent.split(/\s+/).filter((w) => w.length > 0);
             if (words.length > wordLimit) {
               return false;
             }

--- a/packages/core/src/extensions/FloatingMenu.ts
+++ b/packages/core/src/extensions/FloatingMenu.ts
@@ -131,6 +131,13 @@ export const FloatingMenu = Extension.create<FloatingMenuOptions>({
       if (domNode instanceof HTMLElement) {
         const rect = domNode.getBoundingClientRect();
 
+        // Compute offset from the element's offsetParent so positioning
+        // works for both position:fixed and position:absolute elements.
+        const offsetParent = element.offsetParent;
+        const parentRect = offsetParent
+          ? offsetParent.getBoundingClientRect()
+          : { top: 0, left: 0 };
+
         let top = rect.bottom + offset[1];
         const left = rect.left + offset[0];
 
@@ -142,8 +149,9 @@ export const FloatingMenu = Extension.create<FloatingMenuOptions>({
           top = rect.top - menuRect.height - offset[1];
         }
 
-        element.style.top = `${String(top)}px`;
-        element.style.left = `${String(left)}px`;
+        // Convert viewport coordinates to offsetParent-relative coordinates
+        element.style.top = `${String(top - parentRect.top)}px`;
+        element.style.left = `${String(left - parentRect.left)}px`;
       }
 
       element.setAttribute('data-show', '');

--- a/packages/core/src/extensions/History.ts
+++ b/packages/core/src/extensions/History.ts
@@ -55,9 +55,9 @@ export const History = Extension.create<HistoryOptions>({
 
   addKeyboardShortcuts() {
     return {
-      'Mod-z': () => this.editor?.commands['undo']?.() ?? false,
-      'Mod-Shift-z': () => this.editor?.commands['redo']?.() ?? false,
-      'Mod-y': () => this.editor?.commands['redo']?.() ?? false,
+      'Mod-z': () => this.editor?.commands.undo() ?? false,
+      'Mod-Shift-z': () => this.editor?.commands.redo() ?? false,
+      'Mod-y': () => this.editor?.commands.redo() ?? false,
     };
   },
 

--- a/packages/core/src/extensions/ListKeymap.ts
+++ b/packages/core/src/extensions/ListKeymap.ts
@@ -7,9 +7,11 @@
  * - Backspace: Lift list item when at start of empty item
  */
 import { liftListItem, sinkListItem } from 'prosemirror-schema-list';
+import type { NodeType } from 'prosemirror-model';
 import type { EditorState } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import { Extension } from '../Extension.js';
+import type { ExtensionEditorInterface } from '../Extension.js';
 
 export interface ListKeymapOptions {
   /**
@@ -17,6 +19,25 @@ export interface ListKeymapOptions {
    * @default 'listItem'
    */
   listItem: string;
+}
+
+/** Resolves the list item NodeType and checks if cursor is inside one. */
+function getListItemContext(
+  editor: ExtensionEditorInterface,
+  listItemName: string,
+): { state: EditorState; view: EditorView; listItemType: NodeType } | null {
+  const { state, view } = editor as { state: EditorState; view: EditorView };
+  const listItemType = state.schema.nodes[listItemName];
+  if (!listItemType) return null;
+
+  const { $from } = state.selection;
+  for (let d = $from.depth; d > 0; d--) {
+    if ($from.node(d).type === listItemType) {
+      return { state, view, listItemType };
+    }
+  }
+
+  return null;
 }
 
 export const ListKeymap = Extension.create<ListKeymapOptions>({
@@ -32,54 +53,18 @@ export const ListKeymap = Extension.create<ListKeymapOptions>({
     return {
       // Tab to sink (indent) list item
       Tab: () => {
-        const editor = this.editor;
-        if (!editor) return false;
-
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        const listItemType = state.schema.nodes[this.options.listItem] ;
-
-        if (!listItemType) return false;
-
-        // Check if we're actually inside a list item
-        const { $from } = state.selection;
-        let inListItem = false;
-
-        for (let d = $from.depth; d > 0; d--) {
-          if ($from.node(d).type === listItemType) {
-            inListItem = true;
-            break;
-          }
-        }
-
-        if (!inListItem) return false;
-
-        return sinkListItem(listItemType)(state, view.dispatch);
+        if (!this.editor) return false;
+        const ctx = getListItemContext(this.editor, this.options.listItem);
+        if (!ctx) return false;
+        return sinkListItem(ctx.listItemType)(ctx.state, ctx.view.dispatch);
       },
 
       // Shift-Tab to lift (outdent) list item
       'Shift-Tab': () => {
-        const editor = this.editor;
-        if (!editor) return false;
-
-        const { state, view } = editor as { state: EditorState; view: EditorView };
-        const listItemType = state.schema.nodes[this.options.listItem] ;
-
-        if (!listItemType) return false;
-
-        // Check if we're actually inside a list item
-        const { $from } = state.selection;
-        let inListItem = false;
-
-        for (let d = $from.depth; d > 0; d--) {
-          if ($from.node(d).type === listItemType) {
-            inListItem = true;
-            break;
-          }
-        }
-
-        if (!inListItem) return false;
-
-        return liftListItem(listItemType)(state, view.dispatch);
+        if (!this.editor) return false;
+        const ctx = getListItemContext(this.editor, this.options.listItem);
+        if (!ctx) return false;
+        return liftListItem(ctx.listItemType)(ctx.state, ctx.view.dispatch);
       },
 
       // Backspace at start of list item to lift
@@ -93,7 +78,7 @@ export const ListKeymap = Extension.create<ListKeymapOptions>({
         // Only at start of textblock with empty selection
         if (!empty || $from.parentOffset !== 0) return false;
 
-        const listItemType = state.schema.nodes[this.options.listItem] ;
+        const listItemType = state.schema.nodes[this.options.listItem];
         if (!listItemType) return false;
 
         // Check if we're at the start of a list item

--- a/packages/core/src/extensions/Selection.test.ts
+++ b/packages/core/src/extensions/Selection.test.ts
@@ -16,16 +16,7 @@ describe('Selection', () => {
     });
 
     it('has default options', () => {
-      expect(Selection.options).toEqual({
-        HTMLAttributes: {},
-      });
-    });
-
-    it('can configure HTMLAttributes', () => {
-      const CustomSelection = Selection.configure({
-        HTMLAttributes: { class: 'custom' },
-      });
-      expect(CustomSelection.options.HTMLAttributes).toEqual({ class: 'custom' });
+      expect(Selection.options).toEqual({});
     });
   });
 
@@ -295,7 +286,7 @@ describe('Selection', () => {
         editor.commands.setSelection(6, 11);
         editor.commands.extendSelection('start');
 
-        expect(editor.state.selection.from).toBe(0);
+        expect(editor.state.selection.from).toBe(1);
         expect(editor.state.selection.to).toBe(11);
       });
 

--- a/packages/core/src/extensions/Selection.test.ts
+++ b/packages/core/src/extensions/Selection.test.ts
@@ -300,7 +300,10 @@ describe('Selection', () => {
         editor.commands.extendSelection('end');
 
         expect(editor.state.selection.from).toBe(1);
-        expect(editor.state.selection.to).toBe(editor.state.doc.content.size);
+        // Selection.atEnd gives the last valid text position (inside the
+        // last textblock), not doc.content.size (which is after the block).
+        // For '<p>Hello world</p>': text ends at position 12.
+        expect(editor.state.selection.to).toBe(12);
       });
     });
 

--- a/packages/core/src/extensions/Selection.ts
+++ b/packages/core/src/extensions/Selection.ts
@@ -31,7 +31,7 @@
  * ```
  */
 import { Extension } from '../Extension.js';
-import { NodeSelection, TextSelection } from 'prosemirror-state';
+import { NodeSelection, TextSelection, Selection as PMSelection } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import type { Editor } from '../Editor.js';
 import type { CommandSpec } from '../types/Commands.js';
@@ -205,18 +205,22 @@ export const Selection = Extension.create<SelectionOptions, SelectionStorage>({
           // Use tr.selection/tr.doc for chain compatibility
           let { from, to } = tr.selection;
 
+          // Use Selection.atStart/atEnd to find the first/last valid
+          // text position, which handles nested structures correctly
+          // (e.g. doc > blockquote > paragraph where position 1 is not
+          // inside a textblock).
           switch (direction) {
             case 'left':
-              from = Math.max(0, from - 1);
+              from = Math.max(PMSelection.atStart(tr.doc).from, from - 1);
               break;
             case 'right':
-              to = Math.min(tr.doc.content.size, to + 1);
+              to = Math.min(PMSelection.atEnd(tr.doc).to, to + 1);
               break;
             case 'start':
-              from = 1;
+              from = PMSelection.atStart(tr.doc).from;
               break;
             case 'end':
-              to = tr.doc.content.size;
+              to = PMSelection.atEnd(tr.doc).to;
               break;
           }
 

--- a/packages/core/src/extensions/Selection.ts
+++ b/packages/core/src/extensions/Selection.ts
@@ -45,13 +45,7 @@ declare module '../types/Commands.js' {
   }
 }
 
-export interface SelectionOptions {
-  /**
-   * HTML attributes to apply.
-   * @default {}
-   */
-  HTMLAttributes: Record<string, unknown>;
-}
+export interface SelectionOptions {}
 
 export interface SelectionStorage {
   /**
@@ -82,12 +76,6 @@ export interface SelectionStorage {
 
 export const Selection = Extension.create<SelectionOptions, SelectionStorage>({
   name: 'selection',
-
-  addOptions() {
-    return {
-      HTMLAttributes: {},
-    };
-  },
 
   addStorage() {
     return {
@@ -225,7 +213,7 @@ export const Selection = Extension.create<SelectionOptions, SelectionStorage>({
               to = Math.min(tr.doc.content.size, to + 1);
               break;
             case 'start':
-              from = 0;
+              from = 1;
               break;
             case 'end':
               to = tr.doc.content.size;

--- a/packages/core/src/extensions/TextAlign.ts
+++ b/packages/core/src/extensions/TextAlign.ts
@@ -94,13 +94,13 @@ export const TextAlign = Extension.create<TextAlignOptions>({
   addKeyboardShortcuts() {
     return {
       'Mod-Shift-l': () =>
-        this.editor?.commands['setTextAlign']?.('left') ?? false,
+        this.editor?.commands.setTextAlign('left') ?? false,
       'Mod-Shift-e': () =>
-        this.editor?.commands['setTextAlign']?.('center') ?? false,
+        this.editor?.commands.setTextAlign('center') ?? false,
       'Mod-Shift-r': () =>
-        this.editor?.commands['setTextAlign']?.('right') ?? false,
+        this.editor?.commands.setTextAlign('right') ?? false,
       'Mod-Shift-j': () =>
-        this.editor?.commands['setTextAlign']?.('justify') ?? false,
+        this.editor?.commands.setTextAlign('justify') ?? false,
     };
   },
 });

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -178,11 +178,16 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
 
         // Apply initial IDs after the view is ready
         view(editorView) {
-          const tr = editorView.state.tr;
-          assignMissingIDs(editorView.state.doc, tr);
-          if (tr.docChanged) {
-            setTimeout(() => { editorView.dispatch(tr); }, 0);
-          }
+          // Use setTimeout to avoid dispatching during plugin init, but
+          // re-create the transaction from the *current* state inside the
+          // callback to avoid stale-transaction bugs.
+          setTimeout(() => {
+            const tr = editorView.state.tr;
+            assignMissingIDs(editorView.state.doc, tr);
+            if (tr.docChanged) {
+              editorView.dispatch(tr);
+            }
+          }, 0);
           return {};
         },
 

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -181,14 +181,18 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
           // Use setTimeout to avoid dispatching during plugin init, but
           // re-create the transaction from the *current* state inside the
           // callback to avoid stale-transaction bugs.
-          setTimeout(() => {
+          const timeoutId = setTimeout(() => {
             const tr = editorView.state.tr;
             assignMissingIDs(editorView.state.doc, tr);
             if (tr.docChanged) {
               editorView.dispatch(tr);
             }
           }, 0);
-          return {};
+          return {
+            destroy() {
+              clearTimeout(timeoutId);
+            },
+          };
         },
 
         // Ensure new nodes get IDs

--- a/packages/core/src/types/ExtensionConfig.ts
+++ b/packages/core/src/types/ExtensionConfig.ts
@@ -8,17 +8,16 @@
 import type { Plugin, Transaction, EditorState } from 'prosemirror-state';
 import type { InputRule } from 'prosemirror-inputrules';
 import type { EditorView } from 'prosemirror-view';
-import type { Command, KeyboardShortcutCommand } from './Commands.js';
+import type { Command, KeyboardShortcutCommand, SingleCommands } from './Commands.js';
 
 /**
  * Editor instance type (forward declaration)
- * Will be properly typed when Extension class is implemented
  */
 export interface ExtensionEditor {
   readonly state: EditorState;
   readonly view: EditorView;
   readonly schema: unknown;
-  readonly commands: Record<string, (...args: unknown[]) => boolean>;
+  readonly commands: SingleCommands;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix stale-transaction bug in UniqueID plugin (`setTimeout` now creates fresh `tr` from current state, with `clearTimeout` cleanup in `destroy()`)
- Use `Selection.atStart/atEnd` in Selection extension instead of hardcoded `0`/`content.size` for robust cursor positions in nested structures
- Fix CharacterCount limit enforcement to respect `mode: 'nodeSize'` (was always checking `textContent.length`)
- Fix BubbleMenu/FloatingMenu positioning to account for `offsetParent` (works with both `position: fixed` and `absolute`)
- Fix `Editor.isActive()` to check both `$from` and `$to` paths (node must be ancestor of both ends of selection)
- Fix `toggleList` to use `tr.doc` instead of `state.doc` for chain compatibility

## Changes

- **UniqueID** — `setTimeout` cleanup in `destroy()`, re-create transaction inside callback
- **Selection** — `PMSelection.atStart/atEnd` for correct positions, remove unused `HTMLAttributes` option
- **CharacterCount** — limit plugin uses same counting mode as `characters()` method
- **BubbleMenu/FloatingMenu** — offset from `offsetParent` for correct absolute positioning
- **Editor.isActive** — check both `$from` and `$to` ancestor paths
- **builtIn.ts toggleList** — use `tr.doc` + `EditorState.create()` for chain compat
- **ListKeymap** — extract `getListItemContext()` helper, dedup Tab/Shift-Tab handlers
- **History/TextAlign** — typed `commands.undo()` instead of `commands['undo']?.()`
- **ExtensionConfig** — type `commands` as `SingleCommands` instead of `Record<string, ...>`

## Test plan

- [ ] `pnpm test` passes (1494 tests)
- [ ] `pnpm lint` clean
- [ ] `pnpm typecheck` clean
- [ ] Demo: BubbleMenu/FloatingMenu position correctly in both fixed and absolute containers
- [ ] Demo: Selection `extendSelection('start'/'end')` works in nested blockquote/list structures
