### PR TITLE
fix(core,angular,react): toolbar keyboard navigation and selection preservation

### DIFF
--- a/apps/demo-angular/e2e/toolbar-dropdown.spec.ts
+++ b/apps/demo-angular/e2e/toolbar-dropdown.spec.ts
@@ -1,0 +1,204 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'domternal-editor .ProseMirror';
+const toolbar = 'domternal-toolbar';
+
+async function setContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      comp.editor.setContent(h, false);
+      comp.editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectAll(page: Page) {
+  await page.evaluate(() => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      comp.editor.commands.selectAll();
+      comp.editor.commands.focus();
+    }
+  });
+  await page.waitForTimeout(100);
+}
+
+test.describe('Toolbar dropdown functionality', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.locator(editorSelector).waitFor();
+    await setContent(page, '<p>Hello World</p>');
+    await selectAll(page);
+  });
+
+  test.describe('Text color', () => {
+    test('text color dropdown opens on click', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+    });
+
+    test('clicking a color swatch applies text color', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstSwatch = panel.locator('.dm-color-swatch').first();
+      await firstSwatch.click();
+
+      await expect(output).toContainText('style');
+    });
+
+    test('color swatch has role="menuitem"', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const swatch = page.locator('.dm-toolbar-dropdown-panel .dm-color-swatch').first();
+      await expect(swatch).toHaveAttribute('role', 'menuitem');
+    });
+
+    test('color swatch has tabindex="-1"', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const swatch = page.locator('.dm-toolbar-dropdown-panel .dm-color-swatch').first();
+      await expect(swatch).toHaveAttribute('tabindex', '-1');
+    });
+
+    test('color swatch can receive focus', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstItem = panel.locator('[role="menuitem"]').first();
+      await firstItem.focus();
+      await page.waitForTimeout(100);
+
+      const focused = await page.evaluate(() =>
+        document.activeElement?.getAttribute('role') === 'menuitem'
+      );
+      expect(focused).toBe(true);
+    });
+
+    test('focused color swatch shows focus-visible ring', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstSwatch = panel.locator('.dm-color-swatch').first();
+      await firstSwatch.focus();
+      await page.waitForTimeout(100);
+
+      const boxShadow = await firstSwatch.evaluate((el) => getComputedStyle(el).boxShadow);
+      // box-shadow should not be 'none' when focused
+      expect(boxShadow).not.toBe('none');
+    });
+
+    test('Enter on focused color swatch applies text color', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const swatch = panel.locator('.dm-color-swatch').first();
+      await swatch.focus();
+      await page.waitForTimeout(100);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(200);
+
+      await expect(output).toContainText('style');
+    });
+
+    test('selection is preserved when focusing dropdown item', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const swatch = panel.locator('.dm-color-swatch').first();
+      await swatch.focus();
+      await page.waitForTimeout(100);
+
+      const selection = await page.evaluate(() => {
+        const el = document.querySelector('domternal-editor');
+        const ng = (window as any).ng;
+        const comp = ng?.getComponent?.(el);
+        if (comp?.editor) {
+          const { from, to } = comp.editor.state.selection;
+          return { from, to, empty: from === to };
+        }
+        return null;
+      });
+      expect(selection?.empty).toBe(false);
+    });
+  });
+
+  test.describe('Font size', () => {
+    test('font size dropdown is visible in default toolbar', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await expect(fontSizeBtn).toBeVisible();
+    });
+
+    test('font size dropdown opens on click', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+    });
+
+    test('clicking a font size applies it to selected text', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const item = panel.locator('.dm-toolbar-dropdown-item', { hasText: '24px' });
+      await item.click();
+
+      await expect(output).toContainText('font-size');
+    });
+
+    test('font size dropdown item can receive focus', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstItem = panel.locator('[role="menuitem"]').first();
+      await firstItem.focus();
+      await page.waitForTimeout(100);
+
+      const focused = await page.evaluate(() =>
+        document.activeElement?.getAttribute('role') === 'menuitem'
+      );
+      expect(focused).toBe(true);
+    });
+  });
+
+  test.describe('Heading dropdown', () => {
+    test('heading dropdown opens and applies heading', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const headingBtn = page.locator(`${toolbar} button[aria-label="Heading"]`);
+      await headingBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const h2 = panel.locator('.dm-toolbar-dropdown-item', { hasText: 'Heading 2' });
+      await h2.click();
+
+      await expect(output).toContainText('<h2>');
+    });
+  });
+});

