### PR TITLE
feat(mention,core): add mention renderer, fix keydown & HR bugs, add E2E tests

### DIFF
--- a/apps/demo-angular/e2e/details.spec.ts
+++ b/apps/demo-angular/e2e/details.spec.ts
@@ -1412,3 +1412,241 @@ test.describe('Details — CellSelection toggle', () => {
     expect(cell3HTML).not.toContain('data-type="details"');
   });
 });
+
+// =============================================================================
+// Documentation verification tests
+// =============================================================================
+
+test.describe('Details — documentation verification', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  // --- unsetDetails: empty summary produces NO paragraph ---
+  test('unsetDetails on empty summary does NOT create a paragraph for the summary', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_EMPTY_SUMMARY);
+    // Focus inside the empty summary using editor API
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) comp.editor.commands.focus('start');
+    });
+    await page.waitForTimeout(50);
+
+    // Unwrap via command
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) comp.editor.commands.unsetDetails();
+    });
+    await page.waitForTimeout(100);
+
+    // Should only have the content paragraph, no empty paragraph from the summary
+    const paragraphs = page.locator(`${editorSelector} > p`);
+    const count = await paragraphs.count();
+    // The content had one paragraph "Content", so we should have exactly 1 paragraph
+    expect(count).toBe(1);
+    const text = await paragraphs.first().textContent();
+    expect(text).toContain('Content');
+  });
+
+  // --- unsetDetails: non-empty summary becomes a paragraph ---
+  test('unsetDetails on non-empty summary creates a paragraph for the summary text', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    await focusSummaryStart(page);
+
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) comp.editor.commands.unsetDetails();
+    });
+    await page.waitForTimeout(100);
+
+    // Should have 2 paragraphs: summary text + content
+    const paragraphs = page.locator(`${editorSelector} > p`);
+    const count = await paragraphs.count();
+    expect(count).toBe(2);
+    await expect(paragraphs.nth(0)).toContainText('Summary title');
+    await expect(paragraphs.nth(1)).toContainText('Content body');
+  });
+
+  // --- Enter in summary creates block at START of detailsContent ---
+  test('Enter in summary creates new block at the START of content (before existing content)', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    await clickDetailsToggle(page);
+    await focusSummaryEnd(page);
+
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('First block');
+
+    // The typed text should be in the FIRST paragraph of detailsContent
+    const contentParas = page.locator(`${editorSelector} div[data-details-content] p`);
+    const count = await contentParas.count();
+    expect(count).toBe(2);
+    await expect(contentParas.nth(0)).toContainText('First block');
+    await expect(contentParas.nth(1)).toContainText('Content body');
+  });
+
+  // --- ArrowRight in middle of summary does NOT jump out ---
+  test('ArrowRight in middle of summary text moves cursor normally (does not gap-cursor)', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC + '<p>After</p>');
+    // Click the summary to focus it, then use Home to move to start
+    const summary = page.locator(`${editorSelector} div[data-type="details"] summary`);
+    await summary.click();
+    await page.waitForTimeout(50);
+
+    // Move to start of summary, then right a couple of times (still middle)
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Home';
+    if (process.platform === 'darwin') {
+      await page.keyboard.press('Meta+ArrowLeft');
+    } else {
+      await page.keyboard.press('Home');
+    }
+    await page.waitForTimeout(50);
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type('X');
+
+    // The X should be inside the summary
+    const summaryText = await summary.textContent();
+    expect(summaryText).toContain('X');
+    // And not in the after paragraph
+    const afterPara = page.locator(`${editorSelector} > p`);
+    const afterText = await afterPara.textContent();
+    expect(afterText).not.toContain('X');
+  });
+
+  // --- setDetails nesting prevention returns false ---
+  test('setDetails command returns false when already inside details', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    await clickDetailsToggle(page);
+    await focusContentParagraph(page);
+
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      return comp?.editor?.commands.setDetails() ?? null;
+    });
+    expect(result).toBe(false);
+  });
+
+  // --- toggleDetails single range: inside details = unwrap ---
+  test('toggleDetails unwraps when cursor is inside details (single range)', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    await focusSummaryStart(page);
+
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      return comp?.editor?.commands.toggleDetails() ?? null;
+    });
+    expect(result).toBe(true);
+
+    const details = page.locator(`${editorSelector} div[data-type="details"]`);
+    await expect(details).toHaveCount(0);
+  });
+
+  // --- Content spec: detailsContent requires at least one block (block+) ---
+  test('detailsContent always has at least one block node', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    await clickDetailsToggle(page);
+
+    const blocks = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (!comp?.editor) return -1;
+      let count = 0;
+      comp.editor.state.doc.descendants((node: any) => {
+        if (node.type.name === 'detailsContent') {
+          count = node.childCount;
+          return false;
+        }
+      });
+      return count;
+    });
+    expect(blocks).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Schema: content spec is exactly detailsSummary + detailsContent ---
+  test('details node has exactly one detailsSummary and one detailsContent child', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+
+    const children = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (!comp?.editor) return [];
+      const types: string[] = [];
+      comp.editor.state.doc.descendants((node: any) => {
+        if (node.type.name === 'details') {
+          node.forEach((child: any) => types.push(child.type.name));
+          return false;
+        }
+      });
+      return types;
+    });
+    expect(children).toEqual(['detailsSummary', 'detailsContent']);
+  });
+
+  // --- HTML rendering outputs semantic <details><summary> + <div data-details-content> ---
+  test('getHTML() outputs <details>, <summary>, and <div data-details-content>', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+
+    const html = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('<details>');
+    expect(html).toContain('<summary>Summary title</summary>');
+    expect(html).toContain('<div data-details-content="">');
+    expect(html).toContain('</details>');
+  });
+
+  // --- Enter in summary when collapsed: opens content ---
+  test('Enter in summary opens collapsed content and places cursor in new block at start', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BASIC);
+    expect(await isDetailsOpen(page)).toBe(false);
+
+    await focusSummaryEnd(page);
+    await page.keyboard.press('Enter');
+
+    // Content should now be open
+    expect(await isDetailsOpen(page)).toBe(true);
+    const content = page.locator(`${editorSelector} div[data-details-content]`);
+    await expect(content).not.toHaveAttribute('hidden');
+
+    // Cursor should be in a new block at the start of content
+    await page.keyboard.type('Newly typed');
+    const contentParas = page.locator(`${editorSelector} div[data-details-content] p`);
+    // There should be 2 paragraphs: the new one + the original
+    await expect(contentParas).toHaveCount(2);
+    await expect(contentParas.nth(0)).toContainText('Newly typed');
+  });
+
+  // --- Toolbar item: isActive reflects cursor position ---
+  test('toolbar details button active state reflects cursor position', async ({ page }) => {
+    await setContentAndFocus(page, DETAILS_BETWEEN_PARAS);
+
+    // Click outside details
+    await page.locator(`${editorSelector} > p`).first().click();
+    const btn = page.locator(detailsBtn);
+    await expect(btn).toHaveAttribute('aria-pressed', 'false');
+
+    // Click inside summary
+    await page.locator(`${editorSelector} div[data-type="details"] summary`).click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'true');
+
+    // Click outside again
+    await page.locator(`${editorSelector} > p`).last().click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/apps/demo-angular/e2e/emoji-inline.spec.ts
+++ b/apps/demo-angular/e2e/emoji-inline.spec.ts
@@ -488,3 +488,381 @@ test.describe('Inline Emoji — edge cases', () => {
     expect(html).toContain('data-name="grinning_face"');
   });
 });
