### PR TITLE
chore: rewrite README, add CLA section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ Include:
 - **What** - Problem/issue being solved (optional)
 - **Test plan** - Steps to verify (optional)
 
+## Contributor License Agreement (CLA)
+
+Before your first pull request can be merged, you need to sign our [Contributor License Agreement (CLA)](https://gist.github.com/ThomasNowHere/cdca6f890b). The CLA confirms that you have the right to contribute your code and that you grant the project permission to use it. When you open a PR, the CLA Assistant bot will post a comment with a link to sign. You only need to sign once.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,39 +1,37 @@
 # Domternal
 
+![Domternal - Lightweight Rich Text Editor Toolkit](https://domternal.dev/readme/readme-banner.svg)
+
 A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/domternal/domternal/actions/workflows/ci.yml/badge.svg)](https://github.com/domternal/domternal/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@domternal/core.svg?label=%40domternal%2Fcore)](https://www.npmjs.com/package/@domternal/core)
+
+**[Website](https://domternal.dev)** · **[Getting Started](https://domternal.dev/v1/getting-started)** · **[Packages & Bundle Size](https://domternal.dev/v1/packages)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)**
 
 ## Features
 
 - **Headless core** - use with any framework or vanilla JS/TS
 - **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar - all free
-- **23 nodes, 9 marks, 25 extensions** - paragraphs, headings, lists, task lists, code blocks, blockquotes, images, tables, details/accordion, emoji, mentions, and more
-- **112+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Tree-shakeable** - import only what you use, unused code is stripped from the bundle
-- **TypeScript first** - every schema, command, option, and event is fully typed
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
 - **Light and dark theme** - 70+ CSS custom properties for full visual control
 - **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
 - **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-## Packages
+## Quick Start
 
-| Package | Description |
-|---------|-------------|
-| [`@domternal/core`](packages/core) | Framework-agnostic editor engine with 13 nodes, 9 marks, 25 extensions, toolbar controller, and 45 built-in icons |
-| [`@domternal/theme`](packages/theme) | Light and dark themes with 70+ CSS custom properties |
-| [`@domternal/angular`](packages/angular) | Angular components: editor, toolbar, bubble menu, floating menu, emoji picker |
-| [`@domternal/pm`](packages/pm) | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more) |
-| [`@domternal/extension-table`](packages/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
-| [`@domternal/extension-image`](packages/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
-| [`@domternal/extension-emoji`](packages/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
-| [`@domternal/extension-mention`](packages/extension-mention) | `@mention` autocomplete with multi-trigger and async support |
-| [`@domternal/extension-details`](packages/extension-details) | Collapsible details/accordion blocks |
-| [`@domternal/extension-code-block-lowlight`](packages/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
+### Headless (Vanilla JS/TS)
 
-### Headless Core (Vanilla JS/TS)
+```bash
+pnpm add @domternal/core
+```
 
 ```ts
 import { Editor, Document, Text, Paragraph, Bold, Italic, Underline } from '@domternal/core';
@@ -45,7 +43,15 @@ const editor = new Editor({
 });
 ```
 
+Import only what you need for full control and zero bloat. Use `StarterKit` for a batteries-included setup with headings, lists, code blocks, history, and more.
+
+> **[Try the full Vanilla TS example on StackBlitz](https://stackblitz.com/edit/domternal-vanilla-full-example)** with toolbar, bubble menu, and all extensions.
+
 ### With Theme and Toolbar (Vanilla JS/TS)
+
+```bash
+pnpm add @domternal/core @domternal/theme
+```
 
 ```html
 <div id="editor" class="dm-editor"></div>
@@ -95,6 +101,10 @@ editor.on('transaction', () => {
 
 Requires Angular 17.1+. Standalone components with signals, OnPush change detection, reactive forms (`ControlValueAccessor`), and zoneless mode support.
 
+```bash
+pnpm add @domternal/core @domternal/theme @domternal/angular
+```
+
 ```ts
 import { Component, signal } from '@angular/core';
 import {
@@ -105,6 +115,7 @@ import {
 import { Editor, StarterKit, BubbleMenu } from '@domternal/core';
 
 @Component({
+  selector: 'app-editor',
   imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent],
   template: `
     @if (editor(); as ed) {
@@ -133,13 +144,36 @@ Add the theme to your global stylesheet:
 @use '@domternal/theme';
 ```
 
+> **[Try the full Angular example on StackBlitz](https://stackblitz.com/edit/domternal-angular-full-example)** with all extensions, toolbar, and bubble menu.
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [`@domternal/core`](https://www.npmjs.com/package/@domternal/core) | Editor engine with 13 nodes, 9 marks, 25 extensions, toolbar controller, and 45 built-in icons |
+| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme) | Light and dark themes with 70+ CSS custom properties |
+| [`@domternal/angular`](https://www.npmjs.com/package/@domternal/angular) | 5 Angular components: editor, toolbar, bubble menu, floating menu, emoji picker |
+| [`@domternal/pm`](https://www.npmjs.com/package/@domternal/pm) | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more) |
+| [`@domternal/extension-table`](https://www.npmjs.com/package/@domternal/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
+| [`@domternal/extension-image`](https://www.npmjs.com/package/@domternal/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
+| [`@domternal/extension-emoji`](https://www.npmjs.com/package/@domternal/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
+| [`@domternal/extension-mention`](https://www.npmjs.com/package/@domternal/extension-mention) | `@mention` autocomplete with multi-trigger and async support |
+| [`@domternal/extension-details`](https://www.npmjs.com/package/@domternal/extension-details) | Collapsible details/accordion blocks |
+| [`@domternal/extension-code-block-lowlight`](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
+
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of what each package includes and how tree-shaking works.
+
 ## Documentation
 
-Full documentation, live playground, and API reference at [domternal.dev](https://domternal.dev).
+Full documentation, live playgrounds, and API reference at **[domternal.dev](https://domternal.dev)**.
+
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, PR guidelines, and development setup.
 
 ```bash
 pnpm install    # Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Domternal
 
-![Domternal - Lightweight Rich Text Editor Toolkit](https://domternal.dev/readme/readme-banner.svg)
+[![Domternal Editor](https://domternal.dev/readme/readme-banner.png)](https://domternal.dev)
 
 A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components.
 


### PR DESCRIPTION
## Summary
- Rewrote README with banner image, npm badge, correct stats (140+ commands, 57 extensions), 
  bundle size info, test coverage, links to docs/npm/StackBlitz
- Shortened Quick Start to a single core example with links to Getting Started and StackBlitz
- Added CLA section to CONTRIBUTING.md with link to CLA Assistant

## Changes
- README: added banner image, npm badge, quick-link bar, install commands, StackBlitz links
- README: fixed command count (112+ to 140+), added bundle size and test coverage stats
- README: packages table now links to npm instead of local folders
- README: condensed Quick Start from 3 sections to 1 core example + setup links
- CONTRIBUTING: added Contributor License Agreement section