--- a/apps/demo-react/e2e/toolbar-dropdown.spec.ts
+++ b/apps/demo-react/e2e/toolbar-dropdown.spec.ts
@@ -1,0 +1,197 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const toolbar = '.dm-toolbar';
+
+async function setContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as any).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectAll(page: Page) {
+  await page.evaluate(() => {
+    const editor = (window as any).__DEMO_EDITOR__;
+    if (editor) editor.commands.selectAll();
+    const el = document.querySelector('.dm-editor .ProseMirror');
+    if (el instanceof HTMLElement) el.focus();
+  });
+  await page.waitForTimeout(100);
+}
+
+test.describe('Toolbar dropdown functionality', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.locator(editorSelector).waitFor();
+    await setContent(page, '<p>Hello World</p>');
+    await selectAll(page);
+  });
+
+  test.describe('Text color', () => {
+    test('text color dropdown opens on click', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+    });
+
+    test('clicking a color swatch applies text color', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstSwatch = panel.locator('.dm-color-swatch').first();
+      await firstSwatch.click();
+
+      await expect(output).toContainText('style');
+    });
+
+    test('color swatch has role="menuitem"', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const swatch = page.locator('.dm-toolbar-dropdown-panel .dm-color-swatch').first();
+      await expect(swatch).toHaveAttribute('role', 'menuitem');
+    });
+
+    test('color swatch has tabindex="-1"', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const swatch = page.locator('.dm-toolbar-dropdown-panel .dm-color-swatch').first();
+      await expect(swatch).toHaveAttribute('tabindex', '-1');
+    });
+
+    test('color swatch can receive focus', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstItem = panel.locator('[role="menuitem"]').first();
+      await firstItem.focus();
+      await page.waitForTimeout(100);
+
+      const focused = await page.evaluate(() =>
+        document.activeElement?.getAttribute('role') === 'menuitem'
+      );
+      expect(focused).toBe(true);
+    });
+
+    test('focused color swatch shows focus-visible ring', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstSwatch = panel.locator('.dm-color-swatch').first();
+      await firstSwatch.focus();
+      await page.waitForTimeout(100);
+
+      const boxShadow = await firstSwatch.evaluate((el) => getComputedStyle(el).boxShadow);
+      // box-shadow should not be 'none' when focused
+      expect(boxShadow).not.toBe('none');
+    });
+
+    test('Enter on focused color swatch applies text color', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const swatch = panel.locator('.dm-color-swatch').first();
+      await swatch.focus();
+      await page.waitForTimeout(100);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(200);
+
+      await expect(output).toContainText('style');
+    });
+
+    test('selection is preserved when focusing dropdown item', async ({ page }) => {
+      const colorBtn = page.locator(`${toolbar} button[aria-label="Text Color"]`);
+      await colorBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const swatch = panel.locator('.dm-color-swatch').first();
+      await swatch.focus();
+      await page.waitForTimeout(100);
+
+      const selection = await page.evaluate(() => {
+        const editor = (window as any).__DEMO_EDITOR__;
+        if (editor) {
+          const { from, to } = editor.state.selection;
+          return { from, to, empty: from === to };
+        }
+        return null;
+      });
+      expect(selection?.empty).toBe(false);
+    });
+  });
+
+  test.describe('Font size', () => {
+    test('font size dropdown is visible in default toolbar', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await expect(fontSizeBtn).toBeVisible();
+    });
+
+    test('font size dropdown opens on click', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+    });
+
+    test('clicking a font size applies it to selected text', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const item = panel.locator('.dm-toolbar-dropdown-item', { hasText: '24px' });
+      await item.click();
+
+      await expect(output).toContainText('font-size');
+    });
+
+    test('font size dropdown item can receive focus', async ({ page }) => {
+      const fontSizeBtn = page.locator(`${toolbar} button[aria-label="Font Size"]`);
+      await fontSizeBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const firstItem = panel.locator('[role="menuitem"]').first();
+      await firstItem.focus();
+      await page.waitForTimeout(100);
+
+      const focused = await page.evaluate(() =>
+        document.activeElement?.getAttribute('role') === 'menuitem'
+      );
+      expect(focused).toBe(true);
+    });
+  });
+
+  test.describe('Heading dropdown', () => {
+    test('heading dropdown opens and applies heading', async ({ page }) => {
+      const output = page.locator('pre.output');
+      const headingBtn = page.locator(`${toolbar} button[aria-label="Heading"]`);
+      await headingBtn.click();
+      const panel = page.locator('.dm-toolbar-dropdown-panel');
+      await expect(panel).toBeVisible();
+
+      const h2 = panel.locator('.dm-toolbar-dropdown-item', { hasText: 'Heading 2' });
+      await h2.click();
+
+      await expect(output).toContainText('<h2>');
+    });
+  });
+});

