### PR TITLE
fix(core,table): toolbar layout button name fixes and README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,7 @@ A lightweight, extensible rich text editor toolkit built on [ProseMirror](https:
 - **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
 - **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-## Packages
-
-| Package | Description |
-|---------|-------------|
-| [`@domternal/core`](packages/core) | Framework-agnostic editor engine with 13 nodes, 9 marks, 25 extensions, toolbar controller, and 45 built-in icons |
-| [`@domternal/theme`](packages/theme) | Light and dark themes with 70+ CSS custom properties |
-| [`@domternal/angular`](packages/angular) | Angular components: editor, toolbar, bubble menu, floating menu, emoji picker |
-| [`@domternal/pm`](packages/pm) | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more) |
-| [`@domternal/extension-table`](packages/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
-| [`@domternal/extension-image`](packages/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
-| [`@domternal/extension-emoji`](packages/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
-| [`@domternal/extension-mention`](packages/extension-mention) | `@mention` autocomplete with multi-trigger and async support |
-| [`@domternal/extension-details`](packages/extension-details) | Collapsible details/accordion blocks |
-| [`@domternal/extension-code-block-lowlight`](packages/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
+## Quick Start (Vanilla JS/TS)
 
 ### Headless Core (Vanilla JS/TS)
 
@@ -45,93 +32,32 @@ const editor = new Editor({
 });
 ```
 
-### With Theme and Toolbar (Vanilla JS/TS)
+Import only what you need for full control and zero bloat. Use `StarterKit` for a batteries-included setup with headings, lists, code blocks, history, and more.
 
-```html
-<div id="editor" class="dm-editor"></div>
-```
+### More Setups
 
-```ts
-import { Editor, StarterKit, defaultIcons } from '@domternal/core';
-import '@domternal/theme';
+> **[Getting Started Guide](https://domternal.dev/v1/getting-started)** - headless core, themed UI with toolbar, and Angular component setup
+>
+> **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)** - full Angular example with all extensions, toolbar, and bubble menu
+>
+> **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** - full vanilla example with toolbar, bubble menu, and all extensions
 
-const editorEl = document.getElementById('editor')!;
+## Packages
 
-// Toolbar
-const toolbar = document.createElement('div');
-toolbar.className = 'dm-toolbar';
-toolbar.innerHTML = `<div class="dm-toolbar-group">
-  <button class="dm-toolbar-button" data-mark="bold">${defaultIcons.textB}</button>
-  <button class="dm-toolbar-button" data-mark="italic">${defaultIcons.textItalic}</button>
-  <button class="dm-toolbar-button" data-mark="underline">${defaultIcons.textUnderline}</button>
-</div>`;
-editorEl.before(toolbar);
+| Package | Description |
+|---|---|
+| [`@domternal/core`](https://www.npmjs.com/package/@domternal/core) | Editor engine with 13 nodes, 9 marks, 25 extensions, toolbar controller, and 45 built-in icons |
+| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme) | Light and dark themes with 70+ CSS custom properties |
+| [`@domternal/angular`](https://www.npmjs.com/package/@domternal/angular) | 5 Angular components: editor, toolbar, bubble menu, floating menu, emoji picker |
+| [`@domternal/pm`](https://www.npmjs.com/package/@domternal/pm) | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more) |
+| [`@domternal/extension-table`](https://www.npmjs.com/package/@domternal/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
+| [`@domternal/extension-image`](https://www.npmjs.com/package/@domternal/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
+| [`@domternal/extension-emoji`](https://www.npmjs.com/package/@domternal/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
+| [`@domternal/extension-mention`](https://www.npmjs.com/package/@domternal/extension-mention) | `@mention` autocomplete with multi-trigger and async support |
+| [`@domternal/extension-details`](https://www.npmjs.com/package/@domternal/extension-details) | Collapsible details/accordion blocks |
+| [`@domternal/extension-code-block-lowlight`](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
 
-// Editor
-const editor = new Editor({
-  element: editorEl,
-  extensions: [StarterKit],
-  content: '<p>Hello world</p>',
-});
-
-// Toggle marks on click (event delegation)
-toolbar.addEventListener('click', (e) => {
-  const btn = (e.target as Element).closest<HTMLButtonElement>('[data-mark]');
-  if (!btn) return;
-  editor.chain().focus().toggleMark(btn.dataset.mark!).run();
-});
-
-// Active state sync
-editor.on('transaction', () => {
-  toolbar.querySelectorAll<HTMLButtonElement>('[data-mark]').forEach((btn) => {
-    btn.classList.toggle('dm-toolbar-button--active', editor.isActive(btn.dataset.mark!));
-  });
-});
-```
-
-`StarterKit` includes 13 nodes, 6 marks, and 7 behavior extensions out of the box. Every extension can be disabled or configured individually.
-
-### Angular
-
-Requires Angular 17.1+. Standalone components with signals, OnPush change detection, reactive forms (`ControlValueAccessor`), and zoneless mode support.
-
-```ts
-import { Component, signal } from '@angular/core';
-import {
-  DomternalEditorComponent,
-  DomternalToolbarComponent,
-  DomternalBubbleMenuComponent,
-} from '@domternal/angular';
-import { Editor, StarterKit, BubbleMenu } from '@domternal/core';
-
-@Component({
-  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent],
-  template: `
-    @if (editor(); as ed) {
-      <domternal-toolbar [editor]="ed" />
-    }
-    <domternal-editor
-      [extensions]="extensions"
-      [content]="content"
-      (editorCreated)="editor.set($event)"
-    />
-    @if (editor(); as ed) {
-      <domternal-bubble-menu [editor]="ed" />
-    }
-  `,
-})
-export class EditorComponent {
-  editor = signal<Editor | null>(null);
-  extensions = [StarterKit, BubbleMenu];
-  content = '<p>Hello from Angular!</p>';
-}
-```
-
-Add the theme to your global stylesheet:
-
-```scss
-@use '@domternal/theme';
-```
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of what each package includes and how tree-shaking works.
 
 ## Documentation
 

--- a/packages/core/src/nodes/HardBreak.ts
+++ b/packages/core/src/nodes/HardBreak.ts
@@ -7,6 +7,7 @@
 
 import { Node } from '../Node.js';
 import type { CommandSpec } from '../types/Commands.js';
+import type { ToolbarItem } from '../types/Toolbar.js';
 
 declare module '../types/Commands.js' {
   interface RawCommands {
@@ -57,6 +58,21 @@ export const HardBreak = Node.create<HardBreakOptions>({
           return true;
         },
     };
+  },
+
+  addToolbarItems(): ToolbarItem[] {
+    return [
+      {
+        type: 'button',
+        name: 'hardBreak',
+        command: 'setHardBreak',
+        icon: 'linkBreak',
+        label: 'Hard Break',
+        shortcut: 'Shift-Enter',
+        group: 'insert',
+        priority: 50,
+      },
+    ];
   },
 
   addKeyboardShortcuts() {

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -424,7 +424,7 @@ export const Table = Node.create<TableOptions>({
     return [
       {
         type: 'button',
-        name: 'insertTable',
+        name: 'table',
         command: 'insertTable',
         icon: 'table',
         label: 'Insert Table',


### PR DESCRIPTION
## Summary
- Add `addToolbarItems()` to HardBreak so `'hardBreak'` works in `toolbarLayout`
- Rename Table toolbar button name from `'insertTable'` to `'table'` for consistency
- Resolve README merge conflicts, use shorter Quick Start with StackBlitz links

## Changes
- **HardBreak**: added toolbar button registration (`linkBreak` icon, `Shift-Enter` shortcut, `insert` group)
- **Table**: toolbar item `name` changed from `insertTable` to `table` (command name unchanged)
- **README**: resolved stash conflicts, replaced verbose code examples with short Quick Start + StackBlitz/docs links

## Test plan
- `pnpm test` passes in both `packages/core` (1908) and `packages/extension-table` (212)
- Verify `'table'` and `'hardBreak'` appear in toolbar when added to `toolbarLayout`