+
+// =============================================================================
+// Docs verification: parseHTML
+// =============================================================================
+
+const EMOJI_LEGACY_FORMAT = '<p>Hi <span data-emoji-name="waving_hand">👋</span></p>';
+
+test.describe('Docs verification — parseHTML', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('parses span[data-type="emoji"] format', async ({ page }) => {
+    await setEditorContent(page, EMOJI_HTML);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-type', 'emoji');
+    await expect(emoji).toHaveAttribute('data-name', 'grinning_face');
+    await expect(emoji).toHaveText('😀');
+  });
+
+  test('parses span[data-emoji-name] legacy format', async ({ page }) => {
+    await setEditorContent(page, EMOJI_LEGACY_FORMAT);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toBeVisible();
+    await expect(emoji).toHaveAttribute('data-name', 'waving_hand');
+    await expect(emoji).toHaveText('👋');
+  });
+
+  test('parseHTML normalizes legacy format to data-type="emoji"', async ({ page }) => {
+    await setEditorContent(page, EMOJI_LEGACY_FORMAT);
+    const emoji = page.locator(emojiNodeSelector).first();
+    // After parsing, renderHTML outputs data-type="emoji" format
+    await expect(emoji).toHaveAttribute('data-type', 'emoji');
+  });
+});
+
+// =============================================================================
+// Docs verification: commands
+// =============================================================================
+
+test.describe('Docs verification — commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('insertEmoji inserts emoji node by name', async ({ page }) => {
+    await setEditorContent(page, '<p>Test </p>');
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.chain().focus().insertEmoji('thumbs_up').run();
+    });
+    expect(result).toBe(true);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-name', 'thumbs_up');
+    await expect(emoji).toHaveText('👍');
+  });
+
+  test('insertEmoji returns false for unknown name', async ({ page }) => {
+    await setEditorContent(page, '<p>Test</p>');
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.insertEmoji('nonexistent_emoji_xyz');
+    });
+    expect(result).toBe(false);
+    await expect(page.locator(emojiNodeSelector)).toHaveCount(0);
+  });
+
+  test('insertEmoji returns false inside code block', async ({ page }) => {
+    await setEditorContent(page, '<pre><code>code here</code></pre>');
+    await page.locator(`${editorSelector} pre`).click();
+    await page.waitForTimeout(100);
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.insertEmoji('grinning_face');
+    });
+    expect(result).toBe(false);
+  });
+
+  test('insertEmoji tracks frequency usage', async ({ page }) => {
+    await setEditorContent(page, '<p>Test </p>');
+    // Use addFrequentlyUsed directly (insertEmoji calls this internally)
+    // to verify the storage tracking mechanism documented in the docs
+    const frequent = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      const storage = comp?.editor?.storage.emoji;
+      // Simulate what insertEmoji does internally
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('thumbs_up');
+      return storage?.getFrequentlyUsed();
+    });
+    expect(frequent[0]).toBe('rocket');
+    expect(frequent[1]).toBe('thumbs_up');
+  });
+
+  test('suggestEmoji inserts trigger character', async ({ page }) => {
+    await setEditorContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      comp?.editor?.commands.suggestEmoji();
+    });
+    await page.waitForTimeout(200);
+    const text = await page.locator(editorSelector).textContent();
+    expect(text).toContain(':');
+  });
+});
+
+// =============================================================================
+// Docs verification: input rules in code blocks
+// =============================================================================
+
+test.describe('Docs verification — code block exclusion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('shortcode :smile: does NOT convert inside code block', async ({ page }) => {
+    // Set content with code block and place cursor inside it
+    await setEditorContent(page, '<pre><code>x</code></pre>');
+    // Click inside the code block, then type at the end
+    await page.locator(`${editorSelector} code`).click();
+    await page.keyboard.press('End');
+    await page.keyboard.type(':smile:');
+    await page.waitForTimeout(200);
+    // Emoji should NOT appear - shortcodes are skipped in code blocks
+    await expect(page.locator(emojiNodeSelector)).toHaveCount(0);
+    const text = await page.locator(`${editorSelector} code`).textContent();
+    expect(text).toContain(':smile:');
+  });
+
+  test('shortcode converts normally in paragraph', async ({ page }) => {
+    await clearAndType(page, ':wave:');
+    await page.waitForTimeout(200);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-name', 'waving_hand');
+  });
+});
+
+// =============================================================================
+// Docs verification: storage methods
+// =============================================================================
+
+test.describe('Docs verification — storage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('findEmoji returns emoji by name', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      const item = comp?.editor?.storage.emoji.findEmoji('red_heart');
+      return item ? { emoji: item.emoji, name: item.name } : null;
+    });
+    expect(result).toEqual({ emoji: '❤️', name: 'red_heart' });
+  });
+
+  test('findEmoji returns undefined for unknown name', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.storage.emoji.findEmoji('this_does_not_exist');
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('searchEmoji finds by name, shortcode, and tag', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      const byName = comp?.editor?.storage.emoji.searchEmoji('grinning');
+      const byTag = comp?.editor?.storage.emoji.searchEmoji('happy');
+      return {
+        byNameCount: byName?.length ?? 0,
+        byTagCount: byTag?.length ?? 0,
+        byNameHasGrinning: byName?.some((e: any) => e.name.includes('grinning')),
+      };
+    });
+    expect(result.byNameCount).toBeGreaterThan(0);
+    expect(result.byTagCount).toBeGreaterThan(0);
+    expect(result.byNameHasGrinning).toBe(true);
+  });
+
+  test('searchEmoji is case-insensitive', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      const lower = comp?.editor?.storage.emoji.searchEmoji('heart');
+      const upper = comp?.editor?.storage.emoji.searchEmoji('HEART');
+      return {
+        lowerCount: lower?.length ?? 0,
+        upperCount: upper?.length ?? 0,
+      };
+    });
+    expect(result.lowerCount).toBeGreaterThan(0);
+    expect(result.lowerCount).toBe(result.upperCount);
+  });
+
+  test('getFrequentlyUsed returns empty initially', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.storage.emoji.getFrequentlyUsed();
+    });
+    expect(result).toEqual([]);
+  });
+
+  test('getFrequentlyUsed sorts by usage count descending', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      const storage = comp?.editor?.storage.emoji;
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('heart');
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('rocket');
+      storage?.addFrequentlyUsed('heart');
+      return storage?.getFrequentlyUsed();
+    });
+    expect(result[0]).toBe('rocket');
+    expect(result[1]).toBe('heart');
+  });
+});
+
+// =============================================================================
+// Docs verification: leafText
+// =============================================================================
+
+test.describe('Docs verification — leafText', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getText returns emoji character for emoji nodes', async ({ page }) => {
+    await setEditorContent(page, EMOJI_HTML);
+    const text = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getText();
+    });
+    expect(text).toContain('😀');
+    expect(text).toContain('Hello');
+    expect(text).toContain('world');
+  });
+});
+
+// =============================================================================
+// Docs verification: JSON representation
+// =============================================================================
+
+test.describe('Docs verification — JSON representation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getJSON returns correct emoji node structure', async ({ page }) => {
+    await setEditorContent(page, EMOJI_ONLY);
+    const json = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getJSON();
+    });
+    const para = json.content[0];
+    const emojiNode = para.content[0];
+    expect(emojiNode.type).toBe('emoji');
+    expect(emojiNode.attrs.name).toBe('grinning_face_with_smiling_eyes');
+  });
+
+  test('emoji JSON has type and attrs.name only', async ({ page }) => {
+    await setEditorContent(page, '<p><span data-type="emoji" data-name="thumbs_up">👍</span></p>');
+    const json = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getJSON();
+    });
+    const emojiNode = json.content[0].content[0];
+    expect(emojiNode.type).toBe('emoji');
+    expect(emojiNode.attrs).toEqual({ name: 'thumbs_up' });
+  });
+
+  test('paragraph with text and emoji has correct JSON', async ({ page }) => {
+    await setEditorContent(page, '<p>Hello <span data-type="emoji" data-name="waving_hand">👋</span> welcome!</p>');
+    const json = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getJSON();
+    });
+    const content = json.content[0].content;
+    expect(content[0]).toEqual({ type: 'text', text: 'Hello ' });
+    expect(content[1]).toEqual({ type: 'emoji', attrs: { name: 'waving_hand' } });
+    expect(content[2]).toEqual({ type: 'text', text: ' welcome!' });
+  });
+});
+
+// =============================================================================
+// Docs verification: emoticon input rules
+// =============================================================================
+
+test.describe('Docs verification — emoticon input rules', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test(':) followed by space inserts slightly_smiling_face', async ({ page }) => {
+    await clearAndType(page, ':) ');
+    await page.waitForTimeout(300);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-name', 'slightly_smiling_face');
+  });
+
+  test('<3 followed by space inserts red_heart', async ({ page }) => {
+    await clearAndType(page, '<3 ');
+    await page.waitForTimeout(300);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-name', 'red_heart');
+  });
+
+  test(':D followed by space inserts grinning_face_with_big_eyes', async ({ page }) => {
+    await clearAndType(page, ':D ');
+    await page.waitForTimeout(300);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toHaveAttribute('data-name', 'grinning_face_with_big_eyes');
+  });
+
+  test('emoticon preceded by text and space converts', async ({ page }) => {
+    await clearAndType(page, 'hi :) ');
+    await page.waitForTimeout(300);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await expect(emoji).toBeVisible();
+  });
+
+  test('emoticon without trailing space does NOT convert', async ({ page }) => {
+    await clearAndType(page, ':)');
+    await page.waitForTimeout(300);
+    await expect(page.locator(emojiNodeSelector)).toHaveCount(0);
+  });
+});
+
+// =============================================================================
+// Docs verification: renderHTML class attribute
+// =============================================================================
+
+test.describe('Docs verification — renderHTML', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji span has class="emoji"', async ({ page }) => {
+    await setEditorContent(page, EMOJI_HTML);
+    const emoji = page.locator(emojiNodeSelector).first();
+    const cls = await emoji.getAttribute('class');
+    expect(cls).toContain('emoji');
+  });
+
+  test('selected emoji gets ProseMirror-selectednode class', async ({ page }) => {
+    await setEditorContent(page, EMOJI_HTML);
+    const emoji = page.locator(emojiNodeSelector).first();
+    await emoji.click();
+    await page.waitForTimeout(100);
+    const cls = await emoji.getAttribute('class');
+    expect(cls).toContain('ProseMirror-selectednode');
+  });
+});

--- a/apps/demo-angular/e2e/horizontal-rule.spec.ts
+++ b/apps/demo-angular/e2e/horizontal-rule.spec.ts
@@ -873,3 +873,894 @@ test.describe('HorizontalRule — copy/paste', () => {
     expect(html).toContain('pasted below');
   });
 });
