### PR TITLE
feat(table): add extension-table package with 4 nodes, 16 commands, and TableView

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -224,6 +224,9 @@ export class Node<Options = unknown, Storage = unknown> extends Extension<
     if (this.config.allowGapCursor !== undefined)
       (spec as Record<string, unknown>)['allowGapCursor'] =
         this.config.allowGapCursor;
+    if (this.config.tableRole !== undefined)
+      (spec as Record<string, unknown>)['tableRole'] =
+        this.config.tableRole;
 
     // Top node (only for document)
     if (this.config.topNode) {

--- a/packages/core/src/types/NodeConfig.ts
+++ b/packages/core/src/types/NodeConfig.ts
@@ -190,6 +190,13 @@ interface NodeSchemaProperties {
   allowGapCursor?: boolean;
 
   /**
+   * Table role for prosemirror-tables integration.
+   * Nodes with a tableRole are discovered by prosemirror-tables via spec.tableRole.
+   * One of: 'table', 'row', 'cell', 'header_cell'
+   */
+  tableRole?: 'table' | 'row' | 'cell' | 'header_cell';
+
+  /**
    * Whether this is a top-level node (document root)
    * Only one node should have this set to true
    */

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@domternal/extension-table",
+  "version": "0.0.1",
+  "description": "Table extension for Domternal editor",
+  "author": "Domternal",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@domternal/core": "workspace:*",
+    "prosemirror-tables": "^1.8.0",
+    "prosemirror-model": "^1.25.4",
+    "prosemirror-state": "^1.4.4",
+    "prosemirror-view": "^1.41.5"
+  },
+  "devDependencies": {
+    "jsdom": "^27.4.0",
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.3"
+  },
+  "keywords": [
+    "prosemirror",
+    "editor",
+    "table",
+    "domternal"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/domternal/domternal.git",
+    "directory": "packages/extension-table"
+  },
+  "bugs": {
+    "url": "https://github.com/domternal/domternal/issues"
+  },
+  "homepage": "https://domternal.com"
+}

