### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1 (2026-03-21)
+
+- Added per-package README files for all 10 packages (now visible on npmjs.com)
+- Fixed `@domternal/pm` exports order (types first) and added `.d.cts` declarations for full CJS/Node10/Node16 resolution
+- Fixed `@domternal/theme` missing `type` field in package.json
+- Fixed `@domternal/angular` missing `type: "module"` and `exports` field in package.json
+
 ## 0.1.0 (2026-03-21)
 
 Initial public release.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,0 +1,71 @@
+# @domternal/angular
+
+Angular components for the Domternal editor: editor, toolbar, bubble menu, floating menu, and emoji picker. Standalone components with signals, OnPush change detection, reactive forms (`ControlValueAccessor`), and zoneless mode support.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+Requires Angular 17.1+.
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/theme @domternal/angular
+```
+
+## Quick Start
+
+```ts
+import { Component, signal } from '@angular/core';
+import {
+  DomternalEditorComponent,
+  DomternalToolbarComponent,
+  DomternalBubbleMenuComponent,
+} from '@domternal/angular';
+import { Editor, StarterKit, BubbleMenu } from '@domternal/core';
+
+@Component({
+  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent],
+  template: `
+    @if (editor(); as ed) {
+      <domternal-toolbar [editor]="ed" />
+    }
+    <domternal-editor
+      [extensions]="extensions"
+      [content]="content"
+      (editorCreated)="editor.set($event)"
+    />
+    @if (editor(); as ed) {
+      <domternal-bubble-menu [editor]="ed" />
+    }
+  `,
+})
+export class EditorComponent {
+  editor = signal<Editor | null>(null);
+  extensions = [StarterKit, BubbleMenu];
+  content = '<p>Hello from Angular!</p>';
+}
+```
+
+### Global Styles
+
+Add the theme to your global stylesheet to load editor and toolbar styles:
+
+```scss
+@use '@domternal/theme';
+```
+
+### Available Components
+
+| Component | Description |
+|---|---|
+| `<domternal-editor>` | The core editor surface |
+| `<domternal-toolbar>` | Auto-renders toolbar buttons based on provided extensions |
+| `<domternal-bubble-menu>` | Contextual formatting menu on text selection |
+| `<domternal-floating-menu>` | Block-level insertion menu on empty lines |
+| `<domternal-emoji-picker>` | Emoji picker panel for the Emoji extension |
+
+The toolbar and bubble menu components auto-render buttons based on the extensions you provide. No manual button wiring needed.
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,97 @@
+# @domternal/core
+
+Lightweight, framework-agnostic rich text editor engine with 13 nodes, 9 marks, 25 extensions, 112+ chainable commands, and 45 built-in icons.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core
+```
+
+## Quick Start
+
+### Headless (Vanilla JS/TS)
+
+Import only the extensions you need for full control and zero bloat:
+
+```ts
+import { Editor, Document, Text, Paragraph, Bold, Italic, Underline } from '@domternal/core';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [Document, Text, Paragraph, Bold, Italic, Underline],
+  content: '<p>Hello <strong>World</strong>!</p>',
+});
+```
+
+### With Theme and Toolbar
+
+Use `StarterKit` for a batteries-included setup, and pair it with `@domternal/theme` for styled UI:
+
+```html
+<div id="editor" class="dm-editor"></div>
+```
+
+```ts
+import { Editor, StarterKit, defaultIcons } from '@domternal/core';
+import '@domternal/theme';
+
+const editorEl = document.getElementById('editor')!;
+
+// Toolbar
+const toolbar = document.createElement('div');
+toolbar.className = 'dm-toolbar';
+toolbar.innerHTML = `<div class="dm-toolbar-group">
+  <button class="dm-toolbar-button" data-mark="bold">${defaultIcons.textB}</button>
+  <button class="dm-toolbar-button" data-mark="italic">${defaultIcons.textItalic}</button>
+  <button class="dm-toolbar-button" data-mark="underline">${defaultIcons.textUnderline}</button>
+</div>`;
+editorEl.before(toolbar);
+
+// Editor
+const editor = new Editor({
+  element: editorEl,
+  extensions: [StarterKit],
+  content: '<p>Hello world</p>',
+});
+
+// Toggle marks on click (event delegation)
+toolbar.addEventListener('click', (e) => {
+  const btn = (e.target as Element).closest<HTMLButtonElement>('[data-mark]');
+  if (!btn) return;
+  editor.chain().focus().toggleMark(btn.dataset.mark!).run();
+});
+
+// Active state sync
+editor.on('transaction', () => {
+  toolbar.querySelectorAll<HTMLButtonElement>('[data-mark]').forEach((btn) => {
+    btn.classList.toggle('dm-toolbar-button--active', editor.isActive(btn.dataset.mark!));
+  });
+});
+```
+
+### StarterKit Contents
+
+Every extension in the kit can be disabled with `false` or configured with options:
+
+```ts
+StarterKit.configure({
+  codeBlock: false,                     // disable an extension
+  heading: { levels: [1, 2, 3, 4] },   // limit heading levels
+  history: { depth: 50 },               // configure undo stack
+  link: { openOnClick: false },         // keep links non-clickable while editing
+  linkPopover: false,                   // disable the built-in link popover
+})
+```
+
+| Category | Included |
+|---|---|
+| **Nodes** | Document, Text, Paragraph, Heading, Blockquote, CodeBlock, BulletList, OrderedList, ListItem, TaskList, TaskItem, HorizontalRule, HardBreak |
+| **Marks** | Bold, Italic, Underline, Strike, Code, Link |
+| **Behaviors** | BaseKeymap, History, Dropcursor, Gapcursor, TrailingNode, ListKeymap, LinkPopover |
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -1,0 +1,53 @@
+# @domternal/extension-code-block-lowlight
+
+Syntax-highlighted code blocks for the Domternal editor, powered by [lowlight](https://github.com/wooorm/lowlight) (highlight.js).
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-code-block-lowlight lowlight
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { CodeBlockLowlight } from '@domternal/extension-code-block-lowlight';
+import { createLowlight, common } from 'lowlight';
+
+const lowlight = createLowlight(common);
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit.configure({ codeBlock: false }), // disable the default CodeBlock
+    CodeBlockLowlight.configure({ lowlight }),
+  ],
+});
+```
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `lowlight` | (required) | A lowlight instance created with `createLowlight()` |
+| `defaultLanguage` | `null` | Default language when none is specified |
+| `autoDetect` | `true` | Auto-detect language when none is specified |
+| `tabIndentation` | `true` | Tab key inserts spaces inside code blocks |
+| `tabSize` | `2` | Number of spaces per tab |
+
+### Server-Side Rendering
+
+Use `generateHighlightedHTML` to produce syntax-highlighted HTML on the server:
+
+```ts
+import { generateHighlightedHTML } from '@domternal/extension-code-block-lowlight';
+
+const html = generateHighlightedHTML(jsonContent, { lowlight });
+```
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -1,0 +1,54 @@
+# @domternal/extension-details
+
+Collapsible details/accordion blocks for the Domternal editor, rendered as semantic `<details>`/`<summary>` HTML.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-details
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { Details, DetailsSummary, DetailsContent } from '@domternal/extension-details';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [StarterKit, Details, DetailsSummary, DetailsContent],
+  content: '<p>Hello world</p>',
+});
+
+// Wrap selected content in a details block
+editor.commands.setDetails();
+
+// Toggle details on/off
+editor.commands.toggleDetails();
+
+// Open or close programmatically
+editor.commands.openDetails();
+editor.commands.closeDetails();
+```
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `setDetails` | Wrap selected content in a details structure |
+| `unsetDetails` | Lift content out of details (preserves summary as paragraph) |
+| `toggleDetails` | Toggle between wrapped and unwrapped |
+| `openDetails` / `closeDetails` | Programmatic open/close control |
+| `setDetailsOpen(boolean)` | Set the open state explicitly |
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `persist` | `false` | Persist the open/closed state in the document |
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -1,0 +1,47 @@
+# @domternal/extension-emoji
+
+Emoji extension for Domternal with a picker panel and `:shortcode:` autocomplete suggestions.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-emoji
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { Emoji, emojis } from '@domternal/extension-emoji';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit,
+    Emoji.configure({
+      emojis,
+      enableEmoticons: true,  // converts :) and <3 to emoji
+    }),
+  ],
+});
+
+// Insert emoji by name
+editor.commands.insertEmoji('smile');
+
+// Open the suggestion picker programmatically
+editor.commands.suggestEmoji();
+```
+
+### Features
+
+- **Shortcode input rules** - type `:smile:` to insert an emoji inline
+- **Emoticon support** - converts common emoticons like `:)`, `<3`, and `:(` when `enableEmoticons` is enabled
+- **Autocomplete suggestions** - type `:` followed by a query to see matching emoji in a dropdown
+- **Built-in dataset** - includes approximately 200 popular emoji out of the box
+- **Custom emoji** - provide your own `EmojiItem[]` array for a custom set
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -1,0 +1,57 @@
+# @domternal/extension-image
+
+Image extension for Domternal with paste/drop upload, URL input, XSS protection, and bubble menu controls.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-image
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { Image } from '@domternal/extension-image';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit,
+    Image.configure({
+      allowBase64: true,
+      uploadHandler: async (file) => {
+        // Upload the file and return the URL
+        const url = await myUploadService(file);
+        return url;
+      },
+    }),
+  ],
+});
+
+// Insert an image programmatically
+editor.commands.setImage({ src: 'https://example.com/photo.jpg', alt: 'A photo' });
+
+// Float image to the left
+editor.commands.setImageFloat('left');
+```
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `inline` | `false` | When `true`, images render inline within paragraphs |
+| `allowBase64` | `true` | Allow `data:image/` URLs. When `false`, only `http(s)` URLs are accepted |
+| `uploadHandler` | `null` | Async function that receives a `File` and returns a URL string. Enables paste/drop upload |
+
+### Commands
+
+- `setImage({ src, alt?, title?, width?, height?, float? })` - insert or update an image
+- `setImageFloat('left' | 'right' | 'center' | 'none')` - set text wrapping
+- `deleteImage()` - remove the selected image
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -1,0 +1,71 @@
+# @domternal/extension-mention
+
+`@mention` autocomplete extension for Domternal with multi-trigger and async support.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-mention
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { Mention } from '@domternal/extension-mention';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit,
+    Mention.configure({
+      suggestion: {
+        char: '@',
+        name: 'user',
+        items: ({ query }) =>
+          users.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
+        render: createMentionRenderer,
+      },
+    }),
+  ],
+});
+
+// Insert a mention programmatically
+editor.commands.insertMention({ id: '1', label: 'Alice' });
+```
+
+### Multi-trigger
+
+Use the `triggers` option to support multiple trigger characters (for example, `@` for users and `#` for tags):
+
+```ts
+Mention.configure({
+  triggers: [
+    {
+      char: '@',
+      name: 'user',
+      items: ({ query }) => fetchUsers(query),
+      render: createUserRenderer,
+    },
+    {
+      char: '#',
+      name: 'tag',
+      items: ({ query }) => fetchTags(query),
+      render: createTagRenderer,
+    },
+  ],
+})
+```
+
+### Features
+
+- **Autocomplete dropdown** - type a trigger character followed by a query to see matching items
+- **Async item fetching** - the `items` function can return a `Promise` for server-side lookups
+- **Multi-trigger** - define multiple trigger characters, each with its own item source and renderer
+- **Custom rendering** - provide a `render` function for full control over the suggestion dropdown UI
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -1,0 +1,55 @@
+# @domternal/extension-table
+
+Table extension for Domternal with 18 commands, cell merging, column resize, row/column controls, and cell toolbar.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/core @domternal/extension-table
+```
+
+## Usage
+
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import { Table, TableRow, TableCell, TableHeader } from '@domternal/extension-table';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
+  content: '<p>Hello world</p>',
+});
+
+// Insert a 3x3 table with a header row
+editor.commands.insertTable({ rows: 3, cols: 3, withHeaderRow: true });
+
+// Merge selected cells
+editor.commands.mergeCells();
+
+// Add a row after the current one
+editor.commands.addRowAfter();
+```
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `insertTable` | Insert a new table with configurable rows, cols, and header row |
+| `deleteTable` | Delete the entire table |
+| `addRowBefore` / `addRowAfter` | Insert a row above or below |
+| `deleteRow` | Delete the current row |
+| `addColumnBefore` / `addColumnAfter` | Insert a column left or right |
+| `deleteColumn` | Delete the current column |
+| `mergeCells` | Merge selected cells into one |
+| `splitCell` | Split a merged cell back to individual cells |
+| `toggleHeaderRow` / `toggleHeaderColumn` / `toggleHeaderCell` | Toggle header formatting |
+| `setCellAttribute` | Set an attribute on the current cell |
+| `goToNextCell` / `goToPreviousCell` | Navigate between cells with Tab/Shift-Tab |
+| `fixTables` | Repair malformed tables |
+| `setCellSelection` | Programmatic cell range selection |
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -1,0 +1,51 @@
+# @domternal/pm
+
+Convenience re-exports of ProseMirror packages via subpath imports, so you can depend on a single package instead of twelve.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/pm
+```
+
+## Usage
+
+Import ProseMirror modules through subpath exports:
+
+```ts
+import { EditorState, Plugin, PluginKey } from '@domternal/pm/state';
+import { EditorView } from '@domternal/pm/view';
+import { Schema, Node, Mark } from '@domternal/pm/model';
+import { ReplaceStep } from '@domternal/pm/transform';
+import { keymap } from '@domternal/pm/keymap';
+import { undo, redo, history } from '@domternal/pm/history';
+import { baseKeymap } from '@domternal/pm/commands';
+import { inputRules } from '@domternal/pm/inputrules';
+import { dropCursor } from '@domternal/pm/dropcursor';
+import { gapCursor } from '@domternal/pm/gapcursor';
+import { tableEditing, columnResizing } from '@domternal/pm/tables';
+import { wrapInList, liftListItem } from '@domternal/pm/schema-list';
+```
+
+### Available Subpath Exports
+
+| Import | Re-exports |
+|---|---|
+| `@domternal/pm/state` | `prosemirror-state` |
+| `@domternal/pm/view` | `prosemirror-view` |
+| `@domternal/pm/model` | `prosemirror-model` |
+| `@domternal/pm/transform` | `prosemirror-transform` |
+| `@domternal/pm/commands` | `prosemirror-commands` |
+| `@domternal/pm/keymap` | `prosemirror-keymap` |
+| `@domternal/pm/history` | `prosemirror-history` |
+| `@domternal/pm/inputrules` | `prosemirror-inputrules` |
+| `@domternal/pm/dropcursor` | `prosemirror-dropcursor` |
+| `@domternal/pm/gapcursor` | `prosemirror-gapcursor` |
+| `@domternal/pm/tables` | `prosemirror-tables` |
+| `@domternal/pm/schema-list` | `prosemirror-schema-list` |
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,0 +1,60 @@
+# @domternal/theme
+
+Light and dark themes for the Domternal editor with 70+ CSS custom properties for full visual control.
+
+Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+
+## Installation
+
+```bash
+npm install @domternal/theme
+```
+
+## Usage
+
+### CSS Import
+
+Import the pre-built CSS file in your JavaScript or HTML:
+
+```ts
+import '@domternal/theme';
+```
+
+Or link to the CSS file directly:
+
+```html
+<link rel="stylesheet" href="node_modules/@domternal/theme/dist/domternal-theme.css" />
+```
+
+### SCSS
+
+If your project uses SCSS, use `@use` instead for access to SCSS variables and mixins:
+
+```scss
+@use '@domternal/theme';
+```
+
+### Dark Mode
+
+The theme automatically switches between light and dark based on the user's system preference via `prefers-color-scheme`. You can also force a mode by adding a CSS class to the editor wrapper or a parent element:
+
+- `.dm-theme-dark` - force dark mode
+- `.dm-theme-light` - force light mode
+- `.dm-theme-auto` - follow system preference (default behavior)
+
+### Customization
+
+Override any of the 70+ CSS custom properties on `.dm-editor` to customize the look:
+
+```css
+.dm-editor {
+  --dm-editor-font-family: 'Inter', sans-serif;
+  --dm-editor-font-size: 16px;
+  --dm-editor-border-radius: 8px;
+  --dm-accent: #3b82f6;
+}
+```
+
+## License
+
+[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release 0.1.1 for all 10 packages. Adds per-package README files (now visible on npmjs.com) and includes post-0.1.0 packaging fixes that were committed after the initial publish.

## Changes

- Added per-package README files for all 10 packages (pm, core, theme, angular, table, image, emoji, mention, details, code-block-lowlight)
- Bumped all packages from 0.1.0 to 0.1.1
- Updated CHANGELOG.md with 0.1.1 entry

## Context

v0.1.0 was published without per-package READMEs, so npm package pages show "No README found". This release adds them. It also picks up 4 packaging fixes committed after the 0.1.0 publish:

- `@domternal/pm`: exports order (types first) + `.d.cts` declarations for CJS/Node10/Node16 resolution
- `@domternal/theme`: missing `type` field in package.json
- `@domternal/angular`: missing `type: "module"` and `exports` field in package.json