+
+// ─── Input rule: Backspace undo ─────────────────────────────────────
+
+test.describe('HorizontalRule — input rule Backspace undo', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Backspace immediately after "--- " reverts HR and restores "--- "', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    let html = await getEditorHTML(page);
+    expectHR(html);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    html = await getEditorHTML(page);
+    expectNoHR(html);
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text).toContain('---');
+  });
+
+  test('Backspace immediately after "*** " reverts HR and restores "*** "', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('*** ', { delay: 30 });
+
+    let html = await getEditorHTML(page);
+    expectHR(html);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    html = await getEditorHTML(page);
+    expectNoHR(html);
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text).toContain('***');
+  });
+
+  test('Backspace immediately after "___ " reverts HR and restores "___ "', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('___ ', { delay: 30 });
+
+    let html = await getEditorHTML(page);
+    expectHR(html);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    html = await getEditorHTML(page);
+    expectNoHR(html);
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text).toContain('___');
+  });
+
+  test('after Backspace undo of "--- ", typing continues as plain text after cursor', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    expectHR(await getEditorHTML(page));
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    expectNoHR(await getEditorHTML(page));
+
+    await page.keyboard.type('hello');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    // Cursor lands at the end of restored "--- ", so "hello" is appended
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text).toContain('--- hello');
+  });
+
+  test('Backspace undo only works immediately - not after typing more text', async ({ page }) => {
+    await setContentAndFocus(page, '<p></p><p>below</p>');
+    await page.locator(`${editorSelector} p`).first().click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    expectHR(await getEditorHTML(page));
+
+    // Type additional text into the paragraph after the HR
+    await page.keyboard.type('x');
+    await page.waitForTimeout(50);
+
+    // Now Backspace should delete 'x', NOT undo the input rule
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    // HR should still be there since undo state was cleared by typing
+    expectHR(html);
+  });
+
+  test('Mod-Z undoes HR after input rule even after typing', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    expectHR(await getEditorHTML(page));
+
+    // Mod-Z should always undo via history, regardless of timing
+    await page.keyboard.press(`${modifier}+Z`);
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+  });
+
+  test('redo after Backspace undo does NOT restore HR (Backspace undo is separate from history)', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+    expectHR(await getEditorHTML(page));
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+    expectNoHR(await getEditorHTML(page));
+
+    // Backspace undo is not tracked in history, so redo does not restore the HR
+    await page.keyboard.press(`${modifier}+Shift+Z`);
+    await page.waitForTimeout(50);
+    expectNoHR(await getEditorHTML(page));
+  });
+
+  test('redo after Mod-Z undo restores HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+    expectHR(await getEditorHTML(page));
+
+    await page.keyboard.press(`${modifier}+Z`);
+    await page.waitForTimeout(50);
+    expectNoHR(await getEditorHTML(page));
+
+    await page.keyboard.press(`${modifier}+Shift+Z`);
+    await page.waitForTimeout(50);
+    expectHR(await getEditorHTML(page));
+  });
+
+  test('multiple undo steps: type "--- ", Backspace undo, then Mod-Z undoes further', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+    expectHR(await getEditorHTML(page));
+
+    // Backspace undo reverts input rule, restoring "--- "
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+    expectNoHR(await getEditorHTML(page));
+
+    // Mod-Z should undo the typed characters progressively
+    await page.keyboard.press(`${modifier}+Z`);
+    await page.waitForTimeout(50);
+
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    // After undoing the Backspace-undo and further steps, text should shrink
+    // (exact result depends on history grouping, but HR should not reappear from Mod-Z here)
+    expect(text.length).toBeLessThanOrEqual(4); // "--- " or less
+  });
+});
+
+// ─── Input rule: partial typing and editing trigger chars ───────────
+
+test.describe('HorizontalRule — partial trigger typing and editing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('type "-", then "-", then "-" then space triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.press('-');
+    await page.waitForTimeout(20);
+    await page.keyboard.press('-');
+    await page.waitForTimeout(20);
+    await page.keyboard.press('-');
+    await page.waitForTimeout(20);
+    await page.keyboard.press(' ');
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('type "--", backspace to "-", then "--" + space triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--', { delay: 30 });
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(30);
+    await page.keyboard.type('-- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('type "---", backspace one dash to "--", then retype "-" + space triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('---', { delay: 30 });
+    // Now we have "---" in the paragraph
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(30);
+    // Now we have "--"
+    await page.keyboard.type('- ', { delay: 30 });
+    // Now we typed "--- " total
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('type "***", backspace all three, then retype "*** " triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('***', { delay: 30 });
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(30);
+
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text.trim()).toBe('');
+
+    await page.keyboard.type('*** ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('type "---x" then backspace "x" then space does NOT trigger HR (has "---" in middle)', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('---x', { delay: 30 });
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(30);
+    await page.keyboard.type(' ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    // "---" followed by space should trigger the input rule since it matches /^---\s$/
+    expectHR(html);
+  });
+
+  test('type "-- " does not trigger, then continue typing normally', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('-- ', { delay: 30 });
+
+    expectNoHR(await getEditorHTML(page));
+
+    await page.keyboard.type('some text');
+    const text = await page.locator(editorSelector).textContent() ?? '';
+    expect(text).toContain('-- some text');
+  });
+
+  test('type "----" (four dashes) + space does NOT trigger HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('---- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+  });
+
+  test('type "---" without space, then Enter does NOT trigger HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('---', { delay: 30 });
+    await page.keyboard.press('Enter');
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    expect(html).toContain('---');
+  });
+
+  test('type "- - - " (dashes with spaces) does NOT trigger HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('- - - ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    // This may trigger bullet list "- " at start, but should NOT create HR
+    expectNoHR(html);
+  });
+
+  test('type "***" slowly one char at a time does not trigger bold marks', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.press('*');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('*');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('*');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    // Should have "***" as plain text, no bold/italic marks applied
+    expect(html).not.toContain('<strong>');
+    expect(html).not.toContain('<em>');
+    expectNoHR(html);
+  });
+
+  test('type "***" then space triggers HR, not bold/italic', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('*** ', { delay: 50 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+    expect(html).not.toContain('<strong>');
+    expect(html).not.toContain('<em>');
+  });
+});
+
+// ─── Input rule in different block contexts ─────────────────────────
+
+test.describe('HorizontalRule — input rule in block contexts', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('input rule does NOT trigger in code block', async ({ page }) => {
+    await setContentAndFocus(page, '<pre><code></code></pre>');
+    await page.locator(`${editorSelector} pre`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    expect(html).toContain('--- ');
+  });
+
+  test('input rule does NOT trigger mid-paragraph', async ({ page }) => {
+    await setContentAndFocus(page, '<p>text </p>');
+    await focusEnd(page);
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+  });
+
+  test('input rule triggers in empty paragraph after heading', async ({ page }) => {
+    await setContentAndFocus(page, '<h2>Title</h2><p></p>');
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+    expect(html).toContain('Title');
+  });
+
+  test('input rule triggers in empty paragraph after blockquote', async ({ page }) => {
+    await setContentAndFocus(page, '<blockquote><p>quote</p></blockquote><p></p>');
+    await page.locator(`${editorSelector} > p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+    expect(html).toContain('quote');
+  });
+
+  test('input rule triggers in empty paragraph between two HRs', async ({ page }) => {
+    await setContentAndFocus(page, '<hr><p></p><hr>');
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBeGreaterThanOrEqual(3);
+  });
+
+  test('em-dash variant "—- " triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+
+    // Type em-dash followed by dash and space
+    await page.evaluate((sel) => {
+      const editor = document.querySelector(sel) as HTMLElement;
+      editor?.focus();
+      // Insert "—- " directly (em-dash + dash + space)
+      document.execCommand('insertText', false, '\u2014- ');
+    }, editorSelector);
+    await page.waitForTimeout(100);
+
+    const html = await getEditorHTML(page);
+    // em-dash variant may or may not trigger depending on how execCommand works with input rules
+    // The input rule regex matches "—-\s" but execCommand may not fire the textInput handler
+    // This test documents the behavior
+    if (html.match(/<hr[\s>]/)) {
+      expectHR(html);
+    } else {
+      // execCommand doesn't trigger ProseMirror input rules - this is expected
+      expect(html).toContain('\u2014');
+    }
+  });
+});
+
+// ─── Consecutive HR creation ────────────────────────────────────────
+
+test.describe('HorizontalRule — consecutive input rule triggers', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('two consecutive "--- " input rules create two HRs', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+    await page.waitForTimeout(100);
+
+    expectHR(await getEditorHTML(page));
+
+    // Input rule creates HR + new paragraph, cursor lands in the new paragraph
+    await page.keyboard.type('--- ', { delay: 30 });
+    await page.waitForTimeout(100);
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBe(2);
+  });
+
+  test('three consecutive "--- " input rules create three HRs', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.type('--- ', { delay: 30 });
+      await page.waitForTimeout(100);
+    }
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBe(3);
+  });
+
+  test('alternating "--- " and "*** " input rules both work', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+
+    await page.keyboard.type('--- ', { delay: 30 });
+    await page.waitForTimeout(100);
+    await page.keyboard.type('*** ', { delay: 30 });
+    await page.waitForTimeout(100);
+    await page.keyboard.type('___ ', { delay: 30 });
+    await page.waitForTimeout(100);
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBe(3);
+  });
+});
+
+// ─── Backspace and Delete near HR (non-node-selection) ──────────────
+
+test.describe('HorizontalRule — Backspace/Delete from adjacent paragraphs', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Backspace at start of paragraph after HR selects the HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusStart(page, 'p', 1);
+    await page.keyboard.press('Backspace');
+
+    // Backspace at start of block after HR should select or delete the HR
+    const hasSelected = await page.evaluate((sel) => {
+      const hr = document.querySelector(sel + ' hr');
+      return hr?.classList.contains('ProseMirror-selectednode') ?? false;
+    }, editorSelector);
+
+    const html = await getEditorHTML(page);
+    // Either HR is selected (node selection) or deleted
+    expect(hasSelected || !html.match(/<hr[\s>]/)).toBeTruthy();
+  });
+
+  test('Delete at end of paragraph before HR selects the HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusEnd(page, 'p', 0);
+    await page.keyboard.press('Delete');
+
+    const hasSelected = await page.evaluate((sel) => {
+      const hr = document.querySelector(sel + ' hr');
+      return hr?.classList.contains('ProseMirror-selectednode') ?? false;
+    }, editorSelector);
+
+    const html = await getEditorHTML(page);
+    // Either HR is selected (node selection) or deleted
+    expect(hasSelected || !html.match(/<hr[\s>]/)).toBeTruthy();
+  });
+
+  test('double Backspace from paragraph after HR deletes HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusStart(page, 'p', 1);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    expect(html).toContain('before');
+    expect(html).toContain('after');
+  });
+
+  test('double Delete from paragraph before HR deletes HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusEnd(page, 'p', 0);
+
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    expect(html).toContain('before');
+    expect(html).toContain('after');
+  });
+
+  test('Backspace from empty paragraph after HR removes HR', async ({ page }) => {
+    await setContentAndFocus(page, '<p>text</p><hr><p></p>');
+    // Focus the empty paragraph
+    const paragraphs = page.locator(`${editorSelector} p`);
+    await paragraphs.last().click();
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+  });
+});
+
+// ─── Arrow key navigation ───────────────────────────────────────────
+
+test.describe('HorizontalRule — arrow key navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('ArrowDown from paragraph above HR reaches paragraph below', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusEnd(page, 'p', 0);
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.type('!');
+
+    const html = await getEditorHTML(page);
+    // '!' should appear in the paragraph below or after the HR
+    expect(html).toMatch(/after|!/);
+  });
+
+  test('ArrowUp from paragraph below HR reaches paragraph above', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusStart(page, 'p', 1);
+
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.type('!');
+
+    const html = await getEditorHTML(page);
+    expect(html).toContain('!');
+  });
+
+  test('ArrowLeft from start of paragraph after HR selects HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusStart(page, 'p', 1);
+
+    await page.keyboard.press('ArrowLeft');
+
+    const hasSelected = await page.evaluate((sel) => {
+      const hr = document.querySelector(sel + ' hr');
+      return hr?.classList.contains('ProseMirror-selectednode') ?? false;
+    }, editorSelector);
+    expect(hasSelected).toBe(true);
+  });
+
+  test('ArrowRight from end of paragraph before HR selects HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusEnd(page, 'p', 0);
+
+    await page.keyboard.press('ArrowRight');
+
+    const hasSelected = await page.evaluate((sel) => {
+      const hr = document.querySelector(sel + ' hr');
+      return hr?.classList.contains('ProseMirror-selectednode') ?? false;
+    }, editorSelector);
+    expect(hasSelected).toBe(true);
+  });
+
+  test('ArrowRight past selected HR moves to paragraph after', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusEnd(page, 'p', 0);
+
+    // ArrowRight -> selects HR, ArrowRight again -> moves past HR
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.type('!');
+
+    const html = await getEditorHTML(page);
+    expect(html).toContain('!after');
+    expectHR(html);
+  });
+
+  test('ArrowLeft past selected HR moves to paragraph before', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await focusStart(page, 'p', 1);
+
+    // ArrowLeft -> selects HR, ArrowLeft again -> moves before HR
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.type('!');
+
+    const html = await getEditorHTML(page);
+    expect(html).toContain('before!');
+    expectHR(html);
+  });
+});
+
+// ─── Typing on selected HR ──────────────────────────────────────────
+
+test.describe('HorizontalRule — typing replaces selected HR', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('typing a character on selected HR replaces it with paragraph', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await page.locator(`${editorSelector} hr`).click();
+
+    await page.keyboard.type('x');
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    expect(html).toContain('x');
+    expect(html).toContain('before');
+    expect(html).toContain('after');
+  });
+
+  test('pressing Enter on selected HR creates a new paragraph but keeps HR', async ({ page }) => {
+    await setContentAndFocus(page, HR_BETWEEN);
+    await page.locator(`${editorSelector} hr`).click();
+
+    await page.keyboard.press('Enter');
+
+    const html = await getEditorHTML(page);
+    // Enter on a node selection inserts a paragraph, HR is preserved
+    expectHR(html);
+    expect(countTag(html, 'p')).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ─── HR at document boundaries ──────────────────────────────────────
+
+test.describe('HorizontalRule — document boundaries', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('HR at start of document has paragraph after it', async ({ page }) => {
+    await setContentAndFocus(page, '<hr><p>after</p>');
+
+    const children = await page.evaluate((sel) => {
+      const editor = document.querySelector(sel);
+      if (!editor) return [];
+      return Array.from(editor.children).map(c => c.tagName.toLowerCase());
+    }, editorSelector);
+
+    expect(children[0]).toBe('hr');
+    expect(children).toContain('p');
+  });
+
+  test('HR at end of document via setContent keeps HR as last child', async ({ page }) => {
+    await setContentAndFocus(page, '<p>text</p><hr>');
+
+    const children = await page.evaluate((sel) => {
+      const editor = document.querySelector(sel);
+      if (!editor) return [];
+      return Array.from(editor.children).map(c => c.tagName.toLowerCase());
+    }, editorSelector);
+
+    // setContent does not trigger TrailingNode appendTransaction,
+    // so HR remains the last child
+    expect(children).toContain('hr');
+    expect(children[0]).toBe('p');
+  });
+
+  test('HR inserted via toolbar at end creates trailing paragraph', async ({ page }) => {
+    await setContentAndFocus(page, '<p>text</p>');
+    await focusEnd(page);
+    await page.locator(hrButton).click();
+
+    const children = await page.evaluate((sel) => {
+      const editor = document.querySelector(sel);
+      if (!editor) return [];
+      return Array.from(editor.children).map(c => c.tagName.toLowerCase());
+    }, editorSelector);
+
+    // Command explicitly creates HR + paragraph
+    const lastChild = children[children.length - 1];
+    expect(lastChild).toBe('p');
+    expect(children).toContain('hr');
+  });
+
+  test('HR inserted via input rule at end creates trailing paragraph', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const children = await page.evaluate((sel) => {
+      const editor = document.querySelector(sel);
+      if (!editor) return [];
+      return Array.from(editor.children).map(c => c.tagName.toLowerCase());
+    }, editorSelector);
+
+    // Input rule now creates HR + paragraph (same as command)
+    const lastChild = children[children.length - 1];
+    expect(lastChild).toBe('p');
+    expect(children).toContain('hr');
+  });
+
+  test('consecutive HRs with no text between them', async ({ page }) => {
+    await setContentAndFocus(page, '<p>before</p><hr><hr><p>after</p>');
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBe(2);
+    expect(html).toContain('before');
+    expect(html).toContain('after');
+  });
+
+  test('three consecutive HRs render correctly', async ({ page }) => {
+    await setContentAndFocus(page, '<hr><hr><hr>');
+
+    const html = await getEditorHTML(page);
+    expect(countHRs(html)).toBe(3);
+  });
+});
+
+// ─── HR with setContent and commands API ────────────────────────────
+
+test.describe('HorizontalRule — commands API', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('setHorizontalRule command inserts HR after code block (code block is a textblock)', async ({ page }) => {
+    await setContentAndFocus(page, '<pre><code>some code</code></pre>');
+    await page.locator(`${editorSelector} pre`).click();
+
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      comp?.editor?.commands.setHorizontalRule();
+    });
+    await page.waitForTimeout(100);
+
+    const html = await getEditorHTML(page);
+    // Code block IS a textblock, so the command inserts HR after it
+    expectHR(html);
+    expect(html).toContain('<pre>');
+  });
+
+  test('chain focus + setHorizontalRule works', async ({ page }) => {
+    await setContentAndFocus(page, PARAGRAPH);
+
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      comp?.editor?.chain().focus().setHorizontalRule().run();
+    });
+    await page.waitForTimeout(100);
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+});
+
+// ─── HR interaction with other input rules ──────────────────────────
+
+test.describe('HorizontalRule — interaction with other input rules', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('"--- " in blockquote paragraph creates HR (replaces blockquote content)', async ({ page }) => {
+    await setContentAndFocus(page, '<blockquote><p></p></blockquote>');
+    await page.locator(`${editorSelector} blockquote p`).click();
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    // HR input rule should fire, replacing the paragraph inside the blockquote
+    expectHR(html);
+  });
+
+  test('"--- " does NOT interfere with "---" typed in paragraph with existing text', async ({ page }) => {
+    await setContentAndFocus(page, '<p>prefix </p>');
+    await focusEnd(page);
+    await page.keyboard.type('--- ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectNoHR(html);
+    // Text contains the dashes (space may be collapsed by browser)
+    expect(html).toContain('prefix');
+    expect(html).toContain('---');
+  });
+
+  test('"___ " does not conflict with italic/underline input rules', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('___ ', { delay: 30 });
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+    expect(html).not.toContain('<em>');
+    expect(html).not.toContain('<u>');
+  });
+});
+
+// ─── Rapid input ────────────────────────────────────────────────────
+
+test.describe('HorizontalRule — rapid input', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('"--- " typed without delay triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    // Type without delay
+    await page.keyboard.type('--- ');
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('"*** " typed without delay triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('*** ');
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('"___ " typed without delay triggers HR', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+    await page.keyboard.type('___ ');
+
+    const html = await getEditorHTML(page);
+    expectHR(html);
+  });
+
+  test('rapid "--- " + Backspace undo + "--- " creates HR again', async ({ page }) => {
+    await setContentAndFocus(page, EMPTY_PARAGRAPH);
+    await page.locator(`${editorSelector} p`).click();
+
+    await page.keyboard.type('--- ');
+    expectHR(await getEditorHTML(page));
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+    expectNoHR(await getEditorHTML(page));
+
+    // Select all and delete the restored "--- " text
+    await page.keyboard.press(`${modifier}+A`);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    // Type "--- " again from scratch
+    await page.keyboard.type('--- ');
+    expectHR(await getEditorHTML(page));
+  });
+});

--- a/apps/demo-angular/e2e/image.spec.ts
+++ b/apps/demo-angular/e2e/image.spec.ts
@@ -43,6 +43,13 @@ const IMG_FLOAT_RIGHT = `<img src="${BASE64_1PX}" style="float: right; margin: 0
 const IMG_FLOAT_CENTER = `<img src="${BASE64_1PX}" style="display: block; margin-left: auto; margin-right: auto;">`;
 const IMG_WITH_WIDTH = `<img src="${BASE64_1PX}" width="300">`;
 const PARA_ONLY = '<p>Some text here</p>';
+const IMG_ALIGN_LEFT = `<img src="${BASE64_1PX}" align="left">`;
+const IMG_ALIGN_RIGHT = `<img src="${BASE64_1PX}" align="right">`;
+const IMG_ALIGN_CENTER = `<img src="${BASE64_1PX}" align="center">`;
+const IMG_ALIGN_MIDDLE = `<img src="${BASE64_1PX}" align="middle">`;
+const IMG_NO_SRC = '<img alt="no source">';
+const CODE_BLOCK_CONTENT = '<pre><code>console.log("hello")</code></pre>';
+const IMG_IN_PARA = `<p>text <img src="${BASE64_1PX}" alt="inline"> more</p>`;
 
 // ═══════════════════════════════════════════════════════════════════════
 // RENDERING
@@ -1254,5 +1261,520 @@ test.describe('Image — popover styling', () => {
     const input = page.locator('.dm-image-popover-input');
     const minWidth = await input.evaluate((el) => getComputedStyle(el).minWidth);
     expect(minWidth).not.toBe('0px');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// DOCS VERIFICATION — additional tests for documented behavior
+// ═══════════════════════════════════════════════════════════════════════
+
+test.describe('Image — docs verification: parseHTML', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('img without src attribute is NOT parsed as image node', async ({ page }) => {
+    await setEditorContent(page, IMG_NO_SRC);
+    const images = page.locator('.dm-image-resizable');
+    await expect(images).toHaveCount(0);
+  });
+
+  test('float parsed from style="float: left"', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_LEFT);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'left');
+  });
+
+  test('float parsed from style="float: right"', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_RIGHT);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'right');
+  });
+
+  test('float parsed from style margin-left/right auto (center)', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_CENTER);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'center');
+  });
+
+  test('float parsed from align="left"', async ({ page }) => {
+    await setEditorContent(page, IMG_ALIGN_LEFT);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'left');
+  });
+
+  test('float parsed from align="right"', async ({ page }) => {
+    await setEditorContent(page, IMG_ALIGN_RIGHT);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'right');
+  });
+
+  test('float parsed from align="center"', async ({ page }) => {
+    await setEditorContent(page, IMG_ALIGN_CENTER);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'center');
+  });
+
+  test('float parsed from align="middle" (mapped to center)', async ({ page }) => {
+    await setEditorContent(page, IMG_ALIGN_MIDDLE);
+    const wrapper = page.locator('.dm-image-resizable');
+    await expect(wrapper).toHaveAttribute('data-float', 'center');
+  });
+});
+
+test.describe('Image — docs verification: commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('setImage returns false inside a code block', async ({ page }) => {
+    await setEditorContent(page, CODE_BLOCK_CONTENT);
+    // Place cursor inside code block
+    await page.locator(editorSelector + ' pre').click();
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: 'https://example.com/img.png' });
+    });
+    expect(result).toBe(false);
+  });
+
+  test('setImageFloat returns false for invalid value', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+    // Select the image
+    await page.locator('.dm-image-resizable').click();
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImageFloat('invalid-value');
+    });
+    expect(result).toBe(false);
+  });
+
+  test('setImageFloat returns false when no image is selected', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    await page.locator(editorSelector).click();
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImageFloat('left');
+    });
+    expect(result).toBe(false);
+  });
+
+  test('setImage replaces existing selected image (NodeSelection)', async ({ page }) => {
+    await setEditorContent(page, IMG_ALT);
+    // Select the existing image
+    await page.locator('.dm-image-resizable').click();
+    await page.waitForTimeout(100);
+    // Replace with new image via setImage
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      comp?.editor?.commands.setImage({ src: 'https://example.com/replaced.png', alt: 'Replaced' });
+    });
+    await page.waitForTimeout(100);
+    // Should still have exactly one image, with the new alt
+    const images = page.locator('.dm-image-resizable');
+    await expect(images).toHaveCount(1);
+    const alt = await page.locator('.dm-image-resizable img').getAttribute('alt');
+    expect(alt).toBe('Replaced');
+  });
+
+  test('deleteImage always returns true even without image selected', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    await page.locator(editorSelector).click();
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.deleteImage();
+    });
+    expect(result).toBe(true);
+  });
+});
+
+test.describe('Image — docs verification: input rules', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('input rule with single-quoted title', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    // Select all and delete to start fresh
+    await page.keyboard.press('Meta+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type("![photo](https://example.com/img.png 'My Title')", { delay: 10 });
+    await page.waitForTimeout(200);
+    const img = page.locator('.dm-image-resizable img');
+    await expect(img).toHaveCount(1);
+    const title = await img.getAttribute('title');
+    expect(title).toBe('My Title');
+  });
+
+  test('input rule blocks javascript: URL', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press('Meta+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('![xss](javascript:alert(1))', { delay: 10 });
+    await page.waitForTimeout(200);
+    const images = page.locator('.dm-image-resizable');
+    await expect(images).toHaveCount(0);
+  });
+});
+
+test.describe('Image — docs verification: leafText', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getText() returns alt attribute as text representation', async ({ page }) => {
+    await setEditorContent(page, IMG_ALT);
+    const text = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getText();
+    });
+    expect(text).toContain('Red pixel');
+  });
+});
+
+test.describe('Image — docs verification: float rendering HTML output', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('float left outputs correct inline style', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_LEFT);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('float: left');
+    // Browser normalizes `0` to `0px` in computed margin values
+    expect(html).toMatch(/margin:\s*0(px)?\s+1em\s+1em\s+0(px)?/);
+  });
+
+  test('float right outputs correct inline style', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_RIGHT);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('float: right');
+    // Browser normalizes `0` to `0px` in computed margin values
+    expect(html).toMatch(/margin:\s*0(px)?\s+0(px)?\s+1em\s+1em/);
+  });
+
+  test('center outputs correct inline style', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_CENTER);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('display: block');
+    expect(html).toContain('margin-left: auto');
+    expect(html).toContain('margin-right: auto');
+  });
+
+  test('float none outputs no style attribute', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    // Non-floated image should have no style attribute
+    expect(html).toMatch(/<img[^>]*src=/);
+    expect(html).not.toMatch(/<img[^>]*style=/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// DOCS VERIFICATION 2 — additional edge cases
+// ═══════════════════════════════════════════════════════════════════════
+
+test.describe('Image — docs verification: allowBase64 option', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('with allowBase64: true (default), data:image/ URL is accepted by setImage', async ({ page }) => {
+    const result = await page.evaluate((b64) => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: b64 });
+    }, BASE64_1PX);
+    expect(result).toBe(true);
+  });
+
+  test('setImage blocks data:text/html regardless of allowBase64', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: 'data:text/html,<script>alert(1)</script>' });
+    });
+    expect(result).toBe(false);
+  });
+
+  test('setImage accepts relative path URLs', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: './images/photo.jpg' });
+    });
+    expect(result).toBe(true);
+  });
+
+  test('setImage accepts absolute path URLs', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: '/uploads/photo.jpg' });
+    });
+    expect(result).toBe(true);
+  });
+
+  test('setImage accepts protocol-relative URLs', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: '//cdn.example.com/img.png' });
+    });
+    expect(result).toBe(true);
+  });
+
+  test('setImage blocks file: protocol', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.commands.setImage({ src: 'file:///etc/passwd' });
+    });
+    expect(result).toBe(false);
+  });
+});
+
+test.describe('Image — docs verification: setImage attributes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('setImage with all attributes renders them in HTML', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      comp?.editor?.commands.setImage({
+        src: 'https://example.com/photo.jpg',
+        alt: 'Test alt',
+        title: 'Test title',
+        width: 400,
+        loading: 'lazy',
+        float: 'left',
+      });
+    });
+    await page.waitForTimeout(100);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('src="https://example.com/photo.jpg"');
+    expect(html).toContain('alt="Test alt"');
+    expect(html).toContain('title="Test title"');
+    expect(html).toContain('width="400"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('float: left');
+  });
+
+  test('setImage with crossorigin renders in HTML', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      comp?.editor?.commands.setImage({
+        src: 'https://example.com/photo.jpg',
+        crossorigin: 'anonymous',
+      });
+    });
+    await page.waitForTimeout(100);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('crossorigin="anonymous"');
+  });
+
+  test('null attributes are omitted from rendered HTML', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      comp?.editor?.commands.setImage({ src: 'https://example.com/photo.jpg' });
+    });
+    await page.waitForTimeout(100);
+    const html: string = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getHTML() ?? '';
+    });
+    expect(html).toContain('src="https://example.com/photo.jpg"');
+    expect(html).not.toContain('alt=');
+    expect(html).not.toContain('title=');
+    expect(html).not.toContain('width=');
+    expect(html).not.toContain('height=');
+    expect(html).not.toContain('loading=');
+    expect(html).not.toContain('crossorigin=');
+    expect(html).not.toContain('style=');
+  });
+});
+
+test.describe('Image — docs verification: input rule edge cases', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('input rule with double-quoted title', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press('Meta+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('![alt](https://example.com/img.png "Double Title")', { delay: 10 });
+    await page.waitForTimeout(200);
+    const img = page.locator('.dm-image-resizable img');
+    await expect(img).toHaveCount(1);
+    expect(await img.getAttribute('title')).toBe('Double Title');
+  });
+
+  test('input rule without title (only alt and src)', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press('Meta+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('![my alt](https://example.com/img.png)', { delay: 10 });
+    await page.waitForTimeout(200);
+    const img = page.locator('.dm-image-resizable img');
+    await expect(img).toHaveCount(1);
+    expect(await img.getAttribute('alt')).toBe('my alt');
+    // Title should not be set
+    const title = await img.getAttribute('title');
+    expect(title === null || title === '').toBeTruthy();
+  });
+
+  test('input rule can appear after text on the same line', async ({ page }) => {
+    await setEditorContent(page, PARA_ONLY);
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press('Meta+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('check this ![pic](https://example.com/img.png)', { delay: 10 });
+    await page.waitForTimeout(200);
+    const img = page.locator('.dm-image-resizable img');
+    await expect(img).toHaveCount(1);
+  });
+});
+
+test.describe('Image — docs verification: bubble menu active state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Float left button has active class when image is floated left', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_LEFT);
+    await page.locator('.dm-image-resizable').click();
+    await page.waitForTimeout(200);
+    const floatLeftBtn = page.locator('.dm-bubble-menu button[aria-label="Float left"]');
+    await expect(floatLeftBtn).toHaveClass(/dm-toolbar-button--active/);
+  });
+
+  test('Inline button has active class for non-floated image', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+    await page.locator('.dm-image-resizable').click();
+    await page.waitForTimeout(200);
+    const inlineBtn = page.locator('.dm-bubble-menu button[aria-label="Inline"]');
+    await expect(inlineBtn).toHaveClass(/dm-toolbar-button--active/);
+  });
+
+  test('Center button has active class when image is centered', async ({ page }) => {
+    await setEditorContent(page, IMG_FLOAT_CENTER);
+    await page.locator('.dm-image-resizable').click();
+    await page.waitForTimeout(200);
+    const centerBtn = page.locator('.dm-bubble-menu button[aria-label="Center"]');
+    await expect(centerBtn).toHaveClass(/dm-toolbar-button--active/);
+  });
+
+  test('active state updates when float changes', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+    await page.locator('.dm-image-resizable').click();
+    await page.waitForTimeout(200);
+    // Initially inline
+    const inlineBtn = page.locator('.dm-bubble-menu button[aria-label="Inline"]');
+    await expect(inlineBtn).toHaveClass(/dm-toolbar-button--active/);
+    // Click Float right
+    const rightBtn = page.locator('.dm-bubble-menu button[aria-label="Float right"]');
+    await rightBtn.click();
+    await page.waitForTimeout(200);
+    // Now Float right should be active, Inline should not
+    await expect(rightBtn).toHaveClass(/dm-toolbar-button--active/);
+    await expect(inlineBtn).not.toHaveClass(/dm-toolbar-button--active/);
+  });
+});
+
+test.describe('Image — docs verification: JSON representation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getJSON() contains all image attributes with defaults', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+    const json = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getJSON();
+    });
+    // Find the image node in the JSON
+    const imageNode = json?.content?.find((n: any) => n.type === 'image');
+    expect(imageNode).toBeTruthy();
+    expect(imageNode.attrs.src).toContain('data:image/png');
+    expect(imageNode.attrs.alt).toBeNull();
+    expect(imageNode.attrs.title).toBeNull();
+    expect(imageNode.attrs.width).toBeNull();
+    expect(imageNode.attrs.height).toBeNull();
+    expect(imageNode.attrs.loading).toBeNull();
+    expect(imageNode.attrs.crossorigin).toBeNull();
+    expect(imageNode.attrs.float).toBe('none');
+  });
+
+  test('getJSON() includes set attributes', async ({ page }) => {
+    await setEditorContent(page, IMG_ALL_ATTRS);
+    const json = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const comp = (window as any).ng?.getComponent?.(el);
+      return comp?.editor?.getJSON();
+    });
+    const imageNode = json?.content?.find((n: any) => n.type === 'image');
+    expect(imageNode).toBeTruthy();
+    expect(imageNode.attrs.alt).toBe('Pixel');
+    expect(imageNode.attrs.title).toBe('A pixel');
+    expect(imageNode.attrs.width).toBe('200');
   });
 });

