### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.2 (2026-04-16)
+
+### Fixes
+
+- fix(vue): `Domternal` compound subcomponents (`Domternal.Toolbar`, `Domternal.BubbleMenu`, etc.) were tree-shaken away in production builds due to `sideEffects: false`. Moved assignments into `Domternal.ts` so bundlers can't drop them.
+- fix(vue): `editable` prop on `<Domternal>` and `<DomternalEditor>` was not syncing at runtime. Added reactive `watch` since `useEditor`'s internal watcher can't track plain object props.
+- fix(react,vue): toolbar keyboard activation (Enter/Space) did not work in `EditorContent`. Added `data-dm-editor-ui` attribute so `SelectionDecoration` preserves selection on toolbar focus.
+
 ## 0.6.1 (2026-04-16)
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ pnpm typecheck  # Run type checker
 
 1. Branch: `git checkout -b release/X.Y.Z` from main
 2. Bump `"version"` in all 12 `packages/*/package.json` + `domternal.dev/package.json`
-3. Bump `peerDependencies` and `prepublishOnly` hook versions to `>=X.Y.Z`
+3. Bump `peerDependencies` and `prepublishOnly` hook versions. For patch releases, keep the existing minimum compatible version. For minor/major releases, bump to `>=X.Y.0`.
 4. Update `CHANGELOG.md` and `domternal.dev` changelog
 5. Update all 13 READMEs (root + 12 packages)
 6. Verify: `pnpm test && pnpm build && pnpm typecheck && pnpm lint`

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,15 +34,15 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {
     "hast-util-to-html": "^9.0.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1",
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0",
     "lowlight": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1"
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1"
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1"
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1"
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.6.1",
-    "@domternal/pm": ">=0.6.1"
+    "@domternal/core": ">=0.6.0",
+    "@domternal/pm": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "@domternal/core": ">=0.6.1"
+    "@domternal/core": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -36,7 +36,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -20,7 +20,7 @@
   ],
   "peerDependencies": {
     "vue": ">=3.3",
-    "@domternal/core": ">=0.6.1"
+    "@domternal/core": ">=0.6.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -32,7 +32,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.1'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.6.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Patch release with three Vue/React bug fixes.

## Fixes

- **Vue compound tree-shaking**: `Domternal.Toolbar`, `Domternal.BubbleMenu`, etc. were tree-shaken away in production builds due to `sideEffects: false`. Moved subcomponent assignments into `Domternal.ts`.
- **Vue editable reactivity**: `editable` prop on `<Domternal>` and `<DomternalEditor>` was not syncing at runtime. Added reactive `watch` since `useEditor`'s internal watcher can't track plain object props.
- **React/Vue EditorContent keyboard**: toolbar keyboard activation (Enter/Space) did not work in `EditorContent`. Added `data-dm-editor-ui` attribute so `SelectionDecoration` preserves selection on toolbar focus.

## Verified

- Built and typechecked all packages
- All 91 demo-vue E2E tests pass
- Compound subcomponent assignments survive tree-shaking in production build