--- a/packages/extension-table/src/Table.test.ts
+++ b/packages/extension-table/src/Table.test.ts
@@ -1,0 +1,953 @@
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Table } from './Table.js';
+import { TableRow } from './TableRow.js';
+import { TableCell } from './TableCell.js';
+import { TableHeader } from './TableHeader.js';
+import { TableView } from './TableView.js';
+import { createTable } from './helpers/createTable.js';
+import { Document, Text, Paragraph, Editor } from '@domternal/core';
+import { TextSelection } from 'prosemirror-state';
+
+type AnyJson = any;
+
+const allExtensions = [Document, Text, Paragraph, Table, TableRow, TableCell, TableHeader];
+
+// === Table Node Configuration ===
+
+describe('Table', () => {
+  describe('configuration', () => {
+    it('has correct name', () => {
+      expect(Table.name).toBe('table');
+    });
+
+    it('is a node type', () => {
+      expect(Table.type).toBe('node');
+    });
+
+    it('belongs to block group', () => {
+      expect(Table.config.group).toBe('block');
+    });
+
+    it('has correct content spec', () => {
+      expect(Table.config.content).toBe('tableRow+');
+    });
+
+    it('has table tableRole', () => {
+      expect(Table.config.tableRole).toBe('table');
+    });
+
+    it('is isolating', () => {
+      expect(Table.config.isolating).toBe(true);
+    });
+
+    it('has default options', () => {
+      expect(Table.options).toEqual({
+        HTMLAttributes: {},
+        resizable: false,
+        handleWidth: 5,
+        cellMinWidth: 25,
+        lastColumnResizable: true,
+        allowTableNodeSelection: false,
+        View: TableView,
+      });
+    });
+
+    it('can configure HTMLAttributes', () => {
+      const Custom = Table.configure({ HTMLAttributes: { class: 'my-table' } });
+      expect(Custom.options.HTMLAttributes).toEqual({ class: 'my-table' });
+    });
+
+    it('can configure resizable', () => {
+      const Custom = Table.configure({ resizable: true });
+      expect(Custom.options.resizable).toBe(true);
+    });
+
+    it('can configure allowTableNodeSelection', () => {
+      const Custom = Table.configure({ allowTableNodeSelection: true });
+      expect(Custom.options.allowTableNodeSelection).toBe(true);
+    });
+
+    it('can configure cellMinWidth', () => {
+      const Custom = Table.configure({ cellMinWidth: 50 });
+      expect(Custom.options.cellMinWidth).toBe(50);
+    });
+
+    it('can disable View', () => {
+      const Custom = Table.configure({ View: null });
+      expect(Custom.options.View).toBeNull();
+    });
+  });
+
+  describe('parseHTML', () => {
+    it('returns rule for table tag', () => {
+      const rules = Table.config.parseHTML?.call(Table);
+      expect(rules).toEqual([{ tag: 'table' }]);
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('renders table with tbody', () => {
+      const spec = Table.createNodeSpec();
+      const mockNode = { attrs: {} } as AnyJson;
+      const result = spec.toDOM?.(mockNode) as unknown as AnyJson[];
+      expect(result[0]).toBe('table');
+      expect(result[2]).toEqual(['tbody', 0]);
+    });
+
+    it('merges HTMLAttributes', () => {
+      const Custom = Table.configure({ HTMLAttributes: { class: 'styled' } });
+      const spec = Custom.createNodeSpec();
+      const mockNode = { attrs: {} } as AnyJson;
+      const result = spec.toDOM?.(mockNode) as unknown as AnyJson[];
+      expect(result[1].class).toBe('styled');
+    });
+  });
+
+  describe('createNodeSpec', () => {
+    it('includes tableRole in spec', () => {
+      const spec = Table.createNodeSpec();
+      expect((spec as AnyJson).tableRole).toBe('table');
+    });
+
+    it('is isolating', () => {
+      const spec = Table.createNodeSpec();
+      expect(spec.isolating).toBe(true);
+    });
+  });
+});
+
+// === TableRow Node ===
+
+describe('TableRow', () => {
+  describe('configuration', () => {
+    it('has correct name', () => {
+      expect(TableRow.name).toBe('tableRow');
+    });
+
+    it('is a node type', () => {
+      expect(TableRow.type).toBe('node');
+    });
+
+    it('has correct content spec', () => {
+      expect(TableRow.config.content).toBe('(tableCell | tableHeader)*');
+    });
+
+    it('has row tableRole', () => {
+      expect(TableRow.config.tableRole).toBe('row');
+    });
+
+    it('has default options', () => {
+      expect(TableRow.options).toEqual({
+        HTMLAttributes: {},
+      });
+    });
+  });
+
+  describe('parseHTML', () => {
+    it('returns rule for tr tag', () => {
+      const rules = TableRow.config.parseHTML?.call(TableRow);
+      expect(rules).toEqual([{ tag: 'tr' }]);
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('renders tr element', () => {
+      const spec = TableRow.createNodeSpec();
+      const mockNode = { attrs: {} } as AnyJson;
+      const result = spec.toDOM?.(mockNode) as unknown as AnyJson[];
+      expect(result[0]).toBe('tr');
+      expect(result[2]).toBe(0);
+    });
+  });
+
+  describe('createNodeSpec', () => {
+    it('includes tableRole in spec', () => {
+      const spec = TableRow.createNodeSpec();
+      expect((spec as AnyJson).tableRole).toBe('row');
+    });
+  });
+});
+
+// === TableCell Node ===
+
+describe('TableCell', () => {
+  describe('configuration', () => {
+    it('has correct name', () => {
+      expect(TableCell.name).toBe('tableCell');
+    });
+
+    it('is a node type', () => {
+      expect(TableCell.type).toBe('node');
+    });
+
+    it('has correct content spec', () => {
+      expect(TableCell.config.content).toBe('block+');
+    });
+
+    it('has cell tableRole', () => {
+      expect(TableCell.config.tableRole).toBe('cell');
+    });
+
+    it('is isolating', () => {
+      expect(TableCell.config.isolating).toBe(true);
+    });
+
+    it('has default options', () => {
+      expect(TableCell.options).toEqual({
+        HTMLAttributes: {},
+      });
+    });
+  });
+
+  describe('attributes', () => {
+    it('defines colspan with default 1', () => {
+      const spec = TableCell.createNodeSpec();
+      expect(spec.attrs?.['colspan']?.default).toBe(1);
+    });
+
+    it('defines rowspan with default 1', () => {
+      const spec = TableCell.createNodeSpec();
+      expect(spec.attrs?.['rowspan']?.default).toBe(1);
+    });
+
+    it('defines colwidth with default null', () => {
+      const spec = TableCell.createNodeSpec();
+      expect(spec.attrs?.['colwidth']?.default).toBeNull();
+    });
+  });
+
+  describe('parseHTML', () => {
+    it('returns rule for td tag', () => {
+      const rules = TableCell.config.parseHTML?.call(TableCell);
+      expect(rules).toEqual([{ tag: 'td' }]);
+    });
+
+    it('parses colspan from DOM', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const el = document.createElement('td');
+      el.setAttribute('colspan', '3');
+      const value = attrs?.['colspan']?.parseHTML?.(el);
+      expect(value).toBe(3);
+    });
+
+    it('parses rowspan from DOM', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const el = document.createElement('td');
+      el.setAttribute('rowspan', '2');
+      const value = attrs?.['rowspan']?.parseHTML?.(el);
+      expect(value).toBe(2);
+    });
+
+    it('parses colwidth from data-colwidth', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const el = document.createElement('td');
+      el.setAttribute('data-colwidth', '100,200');
+      const value = attrs?.['colwidth']?.parseHTML?.(el);
+      expect(value).toEqual([100, 200]);
+    });
+
+    it('returns null for missing colwidth', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const el = document.createElement('td');
+      const value = attrs?.['colwidth']?.parseHTML?.(el);
+      expect(value).toBeNull();
+    });
+
+    it('returns default colspan when attribute missing', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const el = document.createElement('td');
+      const value = attrs?.['colspan']?.parseHTML?.(el);
+      expect(value).toBe(1);
+    });
+  });
+
+  describe('renderHTML attributes', () => {
+    it('omits colspan when 1', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['colspan']?.renderHTML?.({ colspan: 1 });
+      expect(result).toBeNull();
+    });
+
+    it('renders colspan when > 1', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['colspan']?.renderHTML?.({ colspan: 3 });
+      expect(result).toEqual({ colspan: 3 });
+    });
+
+    it('omits rowspan when 1', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['rowspan']?.renderHTML?.({ rowspan: 1 });
+      expect(result).toBeNull();
+    });
+
+    it('renders rowspan when > 1', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['rowspan']?.renderHTML?.({ rowspan: 2 });
+      expect(result).toEqual({ rowspan: 2 });
+    });
+
+    it('renders colwidth as data-colwidth', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['colwidth']?.renderHTML?.({ colwidth: [100, 200] });
+      expect(result).toEqual({ 'data-colwidth': '100,200' });
+    });
+
+    it('omits colwidth when null', () => {
+      const attrs = TableCell.config.addAttributes?.call(TableCell);
+      const result = attrs?.['colwidth']?.renderHTML?.({ colwidth: null });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('renders td element', () => {
+      const spec = TableCell.createNodeSpec();
+      const mockNode = { attrs: { colspan: 1, rowspan: 1, colwidth: null } } as AnyJson;
+      const result = spec.toDOM?.(mockNode) as unknown as AnyJson[];
+      expect(result[0]).toBe('td');
+      expect(result[2]).toBe(0);
+    });
+  });
+
+  describe('createNodeSpec', () => {
+    it('includes tableRole in spec', () => {
+      const spec = TableCell.createNodeSpec();
+      expect((spec as AnyJson).tableRole).toBe('cell');
+    });
+
+    it('is isolating', () => {
+      const spec = TableCell.createNodeSpec();
+      expect(spec.isolating).toBe(true);
+    });
+  });
+});
+
+// === TableHeader Node ===
+
+describe('TableHeader', () => {
+  describe('configuration', () => {
+    it('has correct name', () => {
+      expect(TableHeader.name).toBe('tableHeader');
+    });
+
+    it('is a node type', () => {
+      expect(TableHeader.type).toBe('node');
+    });
+
+    it('has correct content spec', () => {
+      expect(TableHeader.config.content).toBe('block+');
+    });
+
+    it('has header_cell tableRole', () => {
+      expect(TableHeader.config.tableRole).toBe('header_cell');
+    });
+
+    it('is isolating', () => {
+      expect(TableHeader.config.isolating).toBe(true);
+    });
+  });
+
+  describe('attributes', () => {
+    it('defines colspan with default 1', () => {
+      const spec = TableHeader.createNodeSpec();
+      expect(spec.attrs?.['colspan']?.default).toBe(1);
+    });
+
+    it('defines rowspan with default 1', () => {
+      const spec = TableHeader.createNodeSpec();
+      expect(spec.attrs?.['rowspan']?.default).toBe(1);
+    });
+
+    it('defines colwidth with default null', () => {
+      const spec = TableHeader.createNodeSpec();
+      expect(spec.attrs?.['colwidth']?.default).toBeNull();
+    });
+  });
+
+  describe('parseHTML', () => {
+    it('returns rule for th tag', () => {
+      const rules = TableHeader.config.parseHTML?.call(TableHeader);
+      expect(rules).toEqual([{ tag: 'th' }]);
+    });
+
+    it('parses colspan from DOM', () => {
+      const attrs = TableHeader.config.addAttributes?.call(TableHeader);
+      const el = document.createElement('th');
+      el.setAttribute('colspan', '4');
+      const value = attrs?.['colspan']?.parseHTML?.(el);
+      expect(value).toBe(4);
+    });
+
+    it('parses rowspan from DOM', () => {
+      const attrs = TableHeader.config.addAttributes?.call(TableHeader);
+      const el = document.createElement('th');
+      el.setAttribute('rowspan', '3');
+      const value = attrs?.['rowspan']?.parseHTML?.(el);
+      expect(value).toBe(3);
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('renders th element', () => {
+      const spec = TableHeader.createNodeSpec();
+      const mockNode = { attrs: { colspan: 1, rowspan: 1, colwidth: null } } as AnyJson;
+      const result = spec.toDOM?.(mockNode) as unknown as AnyJson[];
+      expect(result[0]).toBe('th');
+      expect(result[2]).toBe(0);
+    });
+  });
+
+  describe('createNodeSpec', () => {
+    it('includes tableRole in spec', () => {
+      const spec = TableHeader.createNodeSpec();
+      expect((spec as AnyJson).tableRole).toBe('header_cell');
+    });
+  });
+});
+
+// === Editor Integration ===
+
+describe('Editor Integration', () => {
+  let editor: InstanceType<typeof Editor>;
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('creates editor with table extensions', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Hello</p>',
+    });
+    expect(editor).toBeDefined();
+    expect(editor.schema.nodes['table']).toBeDefined();
+    expect(editor.schema.nodes['tableRow']).toBeDefined();
+    expect(editor.schema.nodes['tableCell']).toBeDefined();
+    expect(editor.schema.nodes['tableHeader']).toBeDefined();
+  });
+
+  it('has tableRole on node specs', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Hello</p>',
+    });
+    expect(editor.schema.nodes['table']!.spec['tableRole']).toBe('table');
+    expect(editor.schema.nodes['tableRow']!.spec['tableRole']).toBe('row');
+    expect(editor.schema.nodes['tableCell']!.spec['tableRole']).toBe('cell');
+    expect(editor.schema.nodes['tableHeader']!.spec['tableRole']).toBe('header_cell');
+  });
+
+  it('parses table HTML content', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<table><tr><td><p>Cell 1</p></td><td><p>Cell 2</p></td></tr></table>',
+    });
+    const json = editor.getJSON() as AnyJson;
+    const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+    expect(tableNode).toBeDefined();
+    expect(tableNode?.content?.[0]?.type).toBe('tableRow');
+    expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableCell');
+  });
+
+  it('parses table with header row', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<table><tr><th><p>Header</p></th></tr><tr><td><p>Cell</p></td></tr></table>',
+    });
+    const json = editor.getJSON() as AnyJson;
+    const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+    expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableHeader');
+    expect(tableNode?.content?.[1]?.content?.[0]?.type).toBe('tableCell');
+  });
+
+  it('parses colspan and rowspan attributes', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<table><tr><td colspan="2" rowspan="3"><p>Wide cell</p></td></tr></table>',
+    });
+    const json = editor.getJSON() as AnyJson;
+    const cell = json.content?.find((n: AnyJson) => n.type === 'table')
+      ?.content?.[0]?.content?.[0];
+    expect(cell?.attrs?.colspan).toBe(2);
+    expect(cell?.attrs?.rowspan).toBe(3);
+  });
+
+  it('parses colwidth from data-colwidth', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<table><tr><td data-colwidth="150"><p>Sized</p></td></tr></table>',
+    });
+    const json = editor.getJSON() as AnyJson;
+    const cell = json.content?.find((n: AnyJson) => n.type === 'table')
+      ?.content?.[0]?.content?.[0];
+    expect(cell?.attrs?.colwidth).toEqual([150]);
+  });
+});
+
+// === Commands ===
+
+describe('Commands', () => {
+  let editor: InstanceType<typeof Editor>;
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  describe('insertTable', () => {
+    it('inserts a default 3x3 table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p></p>',
+      });
+      // Select all so the empty paragraph is the selection
+      editor.commands.selectAll();
+      const result = editor.commands.insertTable();
+      expect(result).toBe(true);
+      const json = editor.getJSON() as AnyJson;
+      const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+      expect(tableNode).toBeDefined();
+      // 3 rows (1 header + 2 data)
+      expect(tableNode?.content?.length).toBe(3);
+      // First row has header cells
+      expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableHeader');
+      // Second row has data cells
+      expect(tableNode?.content?.[1]?.content?.[0]?.type).toBe('tableCell');
+      // 3 cells per row
+      expect(tableNode?.content?.[0]?.content?.length).toBe(3);
+    });
+
+    it('inserts table with custom size', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      const result = editor.commands.insertTable({ rows: 2, cols: 4, withHeaderRow: false });
+      expect(result).toBe(true);
+      const json = editor.getJSON() as AnyJson;
+      const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+      expect(tableNode).toBeDefined();
+      expect(tableNode?.content?.length).toBe(2);
+      expect(tableNode?.content?.[0]?.content?.length).toBe(4);
+      // No header row
+      expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableCell');
+    });
+
+    it('inserts table without header row', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      const result = editor.commands.insertTable({ rows: 2, cols: 2, withHeaderRow: false });
+      expect(result).toBe(true);
+      const json = editor.getJSON() as AnyJson;
+      const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+      expect(tableNode).toBeDefined();
+      expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableCell');
+    });
+  });
+
+  describe('deleteTable', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      const result = editor.commands.deleteTable();
+      expect(result).toBe(false);
+    });
+
+    it('deletes table when cursor inside', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<table><tr><td><p>Cell</p></td></tr></table>',
+      });
+
+      // Place cursor inside table cell
+      const { state } = editor;
+      const tableNode = state.doc.firstChild;
+      if (tableNode) {
+        // Position inside the paragraph inside the cell
+        const pos = 4; // doc > table > row > cell > paragraph
+        const { tr } = state;
+        tr.setSelection(TextSelection.create(tr.doc, pos));
+        editor.view.dispatch(tr);
+      }
+
+      const result = editor.commands.deleteTable();
+      expect(result).toBe(true);
+      const json = editor.getJSON() as AnyJson;
+      const tableExists = json.content?.some((n: AnyJson) => n.type === 'table');
+      expect(tableExists).toBeFalsy();
+    });
+  });
+
+  describe('addRowBefore / addRowAfter', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.addRowBefore()).toBe(false);
+      expect(editor.commands.addRowAfter()).toBe(false);
+    });
+  });
+
+  describe('deleteRow', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.deleteRow()).toBe(false);
+    });
+  });
+
+  describe('addColumnBefore / addColumnAfter', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.addColumnBefore()).toBe(false);
+      expect(editor.commands.addColumnAfter()).toBe(false);
+    });
+  });
+
+  describe('deleteColumn', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.deleteColumn()).toBe(false);
+    });
+  });
+
+  describe('toggleHeaderRow', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.toggleHeaderRow()).toBe(false);
+    });
+  });
+
+  describe('toggleHeaderColumn', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.toggleHeaderColumn()).toBe(false);
+    });
+  });
+
+  describe('toggleHeaderCell', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.toggleHeaderCell()).toBe(false);
+    });
+  });
+
+  describe('goToNextCell / goToPreviousCell', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.goToNextCell()).toBe(false);
+      expect(editor.commands.goToPreviousCell()).toBe(false);
+    });
+  });
+
+  describe('fixTables', () => {
+    it('returns true always', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.fixTables()).toBe(true);
+    });
+  });
+
+  describe('setCellSelection', () => {
+    it('is available as command', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.setCellSelection).toBeDefined();
+    });
+  });
+
+  describe('setCellAttribute', () => {
+    it('returns false when not in table', () => {
+      editor = new Editor({
+        extensions: allExtensions,
+        content: '<p>Hello</p>',
+      });
+      expect(editor.commands.setCellAttribute('background', '#ff0')).toBe(false);
+    });
+  });
+});
+
+// === createTable Helper ===
+
+describe('createTable helper', () => {
+  let editor: InstanceType<typeof Editor>;
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('creates a table with specified dimensions', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+
+    const table = createTable(editor.schema, 2, 3, false);
+    expect(table.type.name).toBe('table');
+    expect(table.childCount).toBe(2); // 2 rows
+    expect(table.firstChild?.childCount).toBe(3); // 3 cells per row
+    expect(table.firstChild?.firstChild?.type.name).toBe('tableCell');
+  });
+
+  it('creates a table with header row', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+
+    const table = createTable(editor.schema, 3, 2, true);
+    expect(table.childCount).toBe(3);
+    // First row has header cells
+    expect(table.firstChild?.firstChild?.type.name).toBe('tableHeader');
+    // Second row has regular cells
+    expect(table.child(1).firstChild?.type.name).toBe('tableCell');
+  });
+
+  it('creates 1x1 table', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+
+    const table = createTable(editor.schema, 1, 1, false);
+    expect(table.childCount).toBe(1);
+    expect(table.firstChild?.childCount).toBe(1);
+  });
+
+  it('creates large table', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+
+    const table = createTable(editor.schema, 10, 5, true);
+    expect(table.childCount).toBe(10);
+    expect(table.firstChild?.childCount).toBe(5);
+  });
+});
+
+// === Exports ===
+
+describe('Exports', () => {
+  it('exports Table', () => {
+    expect(Table).toBeDefined();
+    expect(Table.name).toBe('table');
+  });
+
+  it('exports TableRow', () => {
+    expect(TableRow).toBeDefined();
+    expect(TableRow.name).toBe('tableRow');
+  });
+
+  it('exports TableCell', () => {
+    expect(TableCell).toBeDefined();
+    expect(TableCell.name).toBe('tableCell');
+  });
+
+  it('exports TableHeader', () => {
+    expect(TableHeader).toBeDefined();
+    expect(TableHeader.name).toBe('tableHeader');
+  });
+
+  it('exports TableView', () => {
+    expect(TableView).toBeDefined();
+  });
+
+  it('exports createTable', () => {
+    expect(createTable).toBeDefined();
+    expect(typeof createTable).toBe('function');
+  });
+});
+
+// === Configure / Extend ===
+
+describe('configure / extend', () => {
+  it('Table.configure merges options', () => {
+    const Custom = Table.configure({
+      resizable: true,
+      cellMinWidth: 50,
+    });
+    expect(Custom.options.resizable).toBe(true);
+    expect(Custom.options.cellMinWidth).toBe(50);
+    expect(Custom.options.handleWidth).toBe(5); // unchanged default
+  });
+
+  it('TableCell.configure merges options', () => {
+    const Custom = TableCell.configure({
+      HTMLAttributes: { class: 'custom-cell' },
+    });
+    expect(Custom.options.HTMLAttributes).toEqual({ class: 'custom-cell' });
+  });
+
+  it('TableHeader.configure merges options', () => {
+    const Custom = TableHeader.configure({
+      HTMLAttributes: { class: 'custom-header' },
+    });
+    expect(Custom.options.HTMLAttributes).toEqual({ class: 'custom-header' });
+  });
+
+  it('TableRow.configure merges options', () => {
+    const Custom = TableRow.configure({
+      HTMLAttributes: { class: 'custom-row' },
+    });
+    expect(Custom.options.HTMLAttributes).toEqual({ class: 'custom-row' });
+  });
+});
+
+// === Re-exports from prosemirror-tables ===
+
+describe('Re-exports', () => {
+  it('re-exports CellSelection', async () => {
+    const { CellSelection } = await import('./index.js');
+    expect(CellSelection).toBeDefined();
+  });
+
+  it('re-exports TableMap', async () => {
+    const { TableMap } = await import('./index.js');
+    expect(TableMap).toBeDefined();
+  });
+});
+
+// === Schema Consistency ===
+
+describe('Schema consistency', () => {
+  let editor: InstanceType<typeof Editor>;
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('all four table node types are registered', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+    const nodeNames = Object.keys(editor.schema.nodes);
+    expect(nodeNames).toContain('table');
+    expect(nodeNames).toContain('tableRow');
+    expect(nodeNames).toContain('tableCell');
+    expect(nodeNames).toContain('tableHeader');
+  });
+
+  it('table content spec references tableRow', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+    expect(editor.schema.nodes['table']!.spec.content).toBe('tableRow+');
+  });
+
+  it('tableRow content spec references cells', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+    expect(editor.schema.nodes['tableRow']!.spec.content).toBe('(tableCell | tableHeader)*');
+  });
+
+  it('cell content spec allows blocks', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+    expect(editor.schema.nodes['tableCell']!.spec.content).toBe('block+');
+    expect(editor.schema.nodes['tableHeader']!.spec.content).toBe('block+');
+  });
+
+  it('table and cells are isolating', () => {
+    editor = new Editor({
+      extensions: allExtensions,
+      content: '<p>Test</p>',
+    });
+    expect(editor.schema.nodes['table']!.spec.isolating).toBe(true);
+    expect(editor.schema.nodes['tableCell']!.spec.isolating).toBe(true);
+    expect(editor.schema.nodes['tableHeader']!.spec.isolating).toBe(true);
+  });
+});
+
+// === HTML Round-trip ===
+
+describe('HTML round-trip', () => {
+  let editor: InstanceType<typeof Editor>;
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('preserves basic table structure through parse → serialize', () => {
+    const html = '<table><tbody><tr><td><p>A</p></td><td><p>B</p></td></tr><tr><td><p>C</p></td><td><p>D</p></td></tr></tbody></table>';
+    editor = new Editor({
+      extensions: allExtensions,
+      content: html,
+    });
+    const json = editor.getJSON() as AnyJson;
+    const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+    expect(tableNode?.content?.length).toBe(2); // 2 rows
+    expect(tableNode?.content?.[0]?.content?.length).toBe(2); // 2 cells
+  });
+
+  it('preserves header cells', () => {
+    const html = '<table><tbody><tr><th><p>H1</p></th><th><p>H2</p></th></tr><tr><td><p>D1</p></td><td><p>D2</p></td></tr></tbody></table>';
+    editor = new Editor({
+      extensions: allExtensions,
+      content: html,
+    });
+    const json = editor.getJSON() as AnyJson;
+    const tableNode = json.content?.find((n: AnyJson) => n.type === 'table');
+    expect(tableNode?.content?.[0]?.content?.[0]?.type).toBe('tableHeader');
+    expect(tableNode?.content?.[1]?.content?.[0]?.type).toBe('tableCell');
+  });
+
+  it('preserves colspan in round-trip', () => {
+    const html = '<table><tbody><tr><td colspan="2"><p>Wide</p></td></tr></tbody></table>';
+    editor = new Editor({
+      extensions: allExtensions,
+      content: html,
+    });
+    const json = editor.getJSON() as AnyJson;
+    const cell = json.content?.find((n: AnyJson) => n.type === 'table')
+      ?.content?.[0]?.content?.[0];
+    expect(cell?.attrs?.colspan).toBe(2);
+  });
+
+  it('preserves rowspan in round-trip', () => {
+    const html = '<table><tbody><tr><td rowspan="3"><p>Tall</p></td><td><p>B</p></td></tr></tbody></table>';
+    editor = new Editor({
+      extensions: allExtensions,
+      content: html,
+    });
+    const json = editor.getJSON() as AnyJson;
+    const cell = json.content?.find((n: AnyJson) => n.type === 'table')
+      ?.content?.[0]?.content?.[0];
+    expect(cell?.attrs?.rowspan).toBe(3);
+  });
+});