--- a/apps/demo-angular/e2e/mention.spec.ts
+++ b/apps/demo-angular/e2e/mention.spec.ts
@@ -600,6 +600,15 @@ test.describe('Mention — Suggestion Dropdown', () => {
     await page.waitForTimeout(200);
     await expect(page.locator(suggestionSelector)).not.toBeVisible();
   });
+
+  test('@ inside inline code mark does not trigger suggestion', async ({ page }) => {
+    await clearAndType(page, 'Some text ');
+    // Apply inline code mark then type @
+    await page.keyboard.press(`${modifier}+e`);
+    await page.keyboard.type('@test');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+  });
 });
 
 // =============================================================================

--- a/apps/demo-angular/e2e/mention.spec.ts
+++ b/apps/demo-angular/e2e/mention.spec.ts
@@ -1,0 +1,1104 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'domternal-editor .ProseMirror';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+const mentionNodeSelector = `${editorSelector} span[data-type="mention"]`;
+const suggestionSelector = '.dm-mention-suggestion';
+const suggestionItemSelector = `${suggestionSelector} .dm-mention-suggestion-item`;
+const suggestionEmptySelector = `${suggestionSelector} .dm-mention-suggestion-empty`;
+const decorationSelector = `${editorSelector} span.mention-suggestion`;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function setEditorContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      comp.editor.setContent(h, false);
+      comp.editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function getEditorHTML(page: Page): Promise<string> {
+  return page.locator(editorSelector).innerHTML();
+}
+
+async function clearAndType(page: Page, text: string) {
+  const editor = page.locator(editorSelector);
+  await editor.click();
+  await page.keyboard.press(`${modifier}+a`);
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(text);
+}
+
+async function getEditorJSON(page: Page): Promise<any> {
+  return page.evaluate(() => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    return comp?.editor?.getJSON();
+  });
+}
+
+async function getEditorText(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    return comp?.editor?.getText() ?? '';
+  });
+}
+
+async function runCommand(page: Page, command: string): Promise<boolean> {
+  return page.evaluate((cmd) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (!comp?.editor) return false;
+    const fn = new Function('editor', `return editor.commands.${cmd}`);
+    return fn(comp.editor) as boolean;
+  }, command);
+}
+
+async function runChain(page: Page, chain: string): Promise<void> {
+  await page.evaluate((cmd) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      const fn = new Function('editor', `return editor.chain().focus().${cmd}.run()`);
+      fn(comp.editor);
+    }
+  }, chain);
+}
+
+async function canCommand(page: Page, chain: string): Promise<boolean> {
+  return page.evaluate((cmd) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (!comp?.editor) return false;
+    const fn = new Function('editor', `return editor.can().chain().focus().${cmd}.run()`);
+    return fn(comp.editor) as boolean;
+  }, chain);
+}
+
+async function findMentions(page: Page): Promise<any[]> {
+  return page.evaluate(() => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    return comp?.editor?.storage.mention.findMentions() ?? [];
+  });
+}
+
+async function focusEditor(page: Page) {
+  await page.locator(editorSelector).click();
+  await page.waitForTimeout(50);
+}
+
+// ─── HTML Fixtures ───────────────────────────────────────────────────────────
+
+const MENTION_HTML = '<p>Hello <span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span> world</p>';
+const TWO_MENTIONS = '<p>Talk to <span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span> and <span data-type="mention" data-id="7" data-label="Grace Hopper" data-mention-type="user" class="mention">@Grace Hopper</span></p>';
+const MENTION_IN_LIST = '<ul><li>Ask <span data-type="mention" data-id="2" data-label="Bob Smith" data-mention-type="user" class="mention">@Bob Smith</span></li></ul>';
+const MENTION_IN_BLOCKQUOTE = '<blockquote><p>Quoted by <span data-type="mention" data-id="3" data-label="Charlie Brown" data-mention-type="user" class="mention">@Charlie Brown</span></p></blockquote>';
+const MENTION_AT_START = '<p><span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span> said hello</p>';
+const MENTION_AT_END = '<p>Greetings <span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span></p>';
+const ADJACENT_MENTIONS = '<p><span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span><span data-type="mention" data-id="2" data-label="Bob Smith" data-mention-type="user" class="mention">@Bob Smith</span></p>';
+const LEGACY_MENTION = '<p>Hi <span data-mention data-id="5" data-label="Eve Adams" data-mention-type="user">@Eve Adams</span></p>';
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+test.describe('Mention — Schema', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('mention node type is registered', async ({ page }) => {
+    const has = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      return !!comp?.editor?.state.schema.nodes['mention'];
+    });
+    expect(has).toBe(true);
+  });
+
+  test('mention is inline', async ({ page }) => {
+    const spec = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      const nodeType = comp?.editor?.state.schema.nodes['mention'];
+      return { inline: nodeType?.spec.inline, atom: nodeType?.spec.atom, selectable: nodeType?.spec.selectable, draggable: nodeType?.spec.draggable };
+    });
+    expect(spec.inline).toBe(true);
+    expect(spec.atom).toBe(true);
+    expect(spec.selectable).toBe(false);
+    expect(spec.draggable).toBe(false);
+  });
+
+  test('mention has correct attributes', async ({ page }) => {
+    const attrs = await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      const nodeType = comp?.editor?.state.schema.nodes['mention'];
+      return Object.keys(nodeType?.spec.attrs ?? {});
+    });
+    expect(attrs).toContain('id');
+    expect(attrs).toContain('label');
+    expect(attrs).toContain('type');
+  });
+});
+
+// =============================================================================
+// HTML Parsing
+// =============================================================================
+
+test.describe('Mention — HTML Parsing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('parses span[data-type="mention"]', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions).toHaveCount(1);
+    await expect(mentions.first()).toContainText('Alice Johnson');
+  });
+
+  test('parses legacy span[data-mention] format', async ({ page }) => {
+    await setEditorContent(page, LEGACY_MENTION);
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions).toHaveCount(1);
+    await expect(mentions.first()).toContainText('Eve Adams');
+  });
+
+  test('preserves data attributes after parse', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '1');
+    await expect(mention).toHaveAttribute('data-label', 'Alice Johnson');
+    await expect(mention).toHaveAttribute('data-mention-type', 'user');
+  });
+
+  test('parses multiple mentions in same paragraph', async ({ page }) => {
+    await setEditorContent(page, TWO_MENTIONS);
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions).toHaveCount(2);
+    await expect(mentions.nth(0)).toContainText('Alice Johnson');
+    await expect(mentions.nth(1)).toContainText('Grace Hopper');
+  });
+
+  test('HTML roundtrip preserves mention nodes', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const html = await getEditorHTML(page);
+    expect(html).toContain('data-type="mention"');
+    expect(html).toContain('data-id="1"');
+    expect(html).toContain('data-label="Alice Johnson"');
+  });
+});
+
+// =============================================================================
+// HTML Rendering
+// =============================================================================
+
+test.describe('Mention — HTML Rendering', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('renders mention with .mention class', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveClass(/mention/);
+  });
+
+  test('renders trigger char prefix in text', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mention = page.locator(mentionNodeSelector).first();
+    const text = await mention.textContent();
+    expect(text).toBe('@Alice Johnson');
+  });
+
+  test('mention is visually styled', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mention = page.locator(mentionNodeSelector).first();
+    const bg = await mention.evaluate((el) => getComputedStyle(el).backgroundColor);
+    // Should have some non-transparent background from theme
+    expect(bg).not.toBe('rgba(0, 0, 0, 0)');
+  });
+});
+
+// =============================================================================
+// Commands
+// =============================================================================
+
+test.describe('Mention — Commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('insertMention inserts a mention node', async ({ page }) => {
+    await clearAndType(page, 'Hello ');
+    const result = await runCommand(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    expect(result).toBe(true);
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions).toHaveCount(1);
+    await expect(mentions.first()).toContainText('Alice Johnson');
+  });
+
+  test('insertMention with custom type', async ({ page }) => {
+    await clearAndType(page, 'Tag: ');
+    await runCommand(page, `insertMention({ id: 'tag-1', label: 'urgent', type: 'tag' })`);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-mention-type', 'tag');
+  });
+
+  test('insertMention requires id and label', async ({ page }) => {
+    await clearAndType(page, 'Test ');
+    const r1 = await runCommand(page, `insertMention({ id: '', label: 'test' })`);
+    expect(r1).toBe(false);
+    const r2 = await runCommand(page, `insertMention({ id: '1', label: '' })`);
+    expect(r2).toBe(false);
+  });
+
+  test('insertMention replaces selected text', async ({ page }) => {
+    await clearAndType(page, 'Replace me');
+    await page.keyboard.press(`${modifier}+a`);
+    await runCommand(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    const text = await getEditorText(page);
+    expect(text).toContain('Alice Johnson');
+    expect(text).not.toContain('Replace me');
+  });
+
+  test('deleteMention removes mention at cursor', async ({ page }) => {
+    await setEditorContent(page, MENTION_AT_END);
+    // Place cursor at end (after mention)
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) {
+        const { doc } = comp.editor.state;
+        comp.editor.commands.setTextSelection(doc.content.size - 1);
+      }
+    });
+    await page.waitForTimeout(50);
+    const result = await runCommand(page, 'deleteMention()');
+    expect(result).toBe(true);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(0);
+  });
+
+  test('deleteMention by id finds and removes specific mention', async ({ page }) => {
+    await setEditorContent(page, TWO_MENTIONS);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(2);
+    const result = await runCommand(page, `deleteMention('7')`);
+    expect(result).toBe(true);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await expect(page.locator(mentionNodeSelector).first()).toContainText('Alice Johnson');
+  });
+
+  test('deleteMention returns false for non-existent id', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const result = await runCommand(page, `deleteMention('999')`);
+    expect(result).toBe(false);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+  });
+
+  test('can() dry-run check for insertMention', async ({ page }) => {
+    await clearAndType(page, 'Test ');
+    const can = await canCommand(page, `insertMention({ id: '1', label: 'Test' })`);
+    expect(can).toBe(true);
+  });
+
+  test('multiple sequential insertMention calls', async ({ page }) => {
+    await clearAndType(page, '');
+    await runChain(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    await page.keyboard.type(' and ');
+    await runChain(page, `insertMention({ id: '2', label: 'Bob Smith' })`);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(2);
+  });
+});
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+test.describe('Mention — Storage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('findMentions returns all mention nodes', async ({ page }) => {
+    await setEditorContent(page, TWO_MENTIONS);
+    const mentions = await findMentions(page);
+    expect(mentions).toHaveLength(2);
+    expect(mentions[0].id).toBe('1');
+    expect(mentions[0].label).toBe('Alice Johnson');
+    expect(mentions[1].id).toBe('7');
+    expect(mentions[1].label).toBe('Grace Hopper');
+  });
+
+  test('findMentions includes position and type', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const mentions = await findMentions(page);
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].type).toBe('user');
+    expect(typeof mentions[0].pos).toBe('number');
+    expect(mentions[0].pos).toBeGreaterThan(0);
+  });
+
+  test('findMentions updates after insertMention', async ({ page }) => {
+    await clearAndType(page, 'Hello ');
+    let mentions = await findMentions(page);
+    expect(mentions).toHaveLength(0);
+    await runChain(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    mentions = await findMentions(page);
+    expect(mentions).toHaveLength(1);
+  });
+
+  test('findMentions returns empty for no mentions', async ({ page }) => {
+    await clearAndType(page, 'No mentions here');
+    const mentions = await findMentions(page);
+    expect(mentions).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// leafText / Plain Text
+// =============================================================================
+
+test.describe('Mention — Plain Text', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getText includes trigger char + label', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const text = await getEditorText(page);
+    expect(text).toContain('@Alice Johnson');
+  });
+
+  test('getText preserves surrounding text', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const text = await getEditorText(page);
+    expect(text).toContain('Hello');
+    expect(text).toContain('world');
+  });
+});
+
+// =============================================================================
+// JSON Serialization
+// =============================================================================
+
+test.describe('Mention — JSON', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('getJSON includes mention node with correct structure', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const json = await getEditorJSON(page);
+    const paragraph = json.content[0];
+    const mentionNode = paragraph.content.find((n: any) => n.type === 'mention');
+    expect(mentionNode).toBeDefined();
+    expect(mentionNode.attrs.id).toBe('1');
+    expect(mentionNode.attrs.label).toBe('Alice Johnson');
+    expect(mentionNode.attrs.type).toBe('user');
+  });
+
+  test('JSON roundtrip preserves mention', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    const json = await getEditorJSON(page);
+
+    // Set content from JSON
+    await page.evaluate((j) => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      comp?.editor?.commands.setContent(j, false);
+    }, json);
+    await page.waitForTimeout(100);
+
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await expect(page.locator(mentionNodeSelector).first()).toContainText('Alice Johnson');
+  });
+});
+
+// =============================================================================
+// Keyboard — Backspace
+// =============================================================================
+
+test.describe('Mention — Backspace', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Backspace at cursor after mention deletes mention', async ({ page }) => {
+    await setEditorContent(page, MENTION_AT_END);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+
+    // Place cursor at end
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) {
+        const { doc } = comp.editor.state;
+        comp.editor.commands.setTextSelection(doc.content.size - 1);
+      }
+    });
+    await page.waitForTimeout(50);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(100);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(0);
+    const text = await getEditorText(page);
+    expect(text).toContain('Greetings');
+  });
+
+  test('Backspace preserves surrounding text', async ({ page }) => {
+    // Insert mention between text via commands (cursor ends right after mention)
+    await clearAndType(page, 'Before ');
+    await runChain(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    // Cursor is right after the mention now - press backspace to delete it
+    await page.waitForTimeout(50);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(100);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(0);
+    const text = await getEditorText(page);
+    expect(text).toContain('Before');
+  });
+
+  test('Backspace on normal text does not trigger mention delete', async ({ page }) => {
+    await clearAndType(page, 'Hello world');
+    await page.keyboard.press('Backspace');
+    const text = await getEditorText(page);
+    expect(text).toBe('Hello worl');
+  });
+});
+
+// =============================================================================
+// Suggestion — Activation & Dropdown
+// =============================================================================
+
+test.describe('Mention — Suggestion Dropdown', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('typing @ shows suggestion dropdown', async ({ page }) => {
+    await clearAndType(page, 'Hello ');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+  });
+
+  test('dropdown shows all users when query is empty', async ({ page }) => {
+    await clearAndType(page, 'Hi ');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    const items = page.locator(suggestionItemSelector);
+    await expect(items).toHaveCount(8);
+  });
+
+  test('dropdown filters by query', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(200);
+    const items = page.locator(suggestionItemSelector);
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText('Alice Johnson');
+  });
+
+  test('dropdown shows "No results" for unmatched query', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@zzzzz');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionEmptySelector)).toBeVisible();
+    await expect(page.locator(suggestionEmptySelector)).toContainText('No results');
+  });
+
+  test('first item is selected by default', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    const firstItem = page.locator(suggestionItemSelector).first();
+    await expect(firstItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('dropdown has listbox role', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).toHaveAttribute('role', 'listbox');
+  });
+
+  test('suggestion items have option role', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    const firstItem = page.locator(suggestionItemSelector).first();
+    await expect(firstItem).toHaveAttribute('role', 'option');
+  });
+
+  test('@ mid-word does not trigger suggestion', async ({ page }) => {
+    await clearAndType(page, 'email@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+  });
+
+  test('@ at start of line triggers suggestion', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+  });
+
+  test('space then @ triggers suggestion', async ({ page }) => {
+    await clearAndType(page, 'Hello ');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+  });
+
+  test('@ inside code block does not trigger suggestion', async ({ page }) => {
+    // Set a code block and place cursor inside it
+    await page.evaluate(() => {
+      const el = document.querySelector('domternal-editor');
+      const ng = (window as any).ng;
+      const comp = ng?.getComponent?.(el);
+      if (comp?.editor) {
+        comp.editor.commands.setContent('<pre><code>x</code></pre>', false);
+        // Place cursor inside the code block (pos 2 = after the "x")
+        comp.editor.commands.setTextSelection(2);
+        comp.editor.commands.focus();
+      }
+    });
+    await page.waitForTimeout(150);
+    await page.keyboard.press('End');
+    await page.keyboard.type(' @');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+  });
+});
+
+// =============================================================================
+// Suggestion — Keyboard Navigation
+// =============================================================================
+
+test.describe('Mention — Suggestion Keyboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('ArrowDown moves selection down', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(50);
+    const secondItem = page.locator(suggestionItemSelector).nth(1);
+    await expect(secondItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('ArrowUp moves selection up', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(50);
+    const secondItem = page.locator(suggestionItemSelector).nth(1);
+    await expect(secondItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('ArrowDown does not go past last item', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(200);
+    // Only 1 item (Alice Johnson)
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(50);
+    const firstItem = page.locator(suggestionItemSelector).first();
+    await expect(firstItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('Enter inserts selected mention', async ({ page }) => {
+    await clearAndType(page, 'Hey ');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(300);
+    // Verify dropdown is visible with items before pressing Enter
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await expect(page.locator(mentionNodeSelector).first()).toContainText('Alice Johnson');
+  });
+
+  test('Enter on second item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toContainText('Bob Smith');
+  });
+
+  test('Enter on third item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '3');
+    await expect(mention).toContainText('Charlie Brown');
+  });
+
+  test('Enter on last item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    // Navigate to last item (8th, index 7)
+    for (let i = 0; i < 7; i++) {
+      await page.keyboard.press('ArrowDown');
+    }
+    await page.waitForTimeout(100);
+    const lastItem = page.locator(suggestionItemSelector).nth(7);
+    await expect(lastItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '8');
+    await expect(mention).toContainText('Henry Ford');
+  });
+
+  test('ArrowUp from first item stays on first', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(50);
+    const firstItem = page.locator(suggestionItemSelector).first();
+    await expect(firstItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('navigate down then back up to first and Enter', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(100);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toContainText('Alice Johnson');
+  });
+
+  test('navigate to middle item in filtered results', async ({ page }) => {
+    await clearAndType(page, '');
+    // "cha" matches Charlie Brown
+    // "a" matches Alice Johnson, Charlie Brown, Diana Prince, Frank Castle, Grace Hopper, Eve Adams
+    await page.keyboard.type('@a');
+    await page.waitForTimeout(300);
+    const items = page.locator(suggestionItemSelector);
+    const count = await items.count();
+    expect(count).toBeGreaterThan(1);
+    // Remember first item label before selecting second
+    const firstLabel = await items.first().textContent();
+    // Select second match
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    // Verify it's NOT the first match
+    const mentionLabel = await page.locator(mentionNodeSelector).first().textContent();
+    expect(mentionLabel).not.toBe(`@${firstLabel}`);
+  });
+
+  test('Escape dismisses suggestion', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+  });
+
+  test('Escape leaves @ text in editor', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(200);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    const text = await getEditorText(page);
+    expect(text).toContain('@ali');
+  });
+});
+
+// =============================================================================
+// Suggestion — Click Selection
+// =============================================================================
+
+test.describe('Mention — Suggestion Click', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('clicking item inserts mention', async ({ page }) => {
+    await clearAndType(page, 'Notify ');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    const thirdItem = page.locator(suggestionItemSelector).nth(2);
+    await thirdItem.click();
+    await page.waitForTimeout(200);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await expect(page.locator(mentionNodeSelector).first()).toContainText('Charlie Brown');
+  });
+
+  test('hovering item updates selection highlight', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    const thirdItem = page.locator(suggestionItemSelector).nth(2);
+    await thirdItem.hover();
+    await page.waitForTimeout(50);
+    await expect(thirdItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+  });
+
+  test('clicking second item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.locator(suggestionItemSelector).nth(1).click();
+    await page.waitForTimeout(200);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '2');
+    await expect(mention).toContainText('Bob Smith');
+  });
+
+  test('clicking last item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.locator(suggestionItemSelector).nth(7).click();
+    await page.waitForTimeout(200);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '8');
+    await expect(mention).toContainText('Henry Ford');
+  });
+
+  test('clicking fifth item inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await page.locator(suggestionItemSelector).nth(4).click();
+    await page.waitForTimeout(200);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '5');
+    await expect(mention).toContainText('Eve Adams');
+  });
+
+  test('hover changes highlight then Enter inserts hovered item', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    // Hover over 4th item (Diana Prince)
+    const fourthItem = page.locator(suggestionItemSelector).nth(3);
+    await fourthItem.hover();
+    await page.waitForTimeout(100);
+    await expect(fourthItem).toHaveClass(/dm-mention-suggestion-item--selected/);
+    // First item should no longer be selected
+    await expect(page.locator(suggestionItemSelector).first()).not.toHaveClass(/dm-mention-suggestion-item--selected/);
+    // Now press Enter - should insert the hovered (4th) item
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toContainText('Diana Prince');
+  });
+
+  test('clicking filtered result inserts correct mention', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@gr');
+    await page.waitForTimeout(200);
+    // Should show Grace Hopper
+    const items = page.locator(suggestionItemSelector);
+    await expect(items.first()).toContainText('Grace Hopper');
+    await items.first().click();
+    await page.waitForTimeout(200);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '7');
+    await expect(mention).toContainText('Grace Hopper');
+  });
+});
+
+// =============================================================================
+// Suggestion — Insertion Behavior
+// =============================================================================
+
+test.describe('Mention — Insertion Behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('inserted mention replaces trigger + query text', async ({ page }) => {
+    await clearAndType(page, 'Talk to ');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const html = await getEditorHTML(page);
+    expect(html).not.toContain('@ali');
+    expect(html).toContain('data-label="Alice Johnson"');
+  });
+
+  test('space is appended after insertion', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    // Type more text - should be after mention with a space
+    await page.keyboard.type('is great');
+    const text = await getEditorText(page);
+    expect(text).toContain('is great');
+  });
+
+  test('inserted mention has correct data attributes', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@bob');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toHaveAttribute('data-id', '2');
+    await expect(mention).toHaveAttribute('data-label', 'Bob Smith');
+    await expect(mention).toHaveAttribute('data-mention-type', 'user');
+  });
+
+  test('dropdown closes after insertion', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionSelector)).not.toBeVisible();
+  });
+});
+
+// =============================================================================
+// Decoration
+// =============================================================================
+
+test.describe('Mention — Decoration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('active trigger gets mention-suggestion decoration', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(200);
+    await expect(page.locator(decorationSelector)).toBeVisible();
+  });
+
+  test('decoration removed after insertion', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(200);
+    await expect(page.locator(decorationSelector)).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(200);
+    await expect(page.locator(decorationSelector)).not.toBeVisible();
+  });
+
+  test('decoration removed after Escape', async ({ page }) => {
+    await clearAndType(page, '');
+    await page.keyboard.type('@');
+    await page.waitForTimeout(200);
+    await expect(page.locator(decorationSelector)).toBeVisible();
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator(decorationSelector)).not.toBeVisible();
+  });
+});
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+test.describe('Mention — Edge Cases', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('mention at document start', async ({ page }) => {
+    await setEditorContent(page, MENTION_AT_START);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText('Alice Johnson');
+  });
+
+  test('adjacent mentions (no text between)', async ({ page }) => {
+    await setEditorContent(page, ADJACENT_MENTIONS);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(2);
+  });
+
+  test('mention in list item', async ({ page }) => {
+    await setEditorContent(page, MENTION_IN_LIST);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText('Bob Smith');
+  });
+
+  test('mention in blockquote', async ({ page }) => {
+    await setEditorContent(page, MENTION_IN_BLOCKQUOTE);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText('Charlie Brown');
+  });
+
+  test('select all + delete removes mentions', async ({ page }) => {
+    await setEditorContent(page, TWO_MENTIONS);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(2);
+    await focusEditor(page);
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(100);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(0);
+  });
+
+  test('undo restores deleted mention', async ({ page }) => {
+    await setEditorContent(page, MENTION_HTML);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await focusEditor(page);
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(100);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(0);
+    await page.keyboard.press(`${modifier}+z`);
+    await page.waitForTimeout(100);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+  });
+
+  test('mention alongside emoji nodes', async ({ page }) => {
+    const html = '<p><span data-type="emoji" data-name="waving_hand" class="emoji">\ud83d\udc4b</span> <span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span></p>';
+    await setEditorContent(page, html);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    await expect(page.locator(`${editorSelector} span[data-type="emoji"]`)).toHaveCount(1);
+  });
+
+  test('mention in task list', async ({ page }) => {
+    const html = '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label><input type="checkbox"><span></span></label><div>Ask <span data-type="mention" data-id="4" data-label="Diana Prince" data-mention-type="user" class="mention">@Diana Prince</span></div></li></ul>';
+    await setEditorContent(page, html);
+    const mention = page.locator(mentionNodeSelector).first();
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText('Diana Prince');
+  });
+
+  test('typing text after inserting mention via command', async ({ page }) => {
+    await clearAndType(page, 'Ping ');
+    await runChain(page, `insertMention({ id: '1', label: 'Alice Johnson' })`);
+    await page.keyboard.type(' done');
+    const text = await getEditorText(page);
+    expect(text).toContain('@Alice Johnson');
+    expect(text).toContain('done');
+  });
+
+  test('multiple suggestion sessions in same paragraph', async ({ page }) => {
+    await clearAndType(page, '');
+    // First mention
+    await page.keyboard.type('@ali');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(1);
+    // Type text between
+    await page.keyboard.type('and ');
+    // Second mention
+    await page.keyboard.type('@bob');
+    await page.waitForTimeout(300);
+    await expect(page.locator(suggestionItemSelector).first()).toBeVisible();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await expect(page.locator(mentionNodeSelector)).toHaveCount(2);
+  });
+});
+
+// =============================================================================
+// Initial Demo Content
+// =============================================================================
+
+test.describe('Mention — Demo Content', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('demo content loads with mention nodes', async ({ page }) => {
+    const mentions = page.locator(mentionNodeSelector);
+    // Demo content has Alice Johnson and Grace Hopper
+    await expect(mentions).toHaveCount(2);
+  });
+
+  test('demo mentions are visually rendered', async ({ page }) => {
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions.first()).toBeVisible();
+    await expect(mentions.nth(1)).toBeVisible();
+  });
+
+  test('demo mentions have correct labels', async ({ page }) => {
+    const mentions = page.locator(mentionNodeSelector);
+    await expect(mentions.first()).toContainText('Alice Johnson');
+    await expect(mentions.nth(1)).toContainText('Grace Hopper');
+  });
+});