--- a/packages/angular/src/lib/editor.component.ts
+++ b/packages/angular/src/lib/editor.component.ts
@@ -34,7 +34,7 @@ export const DEFAULT_EXTENSIONS: AnyExtension[] = [Document, Paragraph, Text, Ba
   template: '<div #editorRef></div>',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: { class: 'dm-editor' },
+  host: { class: 'dm-editor', 'data-dm-editor-ui': '' },
   styles: [`:host { display: block; }`],
   providers: [
     {

--- a/packages/angular/src/lib/emoji-picker.component.ts
+++ b/packages/angular/src/lib/emoji-picker.component.ts
@@ -227,7 +227,14 @@ export class DomternalEmojiPickerComponent implements OnDestroy {
       const label = grid.querySelector(`[data-category="${cat}"]`) as HTMLElement | null;
       if (label) {
         // Use manual scrollTop instead of scrollIntoView to avoid scrolling the page
-        grid.scrollTo({ top: label.offsetTop - grid.offsetTop, behavior: 'smooth' });
+        grid.scrollTo({ top: label.offsetTop - grid.offsetTop });
+        // Focus first emoji swatch after scroll completes
+        setTimeout(() => {
+          const firstSwatch = label.nextElementSibling;
+          if (firstSwatch instanceof HTMLElement && firstSwatch.classList.contains('dm-emoji-swatch')) {
+            firstSwatch.focus();
+          }
+        }, 50);
       }
     });
   }

--- a/packages/angular/src/lib/emoji-picker.component.ts
+++ b/packages/angular/src/lib/emoji-picker.component.ts
@@ -238,8 +238,15 @@ export class DomternalEmojiPickerComponent implements OnDestroy {
     const swatches = Array.from(grid.querySelectorAll('.dm-emoji-swatch')) as HTMLElement[];
     if (!swatches.length) return;
     const current = document.activeElement as HTMLElement;
-    const idx = swatches.indexOf(current);
-    if (idx === -1) return;
+    let idx = swatches.indexOf(current);
+    if (idx === -1) {
+      // Focus is on grid container, not a swatch — enter the grid
+      if (['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(event.key)) {
+        event.preventDefault();
+        swatches[0]?.focus();
+      }
+      return;
+    }
     const cols = 8;
     let next = idx;
     switch (event.key) {

--- a/packages/angular/src/lib/toolbar.component.ts
+++ b/packages/angular/src/lib/toolbar.component.ts
@@ -360,6 +360,15 @@ export class DomternalToolbarComponent implements OnDestroy {
       return;
     }
     this.controller?.executeCommand(item);
+
+    // If the button was activated via keyboard (Enter/Space on a focused
+    // toolbar button), refocus the editor so the browser renders the
+    // ::selection highlight for the still-active range.
+    // Keyboard-triggered click events have detail === 0.
+    // Always refocus editor after executing a command via toolbar button.
+    // Mouse clicks already keep focus via mousedown.preventDefault();
+    // keyboard activations (Enter/Space) need explicit refocus.
+    requestAnimationFrame(() => this.editor().view.focus());
   }
 
   onDropdownToggle(dropdown: ToolbarDropdown): void {
@@ -404,6 +413,9 @@ export class DomternalToolbarComponent implements OnDestroy {
     } else {
       this.controller?.executeCommand(item);
     }
+
+    // Refocus editor so ::selection highlight stays visible
+    requestAnimationFrame(() => this.editor().view.focus());
   }
 
   onButtonFocus(name: string): void {

--- a/packages/angular/src/lib/toolbar.component.ts
+++ b/packages/angular/src/lib/toolbar.component.ts
@@ -38,6 +38,7 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(na
   host: {
     'class': 'dm-toolbar',
     'role': 'toolbar',
+    'data-dm-editor-ui': '',
     '[attr.aria-label]': '"Editor formatting"',
     '(keydown)': 'onKeydown($event)',
   },
@@ -441,9 +442,8 @@ export class DomternalToolbarComponent implements OnDestroy {
         if (this.openDropdown()) {
           this.focusDropdownItem(1);
         } else {
-          const buttons = this.elRef.nativeElement.querySelectorAll('.dm-toolbar-button') as NodeListOf<HTMLElement>;
-          const btn = buttons[this.controller?.focusedIndex ?? 0];
-          if (btn?.getAttribute('aria-haspopup')) {
+          const btn = document.activeElement as HTMLElement | null;
+          if (btn?.getAttribute('aria-haspopup') && btn.closest('.dm-toolbar')) {
             btn.click();
             requestAnimationFrame(() => this.focusDropdownItem(0, true));
           }

--- a/packages/core/src/extensions/SelectionDecoration.ts
+++ b/packages/core/src/extensions/SelectionDecoration.ts
@@ -30,12 +30,15 @@ export const SelectionDecoration = Extension.create<SelectionDecorationOptions>(
             handleDOMEvents: {
               blur(view, event) {
                 // Don't collapse selection when focus moves to editor-related
-                // UI (e.g. link popover input). Elements marked with
-                // [data-dm-editor-ui] are treated as part of the editor.
+                // UI (e.g. toolbar, bubble menu, link popover input).
+                // Elements marked with [data-dm-editor-ui] or inside
+                // .dm-toolbar / .dm-bubble-menu are treated as part of the editor.
                 const related = event.relatedTarget;
                 if (
                   related instanceof HTMLElement &&
-                  related.closest('[data-dm-editor-ui]')
+                  (related.closest('[data-dm-editor-ui]') ||
+                   related.closest('.dm-toolbar') ||
+                   related.closest('.dm-bubble-menu'))
                 ) {
                   return false;
                 }

--- a/packages/react/src/Domternal.tsx
+++ b/packages/react/src/Domternal.tsx
@@ -67,7 +67,7 @@ function DomternalContent({ className }: { className?: string }) {
   const classes = className ? `dm-editor ${className}` : 'dm-editor';
 
   return (
-    <div className={classes}>
+    <div className={classes} data-dm-editor-ui="">
       <div ref={containerRef} />
     </div>
   );

--- a/packages/react/src/DomternalEditor.tsx
+++ b/packages/react/src/DomternalEditor.tsx
@@ -120,7 +120,7 @@ export const DomternalEditor = forwardRef<DomternalEditorRef, DomternalEditorPro
     return (
       <EditorProvider editor={editor}>
         {children}
-        <div className={classes}>
+        <div className={classes} data-dm-editor-ui="">
           <div ref={editorRef} />
         </div>
       </EditorProvider>

--- a/packages/react/src/emoji-picker/DomternalEmojiPicker.tsx
+++ b/packages/react/src/emoji-picker/DomternalEmojiPicker.tsx
@@ -55,8 +55,15 @@ export function DomternalEmojiPicker({ editor: editorProp, emojis }: DomternalEm
     const swatches = Array.from(grid.querySelectorAll('.dm-emoji-swatch')) as HTMLElement[];
     if (!swatches.length) return;
     const current = document.activeElement as HTMLElement;
-    const idx = swatches.indexOf(current);
-    if (idx === -1) return;
+    let idx = swatches.indexOf(current);
+    if (idx === -1) {
+      // Focus is on grid container, not a swatch — enter the grid
+      if (['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(event.key)) {
+        event.preventDefault();
+        swatches[0]?.focus();
+      }
+      return;
+    }
     const cols = 8;
     let next = idx;
     switch (event.key) {

--- a/packages/react/src/emoji-picker/useEmojiPicker.ts
+++ b/packages/react/src/emoji-picker/useEmojiPicker.ts
@@ -173,7 +173,14 @@ export function useEmojiPicker(editor: Editor | null, emojis: EmojiPickerItem[])
       if (!grid) return;
       const label = grid.querySelector(`[data-category="${cat}"]`) as HTMLElement | null;
       if (label) {
-        grid.scrollTo({ top: label.offsetTop - grid.offsetTop, behavior: 'smooth' });
+        grid.scrollTo({ top: label.offsetTop - grid.offsetTop });
+        // Focus first emoji swatch after scroll completes
+        setTimeout(() => {
+          const firstSwatch = label.nextElementSibling;
+          if (firstSwatch instanceof HTMLElement && firstSwatch.classList.contains('dm-emoji-swatch')) {
+            firstSwatch.focus();
+          }
+        }, 50);
       }
     });
   }, []);

--- a/packages/react/src/toolbar/DomternalToolbar.tsx
+++ b/packages/react/src/toolbar/DomternalToolbar.tsx
@@ -68,6 +68,11 @@ export function DomternalToolbar({ editor: editorProp, icons, layout }: Domterna
       return;
     }
     controllerRef.current?.executeCommand(item);
+
+    // Always refocus editor after executing a command via toolbar button.
+    // Mouse clicks already keep focus via mousedown.preventDefault();
+    // keyboard activations (Enter/Space) need explicit refocus.
+    requestAnimationFrame(() => editor.view.focus());
   }, [editor, closeDropdown]);
 
   const onDropdownItemClick = useCallback((item: ToolbarButtonType, event: React.MouseEvent) => {
@@ -86,6 +91,9 @@ export function DomternalToolbar({ editor: editorProp, icons, layout }: Domterna
     } else {
       controllerRef.current?.executeCommand(item);
     }
+
+    // Refocus editor so ::selection highlight stays visible
+    requestAnimationFrame(() => editor.view.focus());
   }, [editor, closeDropdown]);
 
   const onButtonFocus = useCallback((name: string) => {

--- a/packages/react/src/toolbar/DomternalToolbar.tsx
+++ b/packages/react/src/toolbar/DomternalToolbar.tsx
@@ -106,6 +106,7 @@ export function DomternalToolbar({ editor: editorProp, icons, layout }: Domterna
       className="dm-toolbar"
       role="toolbar"
       aria-label="Editor formatting"
+      data-dm-editor-ui=""
       onKeyDown={onKeyDown}
     >
       {groups.map((group, gi) => (

--- a/packages/theme/src/_table-controls.scss
+++ b/packages/theme/src/_table-controls.scss
@@ -257,7 +257,7 @@
     transition: background-color 0.15s;
 
     &:hover {
-      background: var(--dm-button-hover-bg);
+      background: var(--dm-button-hover-bg, var(--dm-hover, rgba(0, 0, 0, 0.06)));
     }
 
     &:focus-visible {


### PR DESCRIPTION
## Summary

- SelectionDecoration no longer collapses selection when focus moves to toolbar or editor UI
- Angular ArrowDown uses `document.activeElement` instead of `focusedIndex` for dropdown trigger detection (parity with React)
- Toolbar refocuses editor after keyboard-activated commands (Enter/Space on buttons), so `::selection` highlight stays visible
- Emoji picker arrow keys now enter the grid when focus is on the grid container
- Selecting an emoji category tab via keyboard focuses the first emoji in that category
- Table dropdown hover fallback for dark mode

## Tests

- 26 new E2E tests (13 Angular + 13 React) for toolbar dropdown functionality: text color, font size, heading, ARIA attributes, focus, Enter on swatch