--- a/packages/extension-table/src/Table.test.ts
+++ b/packages/extension-table/src/Table.test.ts
@@ -44,10 +44,7 @@ describe('Table', () => {
     it('has default options', () => {
       expect(Table.options).toEqual({
         HTMLAttributes: {},
-        resizable: false,
-        handleWidth: 5,
         cellMinWidth: 25,
-        lastColumnResizable: true,
         allowTableNodeSelection: false,
         View: TableView,
       });
@@ -56,11 +53,6 @@ describe('Table', () => {
     it('can configure HTMLAttributes', () => {
       const Custom = Table.configure({ HTMLAttributes: { class: 'my-table' } });
       expect(Custom.options.HTMLAttributes).toEqual({ class: 'my-table' });
-    });
-
-    it('can configure resizable', () => {
-      const Custom = Table.configure({ resizable: true });
-      expect(Custom.options.resizable).toBe(true);
     });
 
     it('can configure allowTableNodeSelection', () => {
@@ -793,12 +785,10 @@ describe('Exports', () => {
 describe('configure / extend', () => {
   it('Table.configure merges options', () => {
     const Custom = Table.configure({
-      resizable: true,
       cellMinWidth: 50,
     });
-    expect(Custom.options.resizable).toBe(true);
     expect(Custom.options.cellMinWidth).toBe(50);
-    expect(Custom.options.handleWidth).toBe(5); // unchanged default
+    expect(Custom.options.allowTableNodeSelection).toBe(false); // unchanged default
   });
 
   it('TableCell.configure merges options', () => {

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -1,0 +1,372 @@
+/**
+ * Table Node
+ *
+ * Block-level table container using HTML <table>.
+ * Built on prosemirror-tables for cell selection, keyboard nav, and table editing.
+ *
+ * FREE Commands (12):
+ * - insertTable: Insert new table with configurable rows/cols/header
+ * - deleteTable: Delete entire table
+ * - addRowBefore / addRowAfter: Insert row
+ * - deleteRow: Delete current row
+ * - addColumnBefore / addColumnAfter: Insert column
+ * - deleteColumn: Delete current column
+ * - toggleHeaderRow / toggleHeaderColumn / toggleHeaderCell: Toggle header
+ * - setCellAttribute: Set cell attribute
+ *
+ * Additional Commands (4):
+ * - goToNextCell / goToPreviousCell: Cell navigation
+ * - fixTables: Repair malformed tables
+ * - setCellSelection: Programmatic cell selection
+ *
+ * Improvements over Tiptap:
+ * - goToNextCell/goToPreviousCell exposed as standalone commands
+ * - fixTables exposed as command
+ * - setCellSelection for programmatic cell range selection
+ * - cellContent option for configurable cell content expression
+ * - Fully typed options and command params
+ * - Angular-ready: TableView isolated for wrapper replacement
+ */
+
+import { Node } from '@domternal/core';
+import type { CommandSpec } from '@domternal/core';
+import { TextSelection } from 'prosemirror-state';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView, NodeView, NodeViewConstructor } from 'prosemirror-view';
+import {
+  tableEditing,
+  columnResizing,
+  addColumnBefore,
+  addColumnAfter,
+  deleteColumn,
+  addRowBefore,
+  addRowAfter,
+  deleteRow,
+  deleteTable,
+  toggleHeader,
+  toggleHeaderCell,
+  setCellAttr,
+  goToNextCell,
+  fixTables,
+  CellSelection,
+} from 'prosemirror-tables';
+
+import { TableView } from './TableView.js';
+import { createTable } from './helpers/createTable.js';
+import { deleteTableWhenAllCellsSelected } from './helpers/deleteTableWhenAllCellsSelected.js';
+
+declare module '@domternal/core' {
+  interface RawCommands {
+    insertTable: CommandSpec<[options?: { rows?: number; cols?: number; withHeaderRow?: boolean }]>;
+    deleteTable: CommandSpec;
+    addRowBefore: CommandSpec;
+    addRowAfter: CommandSpec;
+    deleteRow: CommandSpec;
+    addColumnBefore: CommandSpec;
+    addColumnAfter: CommandSpec;
+    deleteColumn: CommandSpec;
+    toggleHeaderRow: CommandSpec;
+    toggleHeaderColumn: CommandSpec;
+    toggleHeaderCell: CommandSpec;
+    setCellAttribute: CommandSpec<[name: string, value: unknown]>;
+    goToNextCell: CommandSpec;
+    goToPreviousCell: CommandSpec;
+    fixTables: CommandSpec;
+    setCellSelection: CommandSpec<[position: { anchorCell: number; headCell?: number }]>;
+  }
+}
+
+export interface TableOptions {
+  /**
+   * Custom HTML attributes for the rendered table element.
+   */
+  HTMLAttributes: Record<string, unknown>;
+
+  /**
+   * Enable column resizing UI (wiring for columnResizing plugin).
+   * The actual resize drag handles are part of prosemirror-tables.
+   * @default false
+   */
+  resizable: boolean;
+
+  /**
+   * Width of column resize handles in pixels.
+   * @default 5
+   */
+  handleWidth: number;
+
+  /**
+   * Minimum cell width in pixels.
+   * @default 25
+   */
+  cellMinWidth: number;
+
+  /**
+   * Whether the last column can be resized.
+   * @default true
+   */
+  lastColumnResizable: boolean;
+
+  /**
+   * Allow selecting the entire table as a node selection.
+   * @default false
+   */
+  allowTableNodeSelection: boolean;
+
+  /**
+   * Custom NodeView constructor. Override to provide framework-specific rendering.
+   * Set to null to disable custom NodeView.
+   */
+  View: (new (node: PMNode, cellMinWidth: number, view: EditorView) => NodeView) | null;
+}
+
+export const Table = Node.create<TableOptions>({
+  name: 'table',
+  group: 'block',
+  content: 'tableRow+',
+  tableRole: 'table',
+  isolating: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+      resizable: false,
+      handleWidth: 5,
+      cellMinWidth: 25,
+      lastColumnResizable: true,
+      allowTableNodeSelection: false,
+      View: TableView,
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'table' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['table', { ...this.options.HTMLAttributes, ...HTMLAttributes }, ['tbody', 0]];
+  },
+
+  addNodeView() {
+    const ViewClass = this.options.View;
+    const cellMinWidth = this.options.cellMinWidth;
+
+    if (!ViewClass) {
+      return undefined as unknown as NodeViewConstructor;
+    }
+
+    return ((node: PMNode, view: EditorView) =>
+      new ViewClass(node, cellMinWidth, view)) as unknown as NodeViewConstructor;
+  },
+
+  addCommands() {
+    return {
+      insertTable:
+        (options?: { rows?: number; cols?: number; withHeaderRow?: boolean }) =>
+        ({ state, tr, dispatch }) => {
+          const rows = options?.rows ?? 3;
+          const cols = options?.cols ?? 3;
+          const withHeaderRow = options?.withHeaderRow ?? true;
+          const table = createTable(state.schema, rows, cols, withHeaderRow);
+
+          if (!dispatch) {
+            return true;
+          }
+
+          const offset = tr.selection.from + 1;
+          tr.replaceSelectionWith(table)
+            .scrollIntoView()
+            .setSelection(TextSelection.near(tr.doc.resolve(offset)));
+          dispatch(tr);
+
+          return true;
+        },
+
+      deleteTable:
+        () =>
+        ({ state, dispatch }) => {
+          return deleteTable(state, dispatch);
+        },
+
+      addRowBefore:
+        () =>
+        ({ state, dispatch }) => {
+          return addRowBefore(state, dispatch);
+        },
+
+      addRowAfter:
+        () =>
+        ({ state, dispatch }) => {
+          return addRowAfter(state, dispatch);
+        },
+
+      deleteRow:
+        () =>
+        ({ state, dispatch }) => {
+          return deleteRow(state, dispatch);
+        },
+
+      addColumnBefore:
+        () =>
+        ({ state, dispatch }) => {
+          return addColumnBefore(state, dispatch);
+        },
+
+      addColumnAfter:
+        () =>
+        ({ state, dispatch }) => {
+          return addColumnAfter(state, dispatch);
+        },
+
+      deleteColumn:
+        () =>
+        ({ state, dispatch }) => {
+          return deleteColumn(state, dispatch);
+        },
+
+      toggleHeaderRow:
+        () =>
+        ({ state, dispatch }) => {
+          return toggleHeader('row')(state, dispatch);
+        },
+
+      toggleHeaderColumn:
+        () =>
+        ({ state, dispatch }) => {
+          return toggleHeader('column')(state, dispatch);
+        },
+
+      toggleHeaderCell:
+        () =>
+        ({ state, dispatch }) => {
+          return toggleHeaderCell(state, dispatch);
+        },
+
+      setCellAttribute:
+        (name: string, value: unknown) =>
+        ({ state, dispatch }) => {
+          return setCellAttr(name, value)(state, dispatch);
+        },
+
+      goToNextCell:
+        () =>
+        ({ state, dispatch }) => {
+          return goToNextCell(1)(state, dispatch);
+        },
+
+      goToPreviousCell:
+        () =>
+        ({ state, dispatch }) => {
+          return goToNextCell(-1)(state, dispatch);
+        },
+
+      fixTables:
+        () =>
+        ({ state, dispatch }) => {
+          if (dispatch) {
+            fixTables(state);
+          }
+          return true;
+        },
+
+      setCellSelection:
+        (position: { anchorCell: number; headCell?: number }) =>
+        ({ tr, dispatch }) => {
+          if (dispatch) {
+            const selection = CellSelection.create(
+              tr.doc,
+              position.anchorCell,
+              position.headCell,
+            );
+            tr.setSelection(selection as unknown as typeof tr.selection);
+          }
+          return true;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    const editor = this.editor;
+
+    return {
+      Tab: () => {
+        if (!editor) return false;
+
+        // Try to move to next cell
+        if (editor.commands['goToNextCell']?.()) {
+          return true;
+        }
+
+        // If no next cell, add a row and move into it
+        if (editor.commands['addRowAfter']?.()) {
+          editor.commands['goToNextCell']?.();
+          return true;
+        }
+
+        return false;
+      },
+
+      'Shift-Tab': () => {
+        if (!editor) return false;
+        return editor.commands['goToPreviousCell']?.() ?? false;
+      },
+
+      Backspace: () => {
+        if (!editor) return false;
+        return deleteTableWhenAllCellsSelected({
+          state: editor.state,
+          dispatch: editor.view.dispatch,
+        });
+      },
+
+      'Mod-Backspace': () => {
+        if (!editor) return false;
+        return deleteTableWhenAllCellsSelected({
+          state: editor.state,
+          dispatch: editor.view.dispatch,
+        });
+      },
+
+      Delete: () => {
+        if (!editor) return false;
+        return deleteTableWhenAllCellsSelected({
+          state: editor.state,
+          dispatch: editor.view.dispatch,
+        });
+      },
+
+      'Mod-Delete': () => {
+        if (!editor) return false;
+        return deleteTableWhenAllCellsSelected({
+          state: editor.state,
+          dispatch: editor.view.dispatch,
+        });
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const isResizable = this.options.resizable && this.editor?.view.editable;
+
+    const plugins = [];
+
+    if (isResizable) {
+      plugins.push(
+        columnResizing({
+          handleWidth: this.options.handleWidth,
+          cellMinWidth: this.options.cellMinWidth,
+          View: this.options.View ?? null,
+          lastColumnResizable: this.options.lastColumnResizable,
+        }),
+      );
+    }
+
+    plugins.push(
+      tableEditing({
+        allowTableNodeSelection: this.options.allowTableNodeSelection,
+      }),
+    );
+
+    return plugins;
+  },
+});

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -32,7 +32,6 @@ import type { Node as PMNode } from 'prosemirror-model';
 import type { EditorView, NodeView, NodeViewConstructor } from 'prosemirror-view';
 import {
   tableEditing,
-  columnResizing,
   addColumnBefore,
   addColumnAfter,
   deleteColumn,
@@ -80,29 +79,10 @@ export interface TableOptions {
   HTMLAttributes: Record<string, unknown>;
 
   /**
-   * Enable column resizing UI (wiring for columnResizing plugin).
-   * The actual resize drag handles are part of prosemirror-tables.
-   * @default false
-   */
-  resizable: boolean;
-
-  /**
-   * Width of column resize handles in pixels.
-   * @default 5
-   */
-  handleWidth: number;
-
-  /**
    * Minimum cell width in pixels.
    * @default 25
    */
   cellMinWidth: number;
-
-  /**
-   * Whether the last column can be resized.
-   * @default true
-   */
-  lastColumnResizable: boolean;
 
   /**
    * Allow selecting the entire table as a node selection.
@@ -127,10 +107,7 @@ export const Table = Node.create<TableOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
-      resizable: false,
-      handleWidth: 5,
       cellMinWidth: 25,
-      lastColumnResizable: true,
       allowTableNodeSelection: false,
       View: TableView,
     };
@@ -344,27 +321,10 @@ export const Table = Node.create<TableOptions>({
   },
 
   addProseMirrorPlugins() {
-    const isResizable = this.options.resizable && this.editor?.view.editable;
-
-    const plugins = [];
-
-    if (isResizable) {
-      plugins.push(
-        columnResizing({
-          handleWidth: this.options.handleWidth,
-          cellMinWidth: this.options.cellMinWidth,
-          View: this.options.View ?? null,
-          lastColumnResizable: this.options.lastColumnResizable,
-        }),
-      );
-    }
-
-    plugins.push(
+    return [
       tableEditing({
         allowTableNodeSelection: this.options.allowTableNodeSelection,
       }),
-    );
-
-    return plugins;
+    ];
   },
 });

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -4,7 +4,7 @@
  * Block-level table container using HTML <table>.
  * Built on prosemirror-tables for cell selection, keyboard nav, and table editing.
  *
- * FREE Commands (12):
+ * Commands (16):
  * - insertTable: Insert new table with configurable rows/cols/header
  * - deleteTable: Delete entire table
  * - addRowBefore / addRowAfter: Insert row
@@ -13,8 +13,6 @@
  * - deleteColumn: Delete current column
  * - toggleHeaderRow / toggleHeaderColumn / toggleHeaderCell: Toggle header
  * - setCellAttribute: Set cell attribute
- *
- * Additional Commands (4):
  * - goToNextCell / goToPreviousCell: Cell navigation
  * - fixTables: Repair malformed tables
  * - setCellSelection: Programmatic cell selection

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -23,7 +23,6 @@
  * - goToNextCell/goToPreviousCell exposed as standalone commands
  * - fixTables exposed as command
  * - setCellSelection for programmatic cell range selection
- * - cellContent option for configurable cell content expression
  * - Fully typed options and command params
  * - Angular-ready: TableView isolated for wrapper replacement
  */
@@ -264,7 +263,8 @@ export const Table = Node.create<TableOptions>({
         () =>
         ({ state, dispatch }) => {
           if (dispatch) {
-            fixTables(state);
+            const tr = fixTables(state);
+            if (tr) dispatch(tr);
           }
           return true;
         },

--- a/packages/extension-table/src/TableCell.ts
+++ b/packages/extension-table/src/TableCell.ts
@@ -61,6 +61,17 @@ export const TableCell = Node.create<TableCellOptions>({
           return { 'data-colwidth': colwidth.join(',') };
         },
       },
+      background: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          return element.getAttribute('data-background') ?? (element.style.backgroundColor || null);
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const bg = attrs['background'] as string | null;
+          if (!bg) return null;
+          return { 'data-background': bg, style: `background-color: ${bg}` };
+        },
+      },
     };
   },
 

--- a/packages/extension-table/src/TableCell.ts
+++ b/packages/extension-table/src/TableCell.ts
@@ -1,0 +1,74 @@
+/**
+ * TableCell Node
+ *
+ * Table data cell (<td>). Contains block content.
+ * Supports colspan, rowspan, and colwidth attributes for advanced table layouts.
+ */
+
+import { Node } from '@domternal/core';
+
+export interface TableCellOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const TableCell = Node.create<TableCellOptions>({
+  name: 'tableCell',
+  content: 'block+',
+  tableRole: 'cell',
+  isolating: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      colspan: {
+        default: 1,
+        parseHTML: (element: HTMLElement) => {
+          const colspan = element.getAttribute('colspan');
+          return colspan ? Number(colspan) : 1;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const colspan = attrs['colspan'] as number;
+          if (colspan === 1) return null;
+          return { colspan };
+        },
+      },
+      rowspan: {
+        default: 1,
+        parseHTML: (element: HTMLElement) => {
+          const rowspan = element.getAttribute('rowspan');
+          return rowspan ? Number(rowspan) : 1;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const rowspan = attrs['rowspan'] as number;
+          if (rowspan === 1) return null;
+          return { rowspan };
+        },
+      },
+      colwidth: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          const colwidth = element.getAttribute('data-colwidth');
+          return colwidth ? colwidth.split(',').map(Number) : null;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const colwidth = attrs['colwidth'] as number[] | null;
+          if (!colwidth) return null;
+          return { 'data-colwidth': colwidth.join(',') };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'td' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['td', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+  },
+});

--- a/packages/extension-table/src/TableHeader.ts
+++ b/packages/extension-table/src/TableHeader.ts
@@ -1,0 +1,74 @@
+/**
+ * TableHeader Node
+ *
+ * Table header cell (<th>). Contains block content.
+ * Same attributes as TableCell (colspan, rowspan, colwidth).
+ */
+
+import { Node } from '@domternal/core';
+
+export interface TableHeaderOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const TableHeader = Node.create<TableHeaderOptions>({
+  name: 'tableHeader',
+  content: 'block+',
+  tableRole: 'header_cell',
+  isolating: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      colspan: {
+        default: 1,
+        parseHTML: (element: HTMLElement) => {
+          const colspan = element.getAttribute('colspan');
+          return colspan ? Number(colspan) : 1;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const colspan = attrs['colspan'] as number;
+          if (colspan === 1) return null;
+          return { colspan };
+        },
+      },
+      rowspan: {
+        default: 1,
+        parseHTML: (element: HTMLElement) => {
+          const rowspan = element.getAttribute('rowspan');
+          return rowspan ? Number(rowspan) : 1;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const rowspan = attrs['rowspan'] as number;
+          if (rowspan === 1) return null;
+          return { rowspan };
+        },
+      },
+      colwidth: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          const colwidth = element.getAttribute('data-colwidth');
+          return colwidth ? colwidth.split(',').map(Number) : null;
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const colwidth = attrs['colwidth'] as number[] | null;
+          if (!colwidth) return null;
+          return { 'data-colwidth': colwidth.join(',') };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'th' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['th', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+  },
+});

--- a/packages/extension-table/src/TableHeader.ts
+++ b/packages/extension-table/src/TableHeader.ts
@@ -61,6 +61,17 @@ export const TableHeader = Node.create<TableHeaderOptions>({
           return { 'data-colwidth': colwidth.join(',') };
         },
       },
+      background: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          return element.getAttribute('data-background') ?? (element.style.backgroundColor || null);
+        },
+        renderHTML: (attrs: Record<string, unknown>) => {
+          const bg = attrs['background'] as string | null;
+          if (!bg) return null;
+          return { 'data-background': bg, style: `background-color: ${bg}` };
+        },
+      },
     };
   },
 

--- a/packages/extension-table/src/TableRow.ts
+++ b/packages/extension-table/src/TableRow.ts
@@ -1,0 +1,31 @@
+/**
+ * TableRow Node
+ *
+ * Table row (<tr>). Contains table cells and/or table header cells.
+ */
+
+import { Node } from '@domternal/core';
+
+export interface TableRowOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const TableRow = Node.create<TableRowOptions>({
+  name: 'tableRow',
+  content: '(tableCell | tableHeader)*',
+  tableRole: 'row',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'tr' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['tr', { ...this.options.HTMLAttributes, ...HTMLAttributes }, 0];
+  },
+});

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -1,0 +1,128 @@
+/**
+ * TableView - Custom NodeView for table rendering
+ *
+ * Creates: div.tableWrapper > table > colgroup + tbody
+ * - Wrapper div enables horizontal scrolling for wide tables
+ * - Colgroup reflects column widths (foundation for PRO column resize)
+ * - ContentDOM = tbody (ProseMirror renders row content into tbody)
+ */
+
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView, NodeView } from 'prosemirror-view';
+
+export class TableView implements NodeView {
+  node: PMNode;
+  cellMinWidth: number;
+
+  dom: HTMLElement;
+  table: HTMLTableElement;
+  colgroup: HTMLTableColElement;
+  contentDOM: HTMLElement;
+
+  constructor(node: PMNode, cellMinWidth: number, _view: EditorView) {
+    this.node = node;
+    this.cellMinWidth = cellMinWidth;
+
+    // Create wrapper div
+    this.dom = document.createElement('div');
+    this.dom.className = 'tableWrapper';
+
+    // Create table
+    this.table = document.createElement('table');
+    this.dom.appendChild(this.table);
+
+    // Create colgroup
+    this.colgroup = document.createElement('colgroup');
+    this.updateColumns(node);
+    this.table.appendChild(this.colgroup);
+
+    // Create tbody (contentDOM)
+    this.contentDOM = document.createElement('tbody');
+    this.table.appendChild(this.contentDOM);
+  }
+
+  update(node: PMNode): boolean {
+    if (node.type !== this.node.type) {
+      return false;
+    }
+    this.node = node;
+    this.updateColumns(node);
+    return true;
+  }
+
+  ignoreMutation(mutation: MutationRecord | { type: 'selection' }): boolean {
+    // Allow selection mutations
+    if (mutation.type === 'selection') {
+      return false;
+    }
+
+    // Ignore mutations in the colgroup (we manage it)
+    if (
+      mutation instanceof MutationRecord &&
+      this.colgroup.contains(mutation.target)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Rebuild colgroup col elements based on cell widths.
+   * Scans first row to determine column count and widths.
+   */
+  private updateColumns(node: PMNode): void {
+    const cols: { width?: number }[] = [];
+
+    // Walk the first row to get column info
+    const firstRow = node.firstChild;
+    if (firstRow) {
+      for (let i = 0; i < firstRow.childCount; i++) {
+        const cell = firstRow.child(i);
+        const colspan = (cell.attrs['colspan'] as number) || 1;
+        const colwidth = cell.attrs['colwidth'] as number[] | null;
+
+        for (let j = 0; j < colspan; j++) {
+          const w = colwidth?.[j];
+          if (w) {
+            cols.push({ width: w });
+          } else {
+            cols.push({});
+          }
+        }
+      }
+    }
+
+    // Clear existing cols
+    while (this.colgroup.firstChild) {
+      this.colgroup.removeChild(this.colgroup.firstChild);
+    }
+
+    // Calculate if we have all widths defined
+    let totalWidth = 0;
+    let allWidthsDefined = true;
+
+    for (const col of cols) {
+      const colEl = document.createElement('col');
+
+      if (col.width) {
+        colEl.style.width = `${String(col.width)}px`;
+        totalWidth += col.width;
+      } else {
+        colEl.style.width = `${String(this.cellMinWidth)}px`;
+        allWidthsDefined = false;
+      }
+
+      this.colgroup.appendChild(colEl);
+    }
+
+    // Set table width
+    if (allWidthsDefined && totalWidth > 0) {
+      this.table.style.width = `${String(totalWidth)}px`;
+      this.table.style.minWidth = '';
+    } else {
+      this.table.style.width = '';
+      this.table.style.minWidth = `${String(totalWidth || this.cellMinWidth * cols.length)}px`;
+    }
+  }
+}

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -51,9 +51,14 @@ export class TableView implements NodeView {
   }
 
   ignoreMutation(mutation: MutationRecord | { type: 'selection' }): boolean {
-    // Allow selection mutations
+    // Allow selection mutations to propagate
     if (mutation.type === 'selection') {
       return false;
+    }
+
+    // Ignore attribute mutations (style changes from updateColumns)
+    if (mutation.type === 'attributes') {
+      return true;
     }
 
     // Ignore mutations in the colgroup (we manage it)

--- a/packages/extension-table/src/helpers/createTable.ts
+++ b/packages/extension-table/src/helpers/createTable.ts
@@ -1,0 +1,51 @@
+/**
+ * Creates a table node from schema types.
+ *
+ * Builds table → rows → cells structure.
+ * First row gets tableHeader cells if withHeaderRow is true.
+ */
+
+import type { Node as PMNode, Schema } from 'prosemirror-model';
+import { tableNodeTypes } from 'prosemirror-tables';
+
+export function createTable(
+  schema: Schema,
+  rows: number,
+  cols: number,
+  withHeaderRow: boolean,
+  cellContent?: PMNode,
+): PMNode {
+  const types = tableNodeTypes(schema);
+
+  const headerCells: PMNode[] = [];
+  const cells: PMNode[] = [];
+
+  for (let col = 0; col < cols; col++) {
+    const cell = cellContent
+      ? types.cell.createChecked(null, cellContent)
+      : types.cell.createAndFill();
+
+    if (cell) {
+      cells.push(cell);
+    }
+
+    if (withHeaderRow) {
+      const headerCell = cellContent
+        ? types.header_cell.createChecked(null, cellContent)
+        : types.header_cell.createAndFill();
+
+      if (headerCell) {
+        headerCells.push(headerCell);
+      }
+    }
+  }
+
+  const tableRows: PMNode[] = [];
+
+  for (let row = 0; row < rows; row++) {
+    const rowCells = withHeaderRow && row === 0 ? headerCells : cells;
+    tableRows.push(types.row.createChecked(null, rowCells));
+  }
+
+  return types.table.createChecked(null, tableRows);
+}

--- a/packages/extension-table/src/helpers/deleteTableWhenAllCellsSelected.ts
+++ b/packages/extension-table/src/helpers/deleteTableWhenAllCellsSelected.ts
@@ -1,0 +1,59 @@
+/**
+ * Keyboard handler that deletes the table when all cells are selected.
+ *
+ * Used for Backspace, Delete, Mod-Backspace, Mod-Delete.
+ * When a CellSelection covers all cells in a table, delete the entire table.
+ */
+
+import { CellSelection, findTable } from 'prosemirror-tables';
+import { TextSelection } from 'prosemirror-state';
+import type { EditorState, Transaction } from 'prosemirror-state';
+
+export function deleteTableWhenAllCellsSelected({
+  state,
+  dispatch,
+}: {
+  state: EditorState;
+  dispatch?: (tr: Transaction) => void;
+}): boolean {
+  const { selection } = state;
+
+  if (!(selection instanceof CellSelection)) {
+    return false;
+  }
+
+  // Check: is the full table selected?
+  let cellCount = 0;
+  const table = findTable(selection.$anchorCell);
+
+  if (!table) {
+    return false;
+  }
+
+  table.node.descendants((node) => {
+    const role = (node.type.spec as Record<string, unknown>)['tableRole'];
+    if (role === 'cell' || role === 'header_cell') {
+      cellCount++;
+    }
+  });
+
+  const selectionCellCount = selection.ranges.length;
+
+  if (cellCount !== selectionCellCount) {
+    return false;
+  }
+
+  if (dispatch) {
+    const tr = state.tr;
+    tr.delete(table.pos, table.pos + table.node.nodeSize);
+
+    // Place cursor at the position where the table was
+    const $pos = tr.doc.resolve(Math.min(table.pos, tr.doc.content.size));
+    const newSelection = TextSelection.near($pos);
+    tr.setSelection(newSelection);
+
+    dispatch(tr);
+  }
+
+  return true;
+}

--- a/packages/extension-table/src/index.ts
+++ b/packages/extension-table/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @domternal/extension-table
+ * Table extension for Domternal editor
+ *
+ * Built on prosemirror-tables. Provides 4 nodes (Table, TableRow, TableCell, TableHeader),
+ * 16 commands, Tab/Arrow keyboard navigation, and CellSelection support.
+ */
+
+export { Table, type TableOptions } from './Table.js';
+export { TableRow, type TableRowOptions } from './TableRow.js';
+export { TableCell, type TableCellOptions } from './TableCell.js';
+export { TableHeader, type TableHeaderOptions } from './TableHeader.js';
+export { TableView } from './TableView.js';
+export { createTable } from './helpers/createTable.js';
+export { deleteTableWhenAllCellsSelected } from './helpers/deleteTableWhenAllCellsSelected.js';
+
+// Re-export useful types from prosemirror-tables
+export { CellSelection, TableMap } from 'prosemirror-tables';

--- a/packages/extension-table/tsconfig.json
+++ b/packages/extension-table/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["es2022", "dom"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/extension-table/tsup.config.ts
+++ b/packages/extension-table/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  target: 'es2022',
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+  external: [
+    '@domternal/core',
+    'prosemirror-model',
+    'prosemirror-state',
+    'prosemirror-view',
+    'prosemirror-transform',
+    'prosemirror-commands',
+    'prosemirror-keymap',
+    'prosemirror-inputrules',
+    'prosemirror-history',
+    'prosemirror-schema-list',
+    'prosemirror-dropcursor',
+    'prosemirror-gapcursor',
+    'prosemirror-tables',
+  ],
+});

--- a/packages/extension-table/vitest.config.ts
+++ b/packages/extension-table/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['@domternal/source'],
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,34 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  packages/extension-table:
+    dependencies:
+      '@domternal/core':
+        specifier: workspace:*
+        version: link:../core
+      prosemirror-model:
+        specifier: ^1.25.4
+        version: 1.25.4
+      prosemirror-state:
+        specifier: ^1.4.4
+        version: 1.4.4
+      prosemirror-tables:
+        specifier: ^1.8.0
+        version: 1.8.5
+      prosemirror-view:
+        specifier: ^1.41.5
+        version: 1.41.5
+    devDependencies:
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
 packages:
 
   '@acemir/cssom@0.9.31':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,121 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(jsdom@27.4.0)(yaml@2.8.2)
 
+  demo:
+    dependencies:
+      '@tiptap/core':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-bubble-menu':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-character-count':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-code-block-lowlight':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(highlight.js@11.11.1)(lowlight@3.3.0)
+      '@tiptap/extension-color':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-details':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-details-content':
+        specifier: ^2.26.2
+        version: 2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-details-summary':
+        specifier: ^2.26.2
+        version: 2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-emoji':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(emojibase@17.0.0)
+      '@tiptap/extension-floating-menu':
+        specifier: ^3.19.0
+        version: 3.19.0(@floating-ui/dom@1.7.5)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-focus':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-font-family':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-highlight':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-image':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-link':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-mention':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-placeholder':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-subscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-superscript':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-table':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-table-cell':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-table-header':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-table-row':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-task-item':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-task-list':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text-align':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text-style':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-typography':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-underline':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/pm':
+        specifier: ^3.19.0
+        version: 3.19.0
+      '@tiptap/starter-kit':
+        specifier: ^3.19.0
+        version: 3.19.0
+      '@tiptap/suggestion':
+        specifier: ^3.19.0
+        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
+      lowlight:
+        specifier: ^3.3.0
+        version: 3.3.0
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.1(yaml@2.8.2)
+
   packages/core:
     dependencies:
       linkifyjs:
@@ -873,16 +988,34 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -891,16 +1024,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -909,10 +1060,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -921,10 +1084,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -933,10 +1108,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -945,10 +1132,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -957,10 +1156,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -969,16 +1180,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -987,10 +1216,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -999,11 +1240,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -1011,16 +1264,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -1075,6 +1346,15 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1291,6 +1571,11 @@ packages:
     resolution: {integrity: sha512-bFuJRKOscsDAEZ/a8BezcTMAe2BQ/OBRfuMLFUuINfTR5qGVcm4a3xBIrQVepBaPxFj16SJdRjGe05vDiwZmFw==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
@@ -1520,6 +1805,286 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
+  '@tiptap/core@3.19.0':
+    resolution: {integrity: sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==}
+    peerDependencies:
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-blockquote@3.19.0':
+    resolution: {integrity: sha512-y3UfqY9KD5XwWz3ndiiJ089Ij2QKeiXy/g1/tlAN/F1AaWsnkHEHMLxCP1BIqmMpwsX7rZjMLN7G5Lp7c9682A==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-bold@3.19.0':
+    resolution: {integrity: sha512-UZgb1d0XK4J/JRIZ7jW+s4S6KjuEDT2z1PPM6ugcgofgJkWQvRZelCPbmtSFd3kwsD+zr9UPVgTh9YIuGQ8t+Q==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-bubble-menu@3.19.0':
+    resolution: {integrity: sha512-klNVIYGCdznhFkrRokzGd6cwzoi8J7E5KbuOfZBwFwhMKZhlz/gJfKmYg9TJopeUhrr2Z9yHgWTk8dh/YIJCdQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-bullet-list@3.19.0':
+    resolution: {integrity: sha512-F9uNnqd0xkJbMmRxVI5RuVxwB9JaCH/xtRqOUNQZnRBt7IdAElCY+Dvb4hMCtiNv+enGM/RFGJuFHR9TxmI7rw==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-character-count@3.19.0':
+    resolution: {integrity: sha512-ElmlJkSD2tx7f2Hw12qQu4PD8GHfOQfY999EbJENQBtaz+uszUE19Grc1GNs5X+0T757OprM1A9EBPnMX667WQ==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.19.0
+
+  '@tiptap/extension-code-block-lowlight@3.19.0':
+    resolution: {integrity: sha512-P8O8i1J+XozEVA7bF/Ijwf/r1rVqrh1DBQ7dXxBcrUvLpIGyVjtxX228jBF/kD4kf2xOlphvjDhV2fLa8XOVsg==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/extension-code-block': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+      highlight.js: ^11
+      lowlight: ^2 || ^3
+
+  '@tiptap/extension-code-block@3.19.0':
+    resolution: {integrity: sha512-b/2qR+tMn8MQb+eaFYgVk4qXnLNkkRYmwELQ8LEtEDQPxa5Vl7J3eu8+4OyoIFhZrNDZvvoEp80kHMCP8sI6rg==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-code@3.19.0':
+    resolution: {integrity: sha512-2kqqQIXBXj2Or+4qeY3WoE7msK+XaHKL6EKOcKlOP2BW8eYqNTPzNSL+PfBDQ3snA7ljZQkTs/j4GYDj90vR1A==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-color@3.19.0':
+    resolution: {integrity: sha512-SemOrEEnmbKshhbTeKIvffwMlgqDAUDuOYyizfKqYM2dd5fRjohp+oszExO7scVhDtHtvtP/l3UmkBGBYfl4Tg==}
+    peerDependencies:
+      '@tiptap/extension-text-style': ^3.19.0
+
+  '@tiptap/extension-details-content@2.26.2':
+    resolution: {integrity: sha512-2Ia2KqwYucuv7dcTpA/PhytUuDhotzi8uZPXBHlGJLHVI9rAmJsSvID9cX/YWRTvCvAxyNqDp0sBH+Qx8QcloQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/extension-text-style': ^2.7.0
+
+  '@tiptap/extension-details-summary@2.26.2':
+    resolution: {integrity: sha512-rbRq6f56HKvzIuSpPHt513Ubglq728pz8Jx7WBRVqjpYF5/sTpYu9hZpbrIfLfjb2UakXI/LVU8vS50VwTwCnw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/extension-text-style': ^2.7.0
+
+  '@tiptap/extension-details@3.19.0':
+    resolution: {integrity: sha512-BUc9N8UVl/orzXoDSh9YCB+G1csNDAKm4EeKAQpGotbgv32nnTPKv50BvPx+a5pZfVQHaiJlb98Xmi7dMZs1Ug==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/extension-text-style': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-document@3.19.0':
+    resolution: {integrity: sha512-AOf0kHKSFO0ymjVgYSYDncRXTITdTcrj1tqxVazrmO60KNl1Rc2dAggDvIVTEBy5NvceF0scc7q3sE/5ZtVV7A==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-dropcursor@3.19.0':
+    resolution: {integrity: sha512-sf3dEZXiLvsGqVK2maUIzXY6qtYYCvBumag7+VPTMGQ0D4hiZ1X/4ukt4+6VXDg5R2WP1CoIt/QvUetUjWNhbQ==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.19.0
+
+  '@tiptap/extension-emoji@3.19.0':
+    resolution: {integrity: sha512-sMpMUuVKaMqmOdIwFotuRSIw5LgBSECSQJKdC6HUUlETvtcRkUgf6SmrKefixXyir2CQPbA3ioDZTNTI2rs1Wg==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+      '@tiptap/suggestion': ^3.19.0
+
+  '@tiptap/extension-floating-menu@3.19.0':
+    resolution: {integrity: sha512-JaoEkVRkt+Slq3tySlIsxnMnCjS0L5n1CA1hctjLy0iah8edetj3XD5mVv5iKqDzE+LIjF4nwLRRVKJPc8hFBg==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-focus@3.19.0':
+    resolution: {integrity: sha512-XARmebegMrRvrvGPICJVJr1D6MOry8FbsaCKfI2t7C/WqE5dofe+uoiCrOAz9Uz0DMYHGGYZtr2GDM6FKIdPGw==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.19.0
+
+  '@tiptap/extension-font-family@3.19.0':
+    resolution: {integrity: sha512-sUMvgETZkhEUts7arczK+mBz2wnokgGCf3TxRwR2Wy6cx4f9+TTAPT+pm0a7GAvPfra6OzoCWnkcVDVcTJA9/Q==}
+    peerDependencies:
+      '@tiptap/extension-text-style': ^3.19.0
+
+  '@tiptap/extension-gapcursor@3.19.0':
+    resolution: {integrity: sha512-w7DACS4oSZaDWjz7gropZHPc9oXqC9yERZTcjWxyORuuIh1JFf0TRYspleK+OK28plK/IftojD/yUDn1MTRhvA==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.19.0
+
+  '@tiptap/extension-hard-break@3.19.0':
+    resolution: {integrity: sha512-lAmQraYhPS5hafvCl74xDB5+bLuNwBKIEsVoim35I0sDJj5nTrfhaZgMJ91VamMvT+6FF5f1dvBlxBxAWa8jew==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-heading@3.19.0':
+    resolution: {integrity: sha512-uLpLlfyp086WYNOc0ekm1gIZNlEDfmzOhKzB0Hbyi6jDagTS+p9mxUNYeYOn9jPUxpFov43+Wm/4E24oY6B+TQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-highlight@3.19.0':
+    resolution: {integrity: sha512-MYwSDCh/aG12KXw30XmHwrruElBRB8b7Ou0jd8n8H2oXb+QexVqnMa2+ylkuTAl+2D5PR7zdIIOeeHRSTmkPPw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-horizontal-rule@3.19.0':
+    resolution: {integrity: sha512-iqUHmgMGhMgYGwG6L/4JdelVQ5Mstb4qHcgTGd/4dkcUOepILvhdxajPle7OEdf9sRgjQO6uoAU5BVZVC26+ng==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-image@3.19.0':
+    resolution: {integrity: sha512-/rGl8nBziBPVJJ/9639eQWFDKcI3RQsDM3s+cqYQMFQfMqc7sQB9h4o4sHCBpmKxk3Y0FV/0NjnjLbBVm8OKdQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-italic@3.19.0':
+    resolution: {integrity: sha512-6GffxOnS/tWyCbDkirWNZITiXRta9wrCmrfa4rh+v32wfaOL1RRQNyqo9qN6Wjyl1R42Js+yXTzTTzZsOaLMYA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-link@3.19.0':
+    resolution: {integrity: sha512-HEGDJnnCPfr7KWu7Dsq+eRRe/mBCsv6DuI+7fhOCLDJjjKzNgrX2abbo/zG3D/4lCVFaVb+qawgJubgqXR/Smw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-list-item@3.19.0':
+    resolution: {integrity: sha512-VsSKuJz4/Tb6ZmFkXqWpDYkRzmaLTyE6dNSEpNmUpmZ32sMqo58mt11/huADNwfBFB0Ve7siH/VnFNIJYY3xvg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-list-keymap@3.19.0':
+    resolution: {integrity: sha512-bxgmAgA3RzBGA0GyTwS2CC1c+QjkJJq9hC+S6PSOWELGRiTbwDN3MANksFXLjntkTa0N5fOnL27vBHtMStURqw==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-list@3.19.0':
+    resolution: {integrity: sha512-N6nKbFB2VwMsPlCw67RlAtYSK48TAsAUgjnD+vd3ieSlIufdQnLXDFUP6hFKx9mwoUVUgZGz02RA6bkxOdYyTw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-mention@3.19.0':
+    resolution: {integrity: sha512-iBWX6mUouvDe9F75C2fJnFzvBFYVF8fcOa7UvzqWHRSCt8WxqSIp6C1B9Y0npP4TbIZySHzPV4NQQJhtmWwKww==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+      '@tiptap/suggestion': ^3.19.0
+
+  '@tiptap/extension-ordered-list@3.19.0':
+    resolution: {integrity: sha512-cxGsINquwHYE1kmhAcLNLHAofmoDEG6jbesR5ybl7tU5JwtKVO7S/xZatll2DU1dsDAXWPWEeeMl4e/9svYjCg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-paragraph@3.19.0':
+    resolution: {integrity: sha512-xWa6gj82l5+AzdYyrSk9P4ynySaDzg/SlR1FarXE5yPXibYzpS95IWaVR0m2Qaz7Rrk+IiYOTGxGRxcHLOelNg==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-placeholder@3.19.0':
+    resolution: {integrity: sha512-i15OfgyI4IDCYAcYSKUMnuZkYuUInfanjf9zquH8J2BETiomf/jZldVCp/QycMJ8DOXZ38fXDc99wOygnSNySg==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.19.0
+
+  '@tiptap/extension-strike@3.19.0':
+    resolution: {integrity: sha512-xYpabHsv7PccLUBQaP8AYiFCnYbx6P93RHPd0lgNwhdOjYFd931Zy38RyoxPHAgbYVmhf1iyx7lpuLtBnhS5dA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-subscript@3.19.0':
+    resolution: {integrity: sha512-RchUOSIDprlnuzmA/znZIBKMONIlCAXHuR6XkoNX2jFJ/9OHk/si+jEeY8jJfpPDpVqZ3KrwS/zJrqhU/pT+hQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-superscript@3.19.0':
+    resolution: {integrity: sha512-PjLUGjM23/7hqFP5HS1DbdywRm63GhjJ5SD6KqNgyZQwcwDZeJTAW2b/LYTHAP+k07OxOLPdj/k4ntQKtgKNow==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-table-cell@3.19.0':
+    resolution: {integrity: sha512-T67EDWmiRdOGctolaUpMPXffDkEFL+NUppSV61cPU3jQtDwGg01meauy5u67u6OUM8ICiZ+Sc7Xd2DIt+7Nv5g==}
+    peerDependencies:
+      '@tiptap/extension-table': ^3.19.0
+
+  '@tiptap/extension-table-header@3.19.0':
+    resolution: {integrity: sha512-fVHJUCfZp/JOE96hJ3paElRynpIVdukOiAjgZbaY9WuCKoXd3xYqdsbUSdf+XFmdPqwvQKhnkaY/qXW3FIxO3w==}
+    peerDependencies:
+      '@tiptap/extension-table': ^3.19.0
+
+  '@tiptap/extension-table-row@3.19.0':
+    resolution: {integrity: sha512-L3DeIXQARCs+m4rsQWiUPJso1z6xZ6awa/Kc+PCoq7rbPLtwhWUIld3sm9gdLac61Mf/TVwb18EdfygHcU7jCA==}
+    peerDependencies:
+      '@tiptap/extension-table': ^3.19.0
+
+  '@tiptap/extension-table@3.19.0':
+    resolution: {integrity: sha512-Lg8DlkkDUMYE/CcGOxoCWF98B2i7VWh+AGgqlF+XWrHjhlKHfENLRXm1a0vWuyyP3NknRYILoaaZ1s7QzmXKRA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/extension-task-item@3.19.0':
+    resolution: {integrity: sha512-1il70SoaoEA5jKr2QS30CpZoB7EzdSLugROMBPRUPc0feIBKAf6yUPhxlFyU4ez/uT4Pazsf1HAgHI3AOr+MtQ==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-task-list@3.19.0':
+    resolution: {integrity: sha512-Slb6YZi7XpVT966oAJhqzZu4LVuHtUeZgMxA0bdc8FSZBxntcr8OQWmPbqvR437RAR/Xd7b5quXS3JmSeksyvA==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.19.0
+
+  '@tiptap/extension-text-align@3.19.0':
+    resolution: {integrity: sha512-cY8bHWYojLTHXZb2j2srdh7ltmDgnwXYvSxbPL4HK4j7XxQOGnOsTakgM/BNhxymOfEj2414i5Otyy8hlgviFA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-text-style@3.19.0':
+    resolution: {integrity: sha512-R55V6iUfRq03SGt/R2KvaeN+XGFiKJHx1jFJhZzvnWhMV7YqjHSG2r4BLvpTq1HBqteMbEjI+EOnb4t9AKd6aQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-text@3.19.0':
+    resolution: {integrity: sha512-K95+SnbZy0h6hNFtfy23n8t/nOcTFEf69In9TSFVVmwn/Nwlke+IfiESAkqbt1/7sKJeegRXYO7WzFEmFl9Q/g==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-typography@3.19.0':
+    resolution: {integrity: sha512-2Rwwz1ErNhqUcXPzPX2u4frdyrK4Yj6ZMvCLPxLt5lQXj9Eq9YEoD9isw8abR105ko3BCidvfElQYSFu6dWPSw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extension-underline@3.19.0':
+    resolution: {integrity: sha512-800MGEWfG49j10wQzAFiW/ele1HT04MamcL8iyuPNu7ZbjbGN2yknvdrJlRy7hZlzIrVkZMr/1tz62KN33VHIw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+
+  '@tiptap/extensions@3.19.0':
+    resolution: {integrity: sha512-ZmGUhLbMWaGqnJh2Bry+6V4M6gMpUDYo4D1xNux5Gng/E/eYtc+PMxMZ/6F7tNTAuujLBOQKj6D+4SsSm457jw==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
+  '@tiptap/pm@3.19.0':
+    resolution: {integrity: sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==}
+
+  '@tiptap/starter-kit@3.19.0':
+    resolution: {integrity: sha512-dTCkHEz+Y8ADxX7h+xvl6caAj+3nII/wMB1rTQchSuNKqJTOrzyUsCWm094+IoZmLT738wANE0fRIgziNHs/ug==}
+
+  '@tiptap/suggestion@3.19.0':
+    resolution: {integrity: sha512-tUZwMRFqTVPIo566ZmHNRteyZxJy2EE4FA+S3IeIUOOvY6AW0h1imhbpBO7sXV8CeEQvpa+2DWwLvy7L3vmstA==}
+    peerDependencies:
+      '@tiptap/core': ^3.19.0
+      '@tiptap/pm': ^3.19.0
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1541,8 +2106,17 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -1895,6 +2469,9 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1992,8 +2569,20 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emojibase-data@15.3.2:
+    resolution: {integrity: sha512-TpDyTDDTdqWIJixV5sTA6OQ0P0JfIIeK2tFRR3q56G9LK65ylAZ7z3KyBXokpvTTJ+mLUXQXbLNyVkjvnTLE+A==}
+    peerDependencies:
+      emojibase: '*'
+
+  emojibase@17.0.0:
+    resolution: {integrity: sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==}
+    engines: {node: '>=18.12.0'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2035,6 +2624,11 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -2173,6 +2767,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2296,6 +2895,9 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+
+  is-emoji-supported@0.0.5:
+    resolution: {integrity: sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2427,6 +3029,9 @@ packages:
       canvas:
         optional: true
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
@@ -2468,6 +3073,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2477,6 +3086,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -2652,6 +3264,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -2690,6 +3312,12 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  prosemirror-changeset@2.4.0:
+    resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
   prosemirror-commands@1.7.1:
     resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
@@ -2708,8 +3336,17 @@ packages:
   prosemirror-keymap@1.2.3:
     resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
 
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-menu@1.2.5:
+    resolution: {integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==}
+
   prosemirror-model@1.25.4:
     resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
 
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
@@ -2735,6 +3372,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3010,6 +3651,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -3064,6 +3708,46 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -4007,79 +4691,157 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -4132,6 +4894,17 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.9.0': {}
+
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -4339,6 +5112,10 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.16.3':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
@@ -4502,6 +5279,285 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@tiptap/core@3.19.0(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-blockquote@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-bold@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-bubble-menu@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-bullet-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-character-count@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-code-block-lowlight@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(highlight.js@11.11.1)(lowlight@3.3.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-code-block': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      highlight.js: 11.11.1
+      lowlight: 3.3.0
+
+  '@tiptap/extension-code-block@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-code@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-color@3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
+    dependencies:
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+
+  '@tiptap/extension-details-content@2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+
+  '@tiptap/extension-details-summary@2.26.2(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+
+  '@tiptap/extension-details@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-document@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-dropcursor@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-emoji@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(emojibase@17.0.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      emoji-regex: 10.6.0
+      emojibase-data: 15.3.2(emojibase@17.0.0)
+      is-emoji-supported: 0.0.5
+    transitivePeerDependencies:
+      - emojibase
+
+  '@tiptap/extension-floating-menu@3.19.0(@floating-ui/dom@1.7.5)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-focus@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-font-family@3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))':
+    dependencies:
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+
+  '@tiptap/extension-gapcursor@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-hard-break@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-heading@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-highlight@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-horizontal-rule@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-image@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-italic@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-link@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-list-keymap@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-mention@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-ordered-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-paragraph@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-placeholder@3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-strike@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-subscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-superscript@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-table-cell@3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-table-header@3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-table-row@3.19.0(@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-table@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/extension-task-item@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-task-list@3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-text-align@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-text@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-typography@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extension-underline@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+
+  '@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/pm@3.19.0':
+    dependencies:
+      prosemirror-changeset: 2.4.0
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.0
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.4
+      prosemirror-menu: 1.2.5
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)
+      prosemirror-transform: 1.10.5
+      prosemirror-view: 1.41.5
+
+  '@tiptap/starter-kit@3.19.0':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-blockquote': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-bold': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-bullet-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-code': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-code-block': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-document': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-dropcursor': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-gapcursor': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-hard-break': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-heading': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-horizontal-rule': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-italic': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-link': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-list-item': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-list-keymap': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-ordered-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-paragraph': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-strike': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-underline': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
+  '@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+    dependencies:
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4526,9 +5582,18 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -4922,6 +5987,8 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  crelt@1.0.6: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5022,7 +6089,15 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
+
+  emojibase-data@15.3.2(emojibase@17.0.0):
+    dependencies:
+      emojibase: 17.0.0
+
+  emojibase@17.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -5058,6 +6133,35 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -5226,6 +6330,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5350,6 +6457,8 @@ snapshots:
       hasown: 2.0.2
 
   is-docker@2.2.1: {}
+
+  is-emoji-supported@0.0.5: {}
 
   is-extglob@2.1.1: {}
 
@@ -5477,6 +6586,10 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   linkifyjs@4.3.2: {}
 
   load-tsconfig@0.2.5: {}
@@ -5520,6 +6633,15 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.1:
@@ -5535,6 +6657,8 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -5773,6 +6897,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
@@ -5797,6 +6929,14 @@ snapshots:
       react-is: 18.3.1
 
   property-information@7.1.0: {}
+
+  prosemirror-changeset@2.4.0:
+    dependencies:
+      prosemirror-transform: 1.10.5
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
 
   prosemirror-commands@1.7.1:
     dependencies:
@@ -5834,9 +6974,26 @@ snapshots:
       prosemirror-state: 1.4.4
       w3c-keyname: 2.2.8
 
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+      prosemirror-model: 1.25.4
+
+  prosemirror-menu@1.2.5:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
   prosemirror-model@1.25.4:
     dependencies:
       orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.4
 
   prosemirror-schema-list@1.5.1:
     dependencies:
@@ -5877,6 +7034,8 @@ snapshots:
       prosemirror-transform: 1.10.5
 
   proxy-from-env@1.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -6159,6 +7318,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   ufo@1.6.3: {}
 
   uhyphen@0.2.0: {}
@@ -6218,6 +7379,18 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite@6.4.1(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+      yaml: 2.8.2
 
   vite@7.3.1(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

New `@domternal/extension-table` package built on prosemirror-tables, providing full table editing support with 4 nodes, 16 commands, keyboard shortcuts, and a custom NodeView.

## Features

- **4 nodes**: Table, TableRow, TableCell, TableHeader — each with configurable HTML attributes and background cell attribute
- **16 commands**: insertTable, deleteTable, addRow/Column before/after, deleteRow/Column, toggleHeaderRow/Column/Cell, setCellAttribute, goToNextCell/goToPreviousCell, fixTables, setCellSelection
- **TableView**: Custom NodeView with `div.tableWrapper > table > colgroup + tbody` for horizontal scrolling and column width management
- **Keyboard shortcuts**: Tab/Shift-Tab for cell navigation, Backspace/Delete to remove table when all cells selected
- **Helpers**: `createTable` for programmatic table creation, `deleteTableWhenAllCellsSelected` for keyboard handling
- **Core change**: Added `tableRole` property to NodeConfig for prosemirror-tables integration

## Changes

- **packages/core/src/Node.ts** — Forward `tableRole` from config to ProseMirror node spec
- **packages/core/src/types/NodeConfig.ts** — Added `tableRole` property definition
- **packages/extension-table/** — New package: Table, TableRow, TableCell, TableHeader nodes, TableView, helpers, 943-line test suite