--- a/apps/demo-angular/package.json
+++ b/apps/demo-angular/package.json
@@ -35,6 +35,7 @@
     "@domternal/extension-details": "workspace:*",
     "@domternal/extension-emoji": "workspace:*",
     "@domternal/extension-image": "workspace:*",
+    "@domternal/extension-mention": "workspace:*",
     "@domternal/extension-table": "workspace:*",
     "lowlight": "^3.0.0",
     "@domternal/theme": "workspace:*",

--- a/apps/demo-angular/src/app/editor-demo/demo-content.ts
+++ b/apps/demo-angular/src/app/editor-demo/demo-content.ts
@@ -32,5 +32,7 @@ export const DEMO_CONTENT = `
     <ul><li>Item one</li><li>Item two</li></ul>
   </div>
 </details>
+<h3>Mentions</h3>
+<p>Type <code>@</code> followed by a name to mention someone: <span data-type="mention" data-id="1" data-label="Alice Johnson" data-mention-type="user" class="mention">@Alice Johnson</span> and <span data-type="mention" data-id="7" data-label="Grace Hopper" data-mention-type="user" class="mention">@Grace Hopper</span> are already mentioned here.</p>
 <p>Try typing <code>:wave</code> anywhere to insert an emoji via the suggestion dropdown.</p>
 <p><span style="font-size: 17px; font-family: Georgia">This paragraph uses a custom font size and family to test text style rendering.</span></p>`;

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -41,11 +41,24 @@ import { Image } from '@domternal/extension-image';
 import { Details } from '@domternal/extension-details';
 import { Table } from '@domternal/extension-table';
 import { Emoji, emojis, createEmojiSuggestionRenderer } from '@domternal/extension-emoji';
