### PR TITLE
fix(theme,table): accessibility improvements, dark mode dropdown fix, and cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,6 @@ Include:
 - **What** - Problem/issue being solved (optional)
 - **Test plan** - Steps to verify (optional)
 
-## Contributor License Agreement (CLA)
-
-Before your first pull request can be merged, you need to sign our [Contributor License Agreement (CLA)](https://gist.github.com/ThomasNowHere/cdca6f890b). The CLA confirms that you have the right to contribute your code and that you grant the project permission to use it. When you open a PR, the CLA Assistant bot will post a comment with a link to sign. You only need to sign once.
-
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Domternal Editor](https://domternal.dev/readme/readme-banner.png)](https://domternal.dev)
 
-A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components.
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/domternal/domternal/actions/workflows/ci.yml/badge.svg)](https://github.com/domternal/domternal/actions/workflows/ci.yml)

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,70 +1,35 @@
 # @domternal/angular
 
-Angular components for the Domternal editor: editor, toolbar, bubble menu, floating menu, and emoji picker. Standalone components with signals, OnPush change detection, reactive forms (`ControlValueAccessor`), and zoneless mode support.
+[![Version](https://img.shields.io/npm/v/@domternal/angular.svg)](https://www.npmjs.com/package/@domternal/angular)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-Requires Angular 17.1+.
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-## Installation
+## Features
 
-```bash
-npm install @domternal/core @domternal/theme @domternal/angular
-```
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-## Quick Start
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-```ts
-import { Component, signal } from '@angular/core';
-import {
-  DomternalEditorComponent,
-  DomternalToolbarComponent,
-  DomternalBubbleMenuComponent,
-} from '@domternal/angular';
-import { Editor, StarterKit, BubbleMenu } from '@domternal/core';
+## Documentation
 
-@Component({
-  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent],
-  template: `
-    @if (editor(); as ed) {
-      <domternal-toolbar [editor]="ed" />
-    }
-    <domternal-editor
-      [extensions]="extensions"
-      [content]="content"
-      (editorCreated)="editor.set($event)"
-    />
-    @if (editor(); as ed) {
-      <domternal-bubble-menu [editor]="ed" />
-    }
-  `,
-})
-export class EditorComponent {
-  editor = signal<Editor | null>(null);
-  extensions = [StarterKit, BubbleMenu];
-  content = '<p>Hello from Angular!</p>';
-}
-```
-
-### Global Styles
-
-Add the theme to your global stylesheet to load editor and toolbar styles:
-
-```scss
-@use '@domternal/theme';
-```
-
-### Available Components
-
-| Component | Description |
-|---|---|
-| `<domternal-editor>` | The core editor surface |
-| `<domternal-toolbar>` | Auto-renders toolbar buttons based on provided extensions |
-| `<domternal-bubble-menu>` | Contextual formatting menu on text selection |
-| `<domternal-floating-menu>` | Block-level insertion menu on empty lines |
-| `<domternal-emoji-picker>` | Emoji picker panel for the Emoji extension |
-
-The toolbar and bubble menu components auto-render buttons based on the extensions you provide. No manual button wiring needed.
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -68,6 +68,7 @@ interface SchemaShape {
             [class.dm-toolbar-button--active]="isItemActive(item)"
             [disabled]="isItemDisabled(item)"
             [title]="item.label"
+            [attr.aria-label]="item.label"
             [innerHTML]="getCachedIcon(item.icon)"
             (mousedown)="$event.preventDefault()"
             (click)="executeCommand(item)"></button>

--- a/packages/angular/src/lib/emoji-picker.component.ts
+++ b/packages/angular/src/lib/emoji-picker.component.ts
@@ -59,6 +59,7 @@ const CATEGORY_ICONS: Record<string, string> = {
               class="dm-emoji-picker-tab"
               [class.dm-emoji-picker-tab--active]="activeCategory() === cat"
               [title]="cat"
+              [attr.aria-label]="cat"
               (mousedown)="$event.preventDefault()"
               (click)="scrollToCategory(cat)"
             >{{ categoryIcon(cat) }}</button>
@@ -72,6 +73,7 @@ const CATEGORY_ICONS: Record<string, string> = {
                 type="button"
                 class="dm-emoji-swatch"
                 [title]="formatName(item.name)"
+                [attr.aria-label]="formatName(item.name)"
                 (mousedown)="$event.preventDefault()"
                 (click)="selectEmoji(item)"
               >{{ item.emoji }}</button>
@@ -87,6 +89,7 @@ const CATEGORY_ICONS: Record<string, string> = {
                   type="button"
                   class="dm-emoji-swatch"
                   [title]="formatName(item.name)"
+                  [attr.aria-label]="formatName(item.name)"
                   (mousedown)="$event.preventDefault()"
                   (click)="selectEmoji(item)"
                 >{{ item.emoji }}</button>
@@ -99,6 +102,7 @@ const CATEGORY_ICONS: Record<string, string> = {
                   type="button"
                   class="dm-emoji-swatch"
                   [title]="formatName(item.name)"
+                  [attr.aria-label]="formatName(item.name)"
                   (mousedown)="$event.preventDefault()"
                   (click)="selectEmoji(item)"
                 >{{ item.emoji }}</button>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,96 +1,35 @@
 # @domternal/core
 
-Lightweight, framework-agnostic rich text editor engine with 13 nodes, 9 marks, 25 extensions, 112+ chainable commands, and 45 built-in icons.
+[![Version](https://img.shields.io/npm/v/@domternal/core.svg)](https://www.npmjs.com/package/@domternal/core)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core
-```
+## Features
 
-## Quick Start
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-### Headless (Vanilla JS/TS)
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-Import only the extensions you need for full control and zero bloat:
+## Documentation
 
-```ts
-import { Editor, Document, Text, Paragraph, Bold, Italic, Underline } from '@domternal/core';
-
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [Document, Text, Paragraph, Bold, Italic, Underline],
-  content: '<p>Hello <strong>World</strong>!</p>',
-});
-```
-
-### With Theme and Toolbar
-
-Use `StarterKit` for a batteries-included setup, and pair it with `@domternal/theme` for styled UI:
-
-```html
-<div id="editor" class="dm-editor"></div>
-```
-
-```ts
-import { Editor, StarterKit, defaultIcons } from '@domternal/core';
-import '@domternal/theme';
-
-const editorEl = document.getElementById('editor')!;
-
-// Toolbar
-const toolbar = document.createElement('div');
-toolbar.className = 'dm-toolbar';
-toolbar.innerHTML = `<div class="dm-toolbar-group">
-  <button class="dm-toolbar-button" data-mark="bold">${defaultIcons.textB}</button>
-  <button class="dm-toolbar-button" data-mark="italic">${defaultIcons.textItalic}</button>
-  <button class="dm-toolbar-button" data-mark="underline">${defaultIcons.textUnderline}</button>
-</div>`;
-editorEl.before(toolbar);
-
-// Editor
-const editor = new Editor({
-  element: editorEl,
-  extensions: [StarterKit],
-  content: '<p>Hello world</p>',
-});
-
-// Toggle marks on click (event delegation)
-toolbar.addEventListener('click', (e) => {
-  const btn = (e.target as Element).closest<HTMLButtonElement>('[data-mark]');
-  if (!btn) return;
-  editor.chain().focus().toggleMark(btn.dataset.mark!).run();
-});
-
-// Active state sync
-editor.on('transaction', () => {
-  toolbar.querySelectorAll<HTMLButtonElement>('[data-mark]').forEach((btn) => {
-    btn.classList.toggle('dm-toolbar-button--active', editor.isActive(btn.dataset.mark!));
-  });
-});
-```
-
-### StarterKit Contents
-
-Every extension in the kit can be disabled with `false` or configured with options:
-
-```ts
-StarterKit.configure({
-  codeBlock: false,                     // disable an extension
-  heading: { levels: [1, 2, 3, 4] },   // limit heading levels
-  history: { depth: 50 },               // configure undo stack
-  link: { openOnClick: false },         // keep links non-clickable while editing
-  linkPopover: false,                   // disable the built-in link popover
-})
-```
-
-| Category | Included |
-|---|---|
-| **Nodes** | Document, Text, Paragraph, Heading, Blockquote, CodeBlock, BulletList, OrderedList, ListItem, TaskList, TaskItem, HorizontalRule, HardBreak |
-| **Marks** | Bold, Italic, Underline, Strike, Code, Link |
-| **Behaviors** | BaseKeymap, History, Dropcursor, Gapcursor, TrailingNode, ListKeymap, LinkPopover |
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/core/src/extensions/LinkPopover.ts
+++ b/packages/core/src/extensions/LinkPopover.ts
@@ -60,12 +60,14 @@ function linkPopoverPlugin({ editor, markType, protocols }: LinkPopoverPluginOpt
   applyBtn.type = 'button';
   applyBtn.className = 'dm-link-popover-btn dm-link-popover-apply';
   applyBtn.title = 'Apply link';
+  applyBtn.setAttribute('aria-label', 'Apply link');
   applyBtn.innerHTML = defaultIcons['check'] ?? '';
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
   removeBtn.className = 'dm-link-popover-btn dm-link-popover-remove';
   removeBtn.title = 'Remove link';
+  removeBtn.setAttribute('aria-label', 'Remove link');
   removeBtn.innerHTML = defaultIcons['linkBreak'] ?? '';
 
   el.appendChild(input);

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -1,52 +1,35 @@
 # @domternal/extension-code-block-lowlight
 
-Syntax-highlighted code blocks for the Domternal editor, powered by [lowlight](https://github.com/wooorm/lowlight) (highlight.js).
+[![Version](https://img.shields.io/npm/v/@domternal/extension-code-block-lowlight.svg)](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-code-block-lowlight lowlight
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { CodeBlockLowlight } from '@domternal/extension-code-block-lowlight';
-import { createLowlight, common } from 'lowlight';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const lowlight = createLowlight(common);
+## Documentation
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [
-    StarterKit.configure({ codeBlock: false }), // disable the default CodeBlock
-    CodeBlockLowlight.configure({ lowlight }),
-  ],
-});
-```
-
-### Options
-
-| Option | Default | Description |
-|---|---|---|
-| `lowlight` | (required) | A lowlight instance created with `createLowlight()` |
-| `defaultLanguage` | `null` | Default language when none is specified |
-| `autoDetect` | `true` | Auto-detect language when none is specified |
-| `tabIndentation` | `true` | Tab key inserts spaces inside code blocks |
-| `tabSize` | `2` | Number of spaces per tab |
-
-### Server-Side Rendering
-
-Use `generateHighlightedHTML` to produce syntax-highlighted HTML on the server:
-
-```ts
-import { generateHighlightedHTML } from '@domternal/extension-code-block-lowlight';
-
-const html = generateHighlightedHTML(jsonContent, { lowlight });
-```
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -1,53 +1,35 @@
 # @domternal/extension-details
 
-Collapsible details/accordion blocks for the Domternal editor, rendered as semantic `<details>`/`<summary>` HTML.
+[![Version](https://img.shields.io/npm/v/@domternal/extension-details.svg)](https://www.npmjs.com/package/@domternal/extension-details)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-details
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { Details, DetailsSummary, DetailsContent } from '@domternal/extension-details';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [StarterKit, Details, DetailsSummary, DetailsContent],
-  content: '<p>Hello world</p>',
-});
+## Documentation
 
-// Wrap selected content in a details block
-editor.commands.setDetails();
-
-// Toggle details on/off
-editor.commands.toggleDetails();
-
-// Open or close programmatically
-editor.commands.openDetails();
-editor.commands.closeDetails();
-```
-
-### Commands
-
-| Command | Description |
-|---|---|
-| `setDetails` | Wrap selected content in a details structure |
-| `unsetDetails` | Lift content out of details (preserves summary as paragraph) |
-| `toggleDetails` | Toggle between wrapped and unwrapped |
-| `openDetails` / `closeDetails` | Programmatic open/close control |
-| `setDetailsOpen(boolean)` | Set the open state explicitly |
-
-### Options
-
-| Option | Default | Description |
-|---|---|---|
-| `persist` | `false` | Persist the open/closed state in the document |
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-details/src/Details.ts
+++ b/packages/extension-details/src/Details.ts
@@ -121,6 +121,7 @@ export const Details = Node.create<DetailsOptions>({
 
       const toggle = document.createElement('button');
       toggle.type = 'button';
+      toggle.setAttribute('aria-label', 'Toggle details');
       toggle.addEventListener('mousedown', (e) => { e.preventDefault(); });
       dom.append(toggle);
 

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -1,46 +1,35 @@
 # @domternal/extension-emoji
 
-Emoji extension for Domternal with a picker panel and `:shortcode:` autocomplete suggestions.
+[![Version](https://img.shields.io/npm/v/@domternal/extension-emoji.svg)](https://www.npmjs.com/package/@domternal/extension-emoji)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-emoji
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { Emoji, emojis } from '@domternal/extension-emoji';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [
-    StarterKit,
-    Emoji.configure({
-      emojis,
-      enableEmoticons: true,  // converts :) and <3 to emoji
-    }),
-  ],
-});
+## Documentation
 
-// Insert emoji by name
-editor.commands.insertEmoji('smile');
-
-// Open the suggestion picker programmatically
-editor.commands.suggestEmoji();
-```
-
-### Features
-
-- **Shortcode input rules** - type `:smile:` to insert an emoji inline
-- **Emoticon support** - converts common emoticons like `:)`, `<3`, and `:(` when `enableEmoticons` is enabled
-- **Autocomplete suggestions** - type `:` followed by a query to see matching emoji in a dropdown
-- **Built-in dataset** - includes approximately 200 popular emoji out of the box
-- **Custom emoji** - provide your own `EmojiItem[]` array for a custom set
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -1,56 +1,35 @@
 # @domternal/extension-image
 
-Image extension for Domternal with paste/drop upload, URL input, XSS protection, and bubble menu controls.
+[![Version](https://img.shields.io/npm/v/@domternal/extension-image.svg)](https://www.npmjs.com/package/@domternal/extension-image)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-image
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { Image } from '@domternal/extension-image';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [
-    StarterKit,
-    Image.configure({
-      allowBase64: true,
-      uploadHandler: async (file) => {
-        // Upload the file and return the URL
-        const url = await myUploadService(file);
-        return url;
-      },
-    }),
-  ],
-});
+## Documentation
 
-// Insert an image programmatically
-editor.commands.setImage({ src: 'https://example.com/photo.jpg', alt: 'A photo' });
-
-// Float image to the left
-editor.commands.setImageFloat('left');
-```
-
-### Options
-
-| Option | Default | Description |
-|---|---|---|
-| `inline` | `false` | When `true`, images render inline within paragraphs |
-| `allowBase64` | `true` | Allow `data:image/` URLs. When `false`, only `http(s)` URLs are accepted |
-| `uploadHandler` | `null` | Async function that receives a `File` and returns a URL string. Enables paste/drop upload |
-
-### Commands
-
-- `setImage({ src, alt?, title?, width?, height?, float? })` - insert or update an image
-- `setImageFloat('left' | 'right' | 'center' | 'none')` - set text wrapping
-- `deleteImage()` - remove the selected image
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -502,12 +502,14 @@ export const Image = Node.create<ImageOptions>({
       applyBtn.type = 'button';
       applyBtn.className = 'dm-image-popover-btn dm-image-popover-apply';
       applyBtn.title = 'Insert image';
+      applyBtn.setAttribute('aria-label', 'Insert image');
       applyBtn.innerHTML = defaultIcons['check'] ?? '';
 
       const browseBtn = document.createElement('button');
       browseBtn.type = 'button';
       browseBtn.className = 'dm-image-popover-btn dm-image-popover-browse';
       browseBtn.title = 'Browse files';
+      browseBtn.setAttribute('aria-label', 'Browse files');
       browseBtn.innerHTML = defaultIcons['image'] ?? '';
 
       el.appendChild(urlInput);

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -1,70 +1,35 @@
 # @domternal/extension-mention
 
-`@mention` autocomplete extension for Domternal with multi-trigger and async support.
+[![Version](https://img.shields.io/npm/v/@domternal/extension-mention.svg)](https://www.npmjs.com/package/@domternal/extension-mention)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-mention
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { Mention } from '@domternal/extension-mention';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [
-    StarterKit,
-    Mention.configure({
-      suggestion: {
-        char: '@',
-        name: 'user',
-        items: ({ query }) =>
-          users.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
-        render: createMentionRenderer,
-      },
-    }),
-  ],
-});
+## Documentation
 
-// Insert a mention programmatically
-editor.commands.insertMention({ id: '1', label: 'Alice' });
-```
-
-### Multi-trigger
-
-Use the `triggers` option to support multiple trigger characters (for example, `@` for users and `#` for tags):
-
-```ts
-Mention.configure({
-  triggers: [
-    {
-      char: '@',
-      name: 'user',
-      items: ({ query }) => fetchUsers(query),
-      render: createUserRenderer,
-    },
-    {
-      char: '#',
-      name: 'tag',
-      items: ({ query }) => fetchTags(query),
-      render: createTagRenderer,
-    },
-  ],
-})
-```
-
-### Features
-
-- **Autocomplete dropdown** - type a trigger character followed by a query to see matching items
-- **Async item fetching** - the `items` function can return a `Promise` for server-side lookups
-- **Multi-trigger** - define multiple trigger characters, each with its own item source and renderer
-- **Custom rendering** - provide a `render` function for full control over the suggestion dropdown UI
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -1,54 +1,35 @@
 # @domternal/extension-table
 
-Table extension for Domternal with 18 commands, cell merging, column resize, row/column controls, and cell toolbar.
+[![Version](https://img.shields.io/npm/v/@domternal/extension-table.svg)](https://www.npmjs.com/package/@domternal/extension-table)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/core @domternal/extension-table
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-```ts
-import { Editor, StarterKit } from '@domternal/core';
-import { Table, TableRow, TableCell, TableHeader } from '@domternal/extension-table';
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-const editor = new Editor({
-  element: document.getElementById('editor')!,
-  extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
-  content: '<p>Hello world</p>',
-});
+## Documentation
 
-// Insert a 3x3 table with a header row
-editor.commands.insertTable({ rows: 3, cols: 3, withHeaderRow: true });
-
-// Merge selected cells
-editor.commands.mergeCells();
-
-// Add a row after the current one
-editor.commands.addRowAfter();
-```
-
-### Commands
-
-| Command | Description |
-|---|---|
-| `insertTable` | Insert a new table with configurable rows, cols, and header row |
-| `deleteTable` | Delete the entire table |
-| `addRowBefore` / `addRowAfter` | Insert a row above or below |
-| `deleteRow` | Delete the current row |
-| `addColumnBefore` / `addColumnAfter` | Insert a column left or right |
-| `deleteColumn` | Delete the current column |
-| `mergeCells` | Merge selected cells into one |
-| `splitCell` | Split a merged cell back to individual cells |
-| `toggleHeaderRow` / `toggleHeaderColumn` / `toggleHeaderCell` | Toggle header formatting |
-| `setCellAttribute` | Set an attribute on the current cell |
-| `goToNextCell` / `goToPreviousCell` | Navigate between cells with Tab/Shift-Tab |
-| `fixTables` | Repair malformed tables |
-| `setCellSelection` | Programmatic cell range selection |
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -638,6 +638,7 @@ export class TableView implements NodeView {
     dropdown.style.left = String(handleRect.left) + 'px';
     dropdown.style.top = String(handleRect.bottom + 4) + 'px';
 
+    this.copyThemeClass(dropdown);
     document.body.appendChild(dropdown);
     this.dropdown = dropdown;
     this.addDropdownListeners();
@@ -762,6 +763,7 @@ export class TableView implements NodeView {
     dropdown.style.top = String(btnRect.bottom + 4) + 'px';
 
     // Append to body first to measure
+    this.copyThemeClass(dropdown);
     document.body.appendChild(dropdown);
     this.dropdown = dropdown;
 
@@ -774,6 +776,18 @@ export class TableView implements NodeView {
     dropdown.style.left = String(Math.max(0, leftPos)) + 'px';
 
     this.addDropdownListeners();
+  }
+
+  /** Copy dm-theme-* class from the editor to the dropdown so CSS variables apply when appended to body. */
+  private copyThemeClass(dropdown: HTMLElement): void {
+    const editorEl = this.view.dom.closest('.dm-editor');
+    const themeEl = editorEl?.closest('[class*="dm-theme-"]') ?? editorEl;
+    if (!themeEl) return;
+    themeEl.classList.forEach((cls) => {
+      if (cls.startsWith('dm-theme-')) {
+        dropdown.classList.add(cls);
+      }
+    });
   }
 
   private addDropdownListeners(): void {

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -620,6 +620,7 @@ export class TableView implements NodeView {
     for (const item of items) {
       const btn = document.createElement('button');
       btn.type = 'button';
+      btn.setAttribute('aria-label', item.label);
       btn.innerHTML = `<span class="dm-table-controls-dropdown-icon">${item.icon}</span>${item.label}`;
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -669,6 +670,7 @@ export class TableView implements NodeView {
       const resetBtn = document.createElement('button');
       resetBtn.type = 'button';
       resetBtn.className = 'dm-color-palette-reset';
+      resetBtn.setAttribute('aria-label', 'Default color');
       resetBtn.innerHTML =
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="14" height="14"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm88,104a87.56,87.56,0,0,1-20.41,56.28L71.72,60.41A88,88,0,0,1,216,128ZM40,128A87.56,87.56,0,0,1,60.41,71.72L184.28,195.59A88,88,0,0,1,40,128Z"/></svg>' +
         ' Default';
@@ -743,6 +745,7 @@ export class TableView implements NodeView {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'dm-table-align-item' + (active ? ' dm-table-align-item--active' : '');
+    btn.setAttribute('aria-label', label);
     btn.innerHTML = `<span class="dm-table-align-item-icon">${icon}</span><span>${label}</span>`;
     btn.addEventListener('click', (e) => {
       e.stopPropagation();

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -1,50 +1,35 @@
 # @domternal/pm
 
-Convenience re-exports of ProseMirror packages via subpath imports, so you can depend on a single package instead of twelve.
+[![Version](https://img.shields.io/npm/v/@domternal/pm.svg)](https://www.npmjs.com/package/@domternal/pm)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/pm
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-Import ProseMirror modules through subpath exports:
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-```ts
-import { EditorState, Plugin, PluginKey } from '@domternal/pm/state';
-import { EditorView } from '@domternal/pm/view';
-import { Schema, Node, Mark } from '@domternal/pm/model';
-import { ReplaceStep } from '@domternal/pm/transform';
-import { keymap } from '@domternal/pm/keymap';
-import { undo, redo, history } from '@domternal/pm/history';
-import { baseKeymap } from '@domternal/pm/commands';
-import { inputRules } from '@domternal/pm/inputrules';
-import { dropCursor } from '@domternal/pm/dropcursor';
-import { gapCursor } from '@domternal/pm/gapcursor';
-import { tableEditing, columnResizing } from '@domternal/pm/tables';
-import { wrapInList, liftListItem } from '@domternal/pm/schema-list';
-```
+## Documentation
 
-### Available Subpath Exports
-
-| Import | Re-exports |
-|---|---|
-| `@domternal/pm/state` | `prosemirror-state` |
-| `@domternal/pm/view` | `prosemirror-view` |
-| `@domternal/pm/model` | `prosemirror-model` |
-| `@domternal/pm/transform` | `prosemirror-transform` |
-| `@domternal/pm/commands` | `prosemirror-commands` |
-| `@domternal/pm/keymap` | `prosemirror-keymap` |
-| `@domternal/pm/history` | `prosemirror-history` |
-| `@domternal/pm/inputrules` | `prosemirror-inputrules` |
-| `@domternal/pm/dropcursor` | `prosemirror-dropcursor` |
-| `@domternal/pm/gapcursor` | `prosemirror-gapcursor` |
-| `@domternal/pm/tables` | `prosemirror-tables` |
-| `@domternal/pm/schema-list` | `prosemirror-schema-list` |
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,59 +1,35 @@
 # @domternal/theme
 
-Light and dark themes for the Domternal editor with 70+ CSS custom properties for full visual control.
+[![Version](https://img.shields.io/npm/v/@domternal/theme.svg)](https://www.npmjs.com/package/@domternal/theme)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-Part of the [Domternal](https://github.com/domternal/domternal) toolkit. Full docs at [domternal.dev](https://domternal.dev).
+A lightweight, extensible rich text editor toolkit built on [ProseMirror](https://prosemirror.net/). Framework-agnostic headless core with first-class **Angular** support. Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made Angular components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
 
-## Installation
+**[Website](https://domternal.dev)** · **[Documentation](https://domternal.dev/v1/introduction)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** · **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)**
 
-```bash
-npm install @domternal/theme
-```
+## Features
 
-## Usage
+See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of all packages and what each one includes.
 
-### CSS Import
+- **Headless core** - use with any framework or vanilla JS/TS
+- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker (signals, OnPush, zoneless-ready)
+- **57 extensions across 10 packages** - 23 nodes, 9 marks, and 25 behavior extensions
+- **140+ chainable commands** - `editor.chain().focus().toggleBold().run()`
+- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
+- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **~38 KB gzipped** (own code), [~108 KB total](https://domternal.dev/v1/packages) with ProseMirror
+- **TypeScript first** - 100% typed, zero `any`
+- **4,200+ tests** - 2,675 unit tests and 1,550 E2E tests across 34 Playwright specs
+- **Light and dark theme** - 70+ CSS custom properties for full visual control
+- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
+- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
-Import the pre-built CSS file in your JavaScript or HTML:
+## Documentation
 
-```ts
-import '@domternal/theme';
-```
-
-Or link to the CSS file directly:
-
-```html
-<link rel="stylesheet" href="node_modules/@domternal/theme/dist/domternal-theme.css" />
-```
-
-### SCSS
-
-If your project uses SCSS, use `@use` instead for access to SCSS variables and mixins:
-
-```scss
-@use '@domternal/theme';
-```
-
-### Dark Mode
-
-The theme automatically switches between light and dark based on the user's system preference via `prefers-color-scheme`. You can also force a mode by adding a CSS class to the editor wrapper or a parent element:
-
-- `.dm-theme-dark` - force dark mode
-- `.dm-theme-light` - force light mode
-- `.dm-theme-auto` - follow system preference (default behavior)
-
-### Customization
-
-Override any of the 70+ CSS custom properties on `.dm-editor` to customize the look:
-
-```css
-.dm-editor {
-  --dm-editor-font-family: 'Inter', sans-serif;
-  --dm-editor-font-size: 16px;
-  --dm-editor-border-radius: 8px;
-  --dm-accent: #3b82f6;
-}
-```
+- [Getting Started](https://domternal.dev/v1/getting-started) - install and create your first editor
+- [Introduction](https://domternal.dev/v1/introduction) - core concepts, architecture, and design decisions
+- [Packages & Bundle Size](https://domternal.dev/v1/packages) - what each package includes and bundle size breakdown
+- [Blog](https://domternal.dev/blog)
 
 ## License
 

--- a/packages/theme/src/_variables.scss
+++ b/packages/theme/src/_variables.scss
@@ -74,12 +74,12 @@
   // ---------------------------------------------------------------------------
   // Syntax highlighting (CodeBlockLowlight)
   // ---------------------------------------------------------------------------
-  --dm-syntax-keyword: #d73a49;
+  --dm-syntax-keyword: #c72031;
   --dm-syntax-entity: #6f42c1;
   --dm-syntax-constant: #005cc5;
   --dm-syntax-string: #032f62;
-  --dm-syntax-variable: #e36209;
-  --dm-syntax-comment: #6a737d;
+  --dm-syntax-variable: #d35400;
+  --dm-syntax-comment: #57606a;
   --dm-syntax-tag: #22863a;
   --dm-syntax-addition: #22863a;
   --dm-syntax-addition-bg: #f0fff4;

--- a/packages/theme/src/themes/_dark.scss
+++ b/packages/theme/src/themes/_dark.scss
@@ -51,7 +51,8 @@
 .dm-theme-dark .dm-toolbar,
 .dm-theme-dark .dm-bubble-menu,
 .dm-theme-dark .dm-emoji-picker,
-.dm-theme-dark .dm-emoji-suggestion {
+.dm-theme-dark .dm-emoji-suggestion,
+.dm-theme-dark .dm-table-controls-dropdown {
   @include dark-tokens;
 }
 
@@ -62,7 +63,8 @@
   .dm-theme-auto .dm-toolbar,
   .dm-theme-auto .dm-bubble-menu,
   .dm-theme-auto .dm-emoji-picker,
-  .dm-theme-auto .dm-emoji-suggestion {
+  .dm-theme-auto .dm-emoji-suggestion,
+  .dm-theme-auto .dm-table-controls-dropdown {
     @include dark-tokens;
   }
 }

--- a/packages/theme/src/themes/_light.scss
+++ b/packages/theme/src/themes/_light.scss
@@ -23,12 +23,12 @@
   --dm-highlight-bg: #fff3cd;
 
   // Syntax highlighting
-  --dm-syntax-keyword: #d73a49;
+  --dm-syntax-keyword: #c72031;
   --dm-syntax-entity: #6f42c1;
   --dm-syntax-constant: #005cc5;
   --dm-syntax-string: #032f62;
-  --dm-syntax-variable: #e36209;
-  --dm-syntax-comment: #6a737d;
+  --dm-syntax-variable: #d35400;
+  --dm-syntax-comment: #57606a;
   --dm-syntax-tag: #22863a;
   --dm-syntax-addition: #22863a;
   --dm-syntax-addition-bg: #f0fff4;

--- a/packages/theme/src/themes/_light.scss
+++ b/packages/theme/src/themes/_light.scss
@@ -38,6 +38,7 @@
 
 .dm-theme-light,
 .dm-theme-light .dm-editor,
-.dm-theme-light .dm-toolbar {
+.dm-theme-light .dm-toolbar,
+.dm-theme-light .dm-table-controls-dropdown {
   @include light-tokens;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,16 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+    devDependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.1
+        version: 3.7.1
 
   examples/angular:
     dependencies:
@@ -8714,8 +8721,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -13636,7 +13642,8 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
 
-  sax@1.4.4: {}
+  sax@1.4.4:
+    optional: true
 
   sax@1.5.0: {}
 
@@ -13710,7 +13717,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -13792,7 +13798,7 @@ snapshots:
       '@types/node': 24.12.0
       '@types/sax': 1.2.7
       arg: 5.0.2
-      sax: 1.4.4
+      sax: 1.5.0
 
   slice-ansi@7.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixed table dropdowns rendering white in dark mode (appended to `document.body` outside theme scope)
- Added `aria-label` to all interactive buttons missing accessible names
- Improved syntax highlighting contrast ratios for WCAG AA compliance
- Removed CLA section from CONTRIBUTING.md

## Changes
- Added `.dm-table-controls-dropdown` to dark/light/auto theme selectors
- Added `copyThemeClass()` in `TableView.ts` to propagate theme class to body-appended dropdowns
- Added `aria-label` to bubble menu, emoji picker, link popover, image popover, and details toggle buttons
- Adjusted syntax highlighting and light theme color values for better contrast