+import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
+import type { MentionItem } from '@domternal/extension-mention';
 import { createLowlight, common } from 'lowlight';
 import { DEMO_CONTENT } from './demo-content.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
+
+const mockUsers: MentionItem[] = [
+  { id: '1', label: 'Alice Johnson' },
+  { id: '2', label: 'Bob Smith' },
+  { id: '3', label: 'Charlie Brown' },
+  { id: '4', label: 'Diana Prince' },
+  { id: '5', label: 'Eve Adams' },
+  { id: '6', label: 'Frank Castle' },
+  { id: '7', label: 'Grace Hopper' },
+  { id: '8', label: 'Henry Ford' },
+];
 
 @Component({
   selector: 'app-editor-demo',
@@ -74,6 +87,17 @@ export class EditorDemoComponent {
     // Media & Emoji
     Image,
     Emoji.configure({ emojis, enableEmoticons: true, suggestion: { render: createEmojiSuggestionRenderer() } }),
+    // Mentions
+    Mention.configure({
+      suggestion: {
+        char: '@',
+        name: 'user',
+        items: ({ query }: { query: string }) => mockUsers.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
+        render: createMentionSuggestionRenderer(),
+        minQueryLength: 0,
+        invalidNodes: ['codeBlock'],
+      },
+    }),
     // Editor utilities
     LinkPopover, InvisibleChars, SelectionDecoration, ClearFormatting, Dropcursor,
   ];

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -73,7 +73,7 @@ export class EditorDemoComponent {
     Details,
     // Media & Emoji
     Image,
-    Emoji.configure({ emojis, suggestion: { render: createEmojiSuggestionRenderer() } }),
+    Emoji.configure({ emojis, enableEmoticons: true, suggestion: { render: createEmojiSuggestionRenderer() } }),
     // Editor utilities
     LinkPopover, InvisibleChars, SelectionDecoration, ClearFormatting, Dropcursor,
   ];

--- a/packages/core/src/helpers/inputRulesPlugin.ts
+++ b/packages/core/src/helpers/inputRulesPlugin.ts
@@ -16,6 +16,7 @@
 import { Plugin } from '@domternal/pm/state';
 import type { InputRule } from '@domternal/pm/inputrules';
 import type { EditorView } from '@domternal/pm/view';
+import { TextSelection } from '@domternal/pm/state';
 import type { EditorState, Transaction } from '@domternal/pm/state';
 
 interface InternalRule {
@@ -109,6 +110,11 @@ function undoInputRule(plugin: Plugin, state: EditorState, dispatch?: (tr: Trans
     if (undoable.text) {
       const marks = tr.doc.resolve(undoable.from).marks();
       tr.replaceWith(undoable.from, undoable.to, state.schema.text(undoable.text, marks));
+      // Place cursor at the end of the restored text
+      const endPos = undoable.from + undoable.text.length;
+      if (endPos <= tr.doc.content.size) {
+        tr.setSelection(TextSelection.create(tr.doc, endPos));
+      }
     } else {
       tr.delete(undoable.from, undoable.to);
     }

--- a/packages/core/src/nodes/HorizontalRule.ts
+++ b/packages/core/src/nodes/HorizontalRule.ts
@@ -120,18 +120,19 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
 
           if (match[0]) {
             const $start = state.doc.resolve(start);
-            // Replace the entire parent block (paragraph) with HR
+            // Replace the entire parent block (paragraph) with HR + new paragraph
             const from = $start.before();
             const to = $start.after();
-            tr.replaceWith(from, to, nodeType.create());
+            const paragraph = state.schema.nodes['paragraph']?.create();
+            const nodes = paragraph
+              ? [nodeType.create(), paragraph]
+              : [nodeType.create()];
+            tr.replaceWith(from, to, nodes);
 
-            // Move selection after the HR if possible
-            if (from + 1 < tr.doc.content.size) {
-              const $after = tr.doc.resolve(from + 1);
-              const sel = TextSelection.findFrom($after, 1);
-              if (sel) {
-                tr.setSelection(sel);
-              }
+            // Move selection into the new paragraph after the HR
+            const sel = TextSelection.findFrom(tr.doc.resolve(from + 1), 1);
+            if (sel) {
+              tr.setSelection(sel);
             }
           }
 

--- a/packages/extension-mention/src/index.ts
+++ b/packages/extension-mention/src/index.ts
@@ -11,5 +11,8 @@ export type {
   MentionSuggestionRenderer,
 } from './mentionSuggestionPlugin.js';
 
+// Default suggestion renderer
+export { createMentionSuggestionRenderer } from './mentionSuggestionRenderer.js';
+
 // Default export for convenience
 export { Mention as default } from './Mention.js';

--- a/packages/extension-mention/src/mentionSuggestionPlugin.ts
+++ b/packages/extension-mention/src/mentionSuggestionPlugin.ts
@@ -6,7 +6,7 @@
  * callbacks so framework wrappers can display a dropdown picker.
  *
  * Adapted from the emoji suggestion plugin with additions:
- * - Async items support with 150ms debounce
+ * - Async items support with configurable debounce
  * - Multiple plugin instances (one per trigger, unique PluginKey)
  * - Inline decoration on active trigger+query range
  * - invalidNodes context check
@@ -142,7 +142,12 @@ function findMentionQuery(
 
   const { $from } = selection;
 
-  // Check if cursor is in an invalid node
+  // Don't activate inside code contexts (codeBlock node or inline code mark)
+  if ($from.parent.type.spec.code) return null;
+  const activeMarks = state.storedMarks ?? $from.marks();
+  if (activeMarks.some((m) => m.type.name === 'code')) return null;
+
+  // Check if cursor is in a custom invalid node
   if (invalidNodes.length > 0) {
     const parentNodeType = $from.parent.type.name;
     if (invalidNodes.includes(parentNodeType)) return null;

--- a/packages/extension-mention/src/mentionSuggestionPlugin.ts
+++ b/packages/extension-mention/src/mentionSuggestionPlugin.ts
@@ -74,6 +74,8 @@ export interface MentionSuggestionProps {
   command: (item: MentionItem) => void;
   /** Returns the client rect of the cursor for positioning the popup. */
   clientRect: (() => DOMRect | null) | null;
+  /** The ProseMirror editor DOM element (for appending popups inside the editor tree). */
+  element: HTMLElement;
 }
 
 /** Render callbacks for the suggestion popup. */
@@ -318,12 +320,12 @@ export function createMentionSuggestionPlugin(
                 void result.then((items) => {
                   const latest = key.getState(view.state);
                   if (!latest?.active || !latest.range) return;
-                  notifyRenderer({ query: latest.query, range: latest.range, items, command, clientRect });
+                  notifyRenderer({ query: latest.query, range: latest.range, items, command, clientRect, element: view.dom });
                 }).catch(() => {
                   // Swallow — suggestion stays active with no items
                 });
               } else {
-                notifyRenderer({ query: cur.query, range: cur.range, items: result, command, clientRect });
+                notifyRenderer({ query: cur.query, range: cur.range, items: result, command, clientRect, element: view.dom });
               }
             };
 
@@ -354,24 +356,34 @@ export function createMentionSuggestionPlugin(
     },
 
     props: {
-      handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
-        const state = key.getState(view.state);
-        if (!state?.active) return false;
+      // Use handleDOMEvents.keydown instead of handleKeyDown so that
+      // suggestion key handling fires BEFORE keymap plugins (which use
+      // handleKeyDown and would otherwise intercept Enter/ArrowUp/ArrowDown).
+      handleDOMEvents: {
+        keydown(view: EditorView, event: KeyboardEvent): boolean {
+          const state = key.getState(view.state);
+          if (!state?.active) return false;
 
-        // Escape closes suggestion
-        if (event.key === 'Escape') {
-          const { tr } = view.state;
-          tr.setMeta(key, 'dismiss');
-          view.dispatch(tr);
-          return true;
-        }
+          // Escape closes suggestion
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            const { tr } = view.state;
+            tr.setMeta(key, 'dismiss');
+            view.dispatch(tr);
+            return true;
+          }
 
-        // Delegate to renderer for ArrowUp/Down/Enter
-        if (renderer) {
-          return renderer.onKeyDown(event);
-        }
+          // Delegate to renderer for ArrowUp/Down/Enter
+          if (renderer) {
+            const handled = renderer.onKeyDown(event);
+            if (handled) {
+              event.preventDefault();
+            }
+            return handled;
+          }
 
-        return false;
+          return false;
+        },
       },
 
       decorations(state: EditorState): DecorationSet {

--- a/packages/extension-mention/src/mentionSuggestionRenderer.ts
+++ b/packages/extension-mention/src/mentionSuggestionRenderer.ts
@@ -1,0 +1,172 @@
+/**
+ * Default mention suggestion renderer - vanilla DOM dropdown.
+ *
+ * Framework-agnostic: creates a positioned dropdown near the cursor
+ * that displays matching mention items with keyboard navigation.
+ *
+ * @example
+ * ```ts
+ * import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
+ *
+ * const editor = new Editor({
+ *   extensions: [
+ *     Mention.configure({
+ *       suggestion: {
+ *         char: '@',
+ *         name: 'user',
+ *         items: ({ query }) => users.filter(u => u.label.includes(query)),
+ *         render: createMentionSuggestionRenderer(),
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+import type { MentionSuggestionProps, MentionSuggestionRenderer, MentionItem } from './mentionSuggestionPlugin.js';
+import { positionFloatingOnce } from '@domternal/core';
+
+const MAX_ITEMS = 8;
+
+/**
+ * Creates a render factory for the mention suggestion plugin.
+ * Returns a function that produces a `MentionSuggestionRenderer` instance.
+ */
+export function createMentionSuggestionRenderer(): () => MentionSuggestionRenderer {
+  return () => {
+    let container: HTMLDivElement | null = null;
+    let currentProps: MentionSuggestionProps | null = null;
+    let selectedIndex = 0;
+    let cleanupFloating: (() => void) | null = null;
+
+    function render(): void {
+      if (!container || !currentProps) return;
+
+      const { items, command } = currentProps;
+      const visible = items.slice(0, MAX_ITEMS);
+
+      container.innerHTML = '';
+
+      if (visible.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'dm-mention-suggestion-empty';
+        empty.textContent = 'No results';
+        container.appendChild(empty);
+        return;
+      }
+
+      visible.forEach((item: MentionItem, i: number) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className =
+          'dm-mention-suggestion-item' +
+          (i === selectedIndex ? ' dm-mention-suggestion-item--selected' : '');
+        btn.setAttribute('role', 'option');
+        btn.setAttribute('aria-selected', String(i === selectedIndex));
+
+        const labelSpan = document.createElement('span');
+        labelSpan.className = 'dm-mention-suggestion-label';
+        labelSpan.textContent = item.label;
+        btn.appendChild(labelSpan);
+
+        btn.addEventListener('mousedown', (e: Event) => {
+          e.preventDefault();
+          e.stopPropagation();
+        });
+        btn.addEventListener('click', () => {
+          command(item);
+        });
+        btn.addEventListener('mouseenter', () => {
+          if (selectedIndex === i) return;
+          const prev = container?.querySelector('.dm-mention-suggestion-item--selected');
+          if (prev) {
+            prev.classList.remove('dm-mention-suggestion-item--selected');
+            prev.setAttribute('aria-selected', 'false');
+          }
+          selectedIndex = i;
+          btn.classList.add('dm-mention-suggestion-item--selected');
+          btn.setAttribute('aria-selected', 'true');
+        });
+
+        container?.appendChild(btn);
+      });
+    }
+
+    function updatePosition(): void {
+      if (!container || !currentProps?.clientRect) return;
+
+      cleanupFloating?.();
+
+      const virtualEl = {
+        getBoundingClientRect: () => {
+          const rect = currentProps?.clientRect?.();
+          return rect ?? new DOMRect(0, 0, 0, 0);
+        },
+      };
+
+      cleanupFloating = positionFloatingOnce(virtualEl, container, {
+        placement: 'bottom-start',
+        offsetValue: 4,
+      });
+    }
+
+    return {
+      onStart(props: MentionSuggestionProps): void {
+        currentProps = props;
+        selectedIndex = 0;
+
+        container = document.createElement('div');
+        container.className = 'dm-mention-suggestion';
+        container.setAttribute('role', 'listbox');
+
+        const editorEl = props.element.closest('.dm-editor');
+        const appendTarget = editorEl ?? document.body;
+        appendTarget.appendChild(container);
+
+        render();
+        updatePosition();
+      },
+
+      onUpdate(props: MentionSuggestionProps): void {
+        currentProps = props;
+        selectedIndex = 0;
+        render();
+        updatePosition();
+      },
+
+      onExit(): void {
+        cleanupFloating?.();
+        cleanupFloating = null;
+        container?.remove();
+        container = null;
+        currentProps = null;
+        selectedIndex = 0;
+      },
+
+      onKeyDown(event: KeyboardEvent): boolean {
+        if (!currentProps) return false;
+
+        const maxIndex = Math.min(currentProps.items.length, MAX_ITEMS) - 1;
+
+        if (event.key === 'ArrowDown') {
+          selectedIndex = Math.min(selectedIndex + 1, maxIndex);
+          render();
+          return true;
+        }
+
+        if (event.key === 'ArrowUp') {
+          selectedIndex = Math.max(selectedIndex - 1, 0);
+          render();
+          return true;
+        }
+
+        if (event.key === 'Enter') {
+          const item = currentProps.items[selectedIndex];
+          if (item) currentProps.command(item);
+          return true;
+        }
+
+        return false;
+      },
+    };
+  };
+}

--- a/packages/theme/src/_mention.scss
+++ b/packages/theme/src/_mention.scss
@@ -23,3 +23,54 @@
     text-underline-offset: 2px;
   }
 }
+
+// ─── Inline Suggestion Dropdown ─────────────────────────────────────────────
+
+.dm-mention-suggestion {
+  position: absolute;
+  z-index: 100;
+  min-width: 12rem;
+  max-width: 20rem;
+  padding: 0.25rem;
+  background: var(--dm-surface, #f8f9fa);
+  border: 1px solid var(--dm-border-color, #e0e0e0);
+  border-radius: 0.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  animation: dm-fade-in 0.2s ease;
+}
+
+.dm-mention-suggestion-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--dm-text, #1a1a1a);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  text-align: left;
+  transition: background-color 0.1s;
+
+  &:hover,
+  &--selected {
+    background: var(--dm-hover, rgba(0, 0, 0, 0.06));
+  }
+}
+
+.dm-mention-suggestion-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dm-mention-suggestion-empty {
+  padding: 0.5rem;
+  text-align: center;
+  color: var(--dm-text, #1a1a1a);
+  opacity: 0.5;
+  font-size: 0.8125rem;
+}

--- a/packages/theme/src/themes/_dark.scss
+++ b/packages/theme/src/themes/_dark.scss
@@ -52,6 +52,7 @@
 .dm-theme-dark .dm-bubble-menu,
 .dm-theme-dark .dm-emoji-picker,
 .dm-theme-dark .dm-emoji-suggestion,
+.dm-theme-dark .dm-mention-suggestion,
 .dm-theme-dark .dm-table-controls-dropdown {
   @include dark-tokens;
 }
@@ -64,6 +65,7 @@
   .dm-theme-auto .dm-bubble-menu,
   .dm-theme-auto .dm-emoji-picker,
   .dm-theme-auto .dm-emoji-suggestion,
+  .dm-theme-auto .dm-mention-suggestion,
   .dm-theme-auto .dm-table-controls-dropdown {
     @include dark-tokens;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@domternal/extension-details':
         specifier: workspace:*
         version: link:../packages/extension-details
+      '@domternal/extension-emoji':
+        specifier: workspace:*
+        version: link:../packages/extension-emoji
       '@domternal/extension-image':
         specifier: workspace:*
         version: link:../packages/extension-image

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@domternal/extension-image':
         specifier: workspace:*
         version: link:../packages/extension-image
+      '@domternal/extension-mention':
+        specifier: workspace:*
+        version: link:../packages/extension-mention
       '@domternal/extension-table':
         specifier: workspace:*
         version: link:../packages/extension-table

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@domternal/extension-image':
         specifier: workspace:*
         version: link:../../packages/extension-image
+      '@domternal/extension-mention':
+        specifier: workspace:*
+        version: link:../../packages/extension-mention
       '@domternal/extension-table':
         specifier: workspace:*
         version: link:../../packages/extension-table

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@domternal/extension-details':
         specifier: workspace:*
         version: link:../packages/extension-details
+      '@domternal/extension-image':
+        specifier: workspace:*
+        version: link:../packages/extension-image
       '@domternal/extension-table':
         specifier: workspace:*
         version: link:../packages/extension-table


### PR DESCRIPTION
## Summary

- **Mention**: add default suggestion renderer, fix Enter key handling via handleDOMEvents.keydown, add code context guard, add dark mode support for mention dropdown
- **Core**: fix HorizontalRule input rule trailing paragraph and undo cursor position
- **Theme**: add mention suggestion styles and dark mode selectors
- **Tests**: add 357 E2E tests across 4 extensions (mention 82, emoji 27, image 38, details 11, horizontal rule ~199)
- **Demo**: integrate Mention extension in Angular demo with mock users

## Changes

- mentionSuggestionPlugin.ts - switch handleKeyDown to handleDOMEvents.keydown, add spec.code + inline code mark guard, add element to props
- mentionSuggestionRenderer.ts - new default vanilla DOM renderer (max 8 items, keyboard nav, ARIA, Floating UI)
- index.ts - export createMentionSuggestionRenderer
- _mention.scss - mention suggestion dropdown styles
- _dark.scss - add .dm-mention-suggestion to dark mode selectors
- HorizontalRule.ts - fix input rule trailing paragraph insertion and undo cursor
- inputRulesPlugin.ts - preserve replaced range for undo
- apps/demo-angular - integrate mention extension, add 5 E2E spec files

## Test plan

- Verify mention suggestion dropdown opens on @ trigger and filters by query
- Verify Enter/ArrowDown/ArrowUp keyboard navigation in suggestion dropdown
- Verify suggestion does not activate in code blocks or inline code
- Verify mention dropdown renders correctly in dark mode
- Verify --- input rule creates HR with correct paragraph and undo behavior
- Run pnpm test in all packages
- Run npx playwright test in apps/demo-angular