### PR TITLE
fix(angular,react,vue): image bubble menu default visible, add emoji toolbar hide option

### DIFF
--- a/apps/demo-angular/e2e/improvements.spec.ts
+++ b/apps/demo-angular/e2e/improvements.spec.ts
@@ -106,4 +106,59 @@ test.describe('Bubble menu — auto mode (no contexts)', () => {
     const bubbleMenu = page.locator('.dm-bubble-menu');
     await expect(bubbleMenu).toBeVisible();
   });
+
+  test('text selection shows bold/italic/underline by default in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Italic"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Underline"]')).toBeVisible();
+    // Image-specific controls should NOT be present
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from image to text on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+
+    // Step 2: select text (in first paragraph)
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from text to image on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select text first
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+
+    // Step 2: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toHaveCount(0);
+  });
 });

--- a/apps/demo-angular/e2e/improvements.spec.ts
+++ b/apps/demo-angular/e2e/improvements.spec.ts
@@ -1,0 +1,109 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'domternal-editor .ProseMirror';
+const emojiBtn = 'domternal-toolbar button[aria-label="Insert Emoji"]';
+const suggestionSelector = '.dm-emoji-suggestion';
+const suggestionItem = '.dm-emoji-suggestion-item';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+// 1x1 red pixel PNG as base64 for test fixtures
+const BASE64_1PX = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+const IMG_BASIC = `<img src="${BASE64_1PX}">`;
+
+async function setEditorContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as any).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      comp.editor.setContent(h, false);
+      comp.editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+// =============================================================================
+// Emoji toolbar option (toolbar: false hides button)
+// =============================================================================
+
+test.describe('Emoji — toolbar: true (default)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is visible in toolbar by default', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toBeVisible();
+  });
+});
+
+test.describe('Emoji — toolbar: false (hidden)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?emojiToolbar=false');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is not rendered in toolbar', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toHaveCount(0);
+  });
+
+  test('suggestion trigger still works when button hidden', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type(':smi');
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+    const items = page.locator(suggestionItem);
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Bubble menu auto mode (shows on image selection without contexts)
+// =============================================================================
+
+test.describe('Bubble menu — auto mode (no contexts)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?bubbleAuto=true');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('selecting image shows bubble menu without contexts configured', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+
+  test('image bubble menu exposes float controls in auto mode', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('.dm-bubble-menu button[title="Float left"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Float right"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Center"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Delete"]')).toBeVisible();
+  });
+
+  test('text selection still shows bubble menu with default items in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+});

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
@@ -14,9 +14,13 @@
 />
 
 @if (editor(); as ed) {
-  <domternal-bubble-menu [editor]="ed" [contexts]="{
-    text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
-  }" />
+  @if (bubbleAuto) {
+    <domternal-bubble-menu [editor]="ed" />
+  } @else {
+    <domternal-bubble-menu [editor]="ed" [contexts]="{
+      text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
+    }" />
+  }
   <domternal-emoji-picker [editor]="ed" [emojis]="emojiData" />
 }
 

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -70,6 +70,8 @@ export class EditorDemoComponent {
   private readonly params = new URLSearchParams(window.location.search);
   private readonly constrainTable = !this.params.has('constrainTable', 'false');
   private readonly resizeBehavior = (this.params.get('resizeBehavior') ?? 'neighbor') as 'neighbor' | 'independent' | 'redistribute';
+  private readonly emojiToolbar = this.params.get('emojiToolbar') !== 'false';
+  readonly bubbleAuto = this.params.get('bubbleAuto') === 'true';
 
   extensions = [
     // Inline formatting
@@ -86,7 +88,7 @@ export class EditorDemoComponent {
     Details,
     // Media & Emoji
     Image,
-    Emoji.configure({ emojis, enableEmoticons: true, suggestion: { render: createEmojiSuggestionRenderer() } }),
+    Emoji.configure({ emojis, enableEmoticons: true, toolbar: this.emojiToolbar, suggestion: { render: createEmojiSuggestionRenderer() } }),
     // Mentions
     Mention.configure({
       suggestion: {

--- a/apps/demo-react/e2e/improvements.spec.ts
+++ b/apps/demo-react/e2e/improvements.spec.ts
@@ -1,0 +1,107 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const emojiBtn = 'button[aria-label="Insert Emoji"]';
+const suggestionSelector = '.dm-emoji-suggestion';
+const suggestionItem = '.dm-emoji-suggestion-item';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+// 1x1 red pixel PNG as base64 for test fixtures
+const BASE64_1PX = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+const IMG_BASIC = `<img src="${BASE64_1PX}">`;
+
+async function setEditorContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as any).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+// =============================================================================
+// Emoji toolbar option (toolbar: false hides button)
+// =============================================================================
+
+test.describe('Emoji — toolbar: true (default)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is visible in toolbar by default', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toBeVisible();
+  });
+});
+
+test.describe('Emoji — toolbar: false (hidden)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?emojiToolbar=false');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is not rendered in toolbar', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toHaveCount(0);
+  });
+
+  test('suggestion trigger still works when button hidden', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type(':smi');
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+    const items = page.locator(suggestionItem);
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Bubble menu auto mode (shows on image selection without contexts)
+// =============================================================================
+
+test.describe('Bubble menu — auto mode (no contexts)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?bubbleAuto=true');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('selecting image shows bubble menu without contexts configured', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+
+  test('image bubble menu exposes float controls in auto mode', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('.dm-bubble-menu button[title="Float left"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Float right"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Center"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Delete"]')).toBeVisible();
+  });
+
+  test('text selection still shows bubble menu with default items in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+});

--- a/apps/demo-react/e2e/improvements.spec.ts
+++ b/apps/demo-react/e2e/improvements.spec.ts
@@ -104,4 +104,59 @@ test.describe('Bubble menu — auto mode (no contexts)', () => {
     const bubbleMenu = page.locator('.dm-bubble-menu');
     await expect(bubbleMenu).toBeVisible();
   });
+
+  test('text selection shows bold/italic/underline by default in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Italic"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Underline"]')).toBeVisible();
+    // Image-specific controls should NOT be present
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from image to text on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+
+    // Step 2: select text (in first paragraph)
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from text to image on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select text first
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+
+    // Step 2: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toHaveCount(0);
+  });
 });

--- a/apps/demo-react/src/EditorDemo.tsx
+++ b/apps/demo-react/src/EditorDemo.tsx
@@ -63,6 +63,8 @@ const mockUsers: MentionItem[] = [
 const params = new URLSearchParams(window.location.search);
 const constrainTable = !params.has('constrainTable', 'false');
 const resizeBehavior = (params.get('resizeBehavior') ?? 'neighbor') as 'neighbor' | 'independent' | 'redistribute';
+const emojiToolbar = params.get('emojiToolbar') !== 'false';
+const bubbleAuto = params.get('bubbleAuto') === 'true';
 
 const extensions = [
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
@@ -72,7 +74,7 @@ const extensions = [
   Table.configure({ constrainToContainer: constrainTable, resizeBehavior }),
   Details,
   Image,
-  Emoji.configure({ emojis, enableEmoticons: true, suggestion: { render: createEmojiSuggestionRenderer() } }),
+  Emoji.configure({ emojis, enableEmoticons: true, toolbar: emojiToolbar, suggestion: { render: createEmojiSuggestionRenderer() } }),
   Mention.configure({
     suggestion: {
       char: '@',
@@ -138,10 +140,14 @@ export function EditorDemo({ useLayout }: EditorDemoProps) {
 
       {editor && (
         <>
-          <DomternalBubbleMenu
-            editor={editor}
-            contexts={{ text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] }}
-          />
+          {bubbleAuto ? (
+            <DomternalBubbleMenu editor={editor} />
+          ) : (
+            <DomternalBubbleMenu
+              editor={editor}
+              contexts={{ text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] }}
+            />
+          )}
           <DomternalEmojiPicker editor={editor} emojis={emojis} />
         </>
       )}

--- a/apps/demo-vue/e2e/improvements.spec.ts
+++ b/apps/demo-vue/e2e/improvements.spec.ts
@@ -1,0 +1,107 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const emojiBtn = 'button[aria-label="Insert Emoji"]';
+const suggestionSelector = '.dm-emoji-suggestion';
+const suggestionItem = '.dm-emoji-suggestion-item';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+// 1x1 red pixel PNG as base64 for test fixtures
+const BASE64_1PX = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+const IMG_BASIC = `<img src="${BASE64_1PX}">`;
+
+async function setEditorContent(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as any).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+// =============================================================================
+// Emoji toolbar option (toolbar: false hides button)
+// =============================================================================
+
+test.describe('Emoji — toolbar: true (default)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is visible in toolbar by default', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toBeVisible();
+  });
+});
+
+test.describe('Emoji — toolbar: false (hidden)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?emojiToolbar=false');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('emoji button is not rendered in toolbar', async ({ page }) => {
+    await expect(page.locator(emojiBtn)).toHaveCount(0);
+  });
+
+  test('suggestion trigger still works when button hidden', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type(':smi');
+    await expect(page.locator(suggestionSelector)).toBeVisible();
+    const items = page.locator(suggestionItem);
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Bubble menu auto mode (shows on image selection without contexts)
+// =============================================================================
+
+test.describe('Bubble menu — auto mode (no contexts)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?bubbleAuto=true');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('selecting image shows bubble menu without contexts configured', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+
+  test('image bubble menu exposes float controls in auto mode', async ({ page }) => {
+    await setEditorContent(page, IMG_BASIC);
+
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('.dm-bubble-menu button[title="Float left"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Float right"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Center"]')).toBeVisible();
+    await expect(page.locator('.dm-bubble-menu button[title="Delete"]')).toBeVisible();
+  });
+
+  test('text selection still shows bubble menu with default items in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+  });
+});

--- a/apps/demo-vue/e2e/improvements.spec.ts
+++ b/apps/demo-vue/e2e/improvements.spec.ts
@@ -104,4 +104,59 @@ test.describe('Bubble menu — auto mode (no contexts)', () => {
     const bubbleMenu = page.locator('.dm-bubble-menu');
     await expect(bubbleMenu).toBeVisible();
   });
+
+  test('text selection shows bold/italic/underline by default in auto mode', async ({ page }) => {
+    const editor = page.locator(editorSelector);
+    await editor.click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(200);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Italic"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Underline"]')).toBeVisible();
+    // Image-specific controls should NOT be present
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from image to text on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+
+    // Step 2: select text (in first paragraph)
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toHaveCount(0);
+  });
+
+  test('items switch from text to image on selection change', async ({ page }) => {
+    await setEditorContent(page, `<p>Hello world</p>${IMG_BASIC}<p>More text</p>`);
+
+    // Step 1: select text first
+    await page.locator(editorSelector).locator('p').first().click();
+    await page.keyboard.press(`${modifier}+a`);
+    await page.waitForTimeout(300);
+
+    const bubbleMenu = page.locator('.dm-bubble-menu');
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toBeVisible();
+
+    // Step 2: select image
+    const wrapper = page.locator(`${editorSelector} .dm-image-resizable`).first();
+    await wrapper.click();
+    await page.waitForTimeout(300);
+
+    await expect(bubbleMenu.locator('button[title="Float left"]')).toBeVisible();
+    await expect(bubbleMenu.locator('button[title="Bold"]')).toHaveCount(0);
+  });
 });

--- a/apps/demo-vue/src/EditorDemo.vue
+++ b/apps/demo-vue/src/EditorDemo.vue
@@ -67,6 +67,8 @@ const mockUsers: MentionItem[] = [
 const params = new URLSearchParams(window.location.search);
 const constrainTable = !params.has('constrainTable', 'false');
 const resizeBehavior = (params.get('resizeBehavior') ?? 'neighbor') as 'neighbor' | 'independent' | 'redistribute';
+const emojiToolbar = params.get('emojiToolbar') !== 'false';
+const bubbleAuto = params.get('bubbleAuto') === 'true';
 
 const extensions = [
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
@@ -76,7 +78,7 @@ const extensions = [
   Table.configure({ constrainToContainer: constrainTable, resizeBehavior }),
   Details,
   Image,
-  Emoji.configure({ emojis, enableEmoticons: true, suggestion: { render: createEmojiSuggestionRenderer() } }),
+  Emoji.configure({ emojis, enableEmoticons: true, toolbar: emojiToolbar, suggestion: { render: createEmojiSuggestionRenderer() } }),
   Mention.configure({
     suggestion: {
       char: '@',
@@ -137,6 +139,11 @@ defineExpose({ editor, editorRef });
 
   <template v-if="editor">
     <DomternalBubbleMenu
+      v-if="bubbleAuto"
+      :editor="editor"
+    />
+    <DomternalBubbleMenu
+      v-else
       :editor="editor"
       :contexts="{ text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] }"
     />

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,9 +15,9 @@
     "@angular/compiler": "^21.2.0",
     "@angular/core": "^21.2.0",
     "@angular/platform-browser": "^21.2.0",
-    "@domternal/angular": "^0.6.1",
-    "@domternal/core": "^0.6.1",
-    "@domternal/theme": "^0.6.1",
+    "@domternal/angular": "^0.6.2",
+    "@domternal/core": "^0.6.2",
+    "@domternal/theme": "^0.6.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/examples/core-ui/package.json
+++ b/examples/core-ui/package.json
@@ -13,7 +13,7 @@
     "vite": "^8.0.0"
   },
   "dependencies": {
-    "@domternal/core": "^0.6.1",
-    "@domternal/theme": "^0.6.1"
+    "@domternal/core": "^0.6.2",
+    "@domternal/theme": "^0.6.2"
   }
 }

--- a/examples/core/package.json
+++ b/examples/core/package.json
@@ -13,6 +13,6 @@
     "vite": "^8.0.0"
   },
   "dependencies": {
-    "@domternal/core": "^0.6.1"
+    "@domternal/core": "^0.6.2"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@domternal/core": "^0.6.1",
-    "@domternal/theme": "^0.6.1",
-    "@domternal/react": "^0.6.1",
+    "@domternal/core": "^0.6.2",
+    "@domternal/theme": "^0.6.2",
+    "@domternal/react": "^0.6.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -11,9 +11,9 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
-    "@domternal/core": "^0.6.1",
-    "@domternal/theme": "^0.6.1",
-    "@domternal/vue": "^0.6.1",
+    "@domternal/core": "^0.6.2",
+    "@domternal/theme": "^0.6.2",
+    "@domternal/vue": "^0.6.2",
     "vue": "^3.5.31"
   },
   "devDependencies": {

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -135,7 +135,8 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
         } else {
           // Auto/items mode: show when any endpoint's parent allows marks
           shouldShowFn = ({ state }: { state: { selection: SelectionShape } }) => {
-            if (state.selection.empty || state.selection.node) return false;
+            if (state.selection.empty) return false;
+            if (state.selection.node) return this.bubbleDefaults.has(state.selection.node.type.name);
             if (isInsideTableCell(state.selection.$from)) return false;
             return state.selection.$from.parent.type.spec.marks !== ''
                 || state.selection.$to.parent.type.spec.marks !== '';
@@ -327,10 +328,21 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
       this.resolvedItems.set(this.resolveNames(['bold', 'italic', 'underline']));
     }
 
+    const defaultItems = this.items()
+      ? this.resolveNames(this.items()!)
+      : this.resolveNames(['bold', 'italic', 'underline']);
+
     this.transactionHandler = () => {
       this.ngZone.run(() => {
         if (this.contexts()) {
           this.updateContextItems(editor);
+        } else {
+          const sel = editor.state.selection as unknown as SelectionShape;
+          if (sel.node && this.bubbleDefaults.has(sel.node.type.name)) {
+            this.resolvedItems.set(this.bubbleDefaults.get(sel.node.type.name) ?? []);
+          } else {
+            this.resolvedItems.set(defaultItems);
+          }
         }
         this.updateStates(editor);
         this.activeVersion.update(v => v + 1);

--- a/packages/extension-emoji/src/Emoji.test.ts
+++ b/packages/extension-emoji/src/Emoji.test.ts
@@ -50,6 +50,7 @@ describe('Emoji', () => {
         plainText: false,
         HTMLAttributes: {},
         suggestion: null,
+        toolbar: true,
       });
     });
 
@@ -78,6 +79,15 @@ describe('Emoji', () => {
       ];
       const Custom = Emoji.configure({ emojis: custom });
       expect(Custom.options.emojis).toBe(custom);
+    });
+
+    it('defaults toolbar to true', () => {
+      expect(Emoji.options.toolbar).toBe(true);
+    });
+
+    it('can configure toolbar to false', () => {
+      const Custom = Emoji.configure({ toolbar: false });
+      expect(Custom.options.toolbar).toBe(false);
     });
   });
 
@@ -893,6 +903,23 @@ describe('Emoji addToolbarItems', () => {
     const button = items?.[0];
     if (button?.type === 'button') {
       expect(button.emitEvent).toBe('insertEmoji');
+    }
+  });
+
+  it('sets toolbar flag to true by default', () => {
+    const items = Emoji.config.addToolbarItems?.call(Emoji);
+    const button = items?.[0];
+    if (button?.type === 'button') {
+      expect(button.toolbar).toBe(true);
+    }
+  });
+
+  it('sets toolbar flag to false when configured with toolbar: false', () => {
+    const Custom = Emoji.configure({ toolbar: false });
+    const items = Custom.config.addToolbarItems?.call(Custom);
+    const button = items?.[0];
+    if (button?.type === 'button') {
+      expect(button.toolbar).toBe(false);
     }
   });
 });

--- a/packages/extension-emoji/src/Emoji.ts
+++ b/packages/extension-emoji/src/Emoji.ts
@@ -52,6 +52,8 @@ export interface EmojiOptions {
   HTMLAttributes: Record<string, unknown>;
   /** Suggestion plugin config for autocomplete picker. Default: null (disabled). */
   suggestion: SuggestionOptions | null;
+  /** Show emoji button in toolbar. Default: true. Set to false for vanilla setups without a picker component. */
+  toolbar: boolean;
 }
 
 export interface EmojiStorage {
@@ -108,6 +110,7 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
       enableEmoticons: false,
       plainText: false,
       HTMLAttributes: {},
+      toolbar: true,
       suggestion: null,
     };
   },
@@ -226,6 +229,7 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
         group: 'insert',
         priority: 50,
         emitEvent: 'insertEmoji',
+        toolbar: this.options.toolbar,
       },
     ];
   },

--- a/packages/react/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/react/src/bubble-menu/useBubbleMenu.ts
@@ -193,7 +193,8 @@ export function useBubbleMenu(options: UseBubbleMenuOptions) {
         };
       } else {
         shouldShowFn = ({ state }: { state: { selection: SelectionShape } }) => {
-          if (state.selection.empty || state.selection.node) return false;
+          if (state.selection.empty) return false;
+          if (state.selection.node) return bubbleDefaults.has(state.selection.node.type.name);
           if (isInsideTableCell(state.selection.$from)) return false;
           return state.selection.$from.parent.type.spec.marks !== ''
             || state.selection.$to.parent.type.spec.marks !== '';
@@ -243,10 +244,19 @@ export function useBubbleMenu(options: UseBubbleMenuOptions) {
       }
     };
 
+    const defaultItems = items ? resolveNames(items) : resolveNames(['bold', 'italic', 'underline']);
+
     // Transaction handler
     const transactionHandler = () => {
       if (contexts) {
         updateContextItems(editor, contexts, detectContext, resolveNames, getFormatItems, filterBySchema, bubbleDefaults, setItems);
+      } else {
+        const sel = editor.state.selection as unknown as SelectionShape;
+        if (sel.node && bubbleDefaults.has(sel.node.type.name)) {
+          setItems(bubbleDefaults.get(sel.node.type.name) ?? []);
+        } else {
+          setItems(defaultItems);
+        }
       }
       updateStates(editor);
       setActiveVersion(v => v + 1);

--- a/packages/vue/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/useBubbleMenu.ts
@@ -202,7 +202,8 @@ export function useBubbleMenu(options: UseBubbleMenuOptions) {
         };
       } else {
         shouldShowFn = ({ state }: { state: { selection: SelectionShape } }) => {
-          if (state.selection.empty || state.selection.node) return false;
+          if (state.selection.empty) return false;
+          if (state.selection.node) return bubbleDefaults.has(state.selection.node.type.name);
           if (isInsideTableCell(state.selection.$from)) return false;
           return state.selection.$from.parent.type.spec.marks !== ''
             || state.selection.$to.parent.type.spec.marks !== '';
@@ -252,10 +253,19 @@ export function useBubbleMenu(options: UseBubbleMenuOptions) {
       }
     };
 
+    const defaultItems = items ? resolveNames(items) : resolveNames(['bold', 'italic', 'underline']);
+
     // Transaction handler
     const transactionHandler = () => {
       if (contexts) {
         updateContextItems(ed, contexts, detectContext, resolveNames, getFormatItems, filterBySchema, bubbleDefaults, setItems);
+      } else {
+        const sel = ed.state.selection as unknown as SelectionShape;
+        if (sel.node && bubbleDefaults.has(sel.node.type.name)) {
+          setItems(bubbleDefaults.get(sel.node.type.name) ?? []);
+        } else {
+          setItems(defaultItems);
+        }
       }
       updateStates(ed);
       activeVersion.value++;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,41 +260,41 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@25.2.3)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.55.1)(sass@1.97.3)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.2.1)
       '@domternal/angular':
-        specifier: 0.6.0
-        version: 0.6.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.0(linkedom@0.18.12))
+        specifier: 0.6.2
+        version: 0.6.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.2(linkedom@0.18.12))
       '@domternal/core':
-        specifier: 0.6.0
-        version: 0.6.0(linkedom@0.18.12)
+        specifier: 0.6.2
+        version: 0.6.2(linkedom@0.18.12)
       '@domternal/extension-code-block-lowlight':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)(lowlight@3.3.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)(lowlight@3.3.0)
       '@domternal/extension-details':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)
       '@domternal/extension-emoji':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)
       '@domternal/extension-image':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)
       '@domternal/extension-mention':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)
       '@domternal/extension-table':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)
       '@domternal/pm':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.6.2
+        version: 0.6.2
       '@domternal/react':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@domternal/theme':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.6.2
+        version: 0.6.2
       '@domternal/vue':
-        specifier: 0.6.0
-        version: 0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
+        specifier: 0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@8.0.7(@types/node@25.2.3)(esbuild@0.27.4)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(yaml@2.8.2))
@@ -330,14 +330,14 @@ importers:
         specifier: ^21.2.5
         version: 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))
       '@domternal/angular':
-        specifier: ^0.6.1
-        version: 0.6.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.1(linkedom@0.18.12))
+        specifier: ^0.6.2
+        version: 0.6.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.2(linkedom@0.18.12))
       '@domternal/core':
-        specifier: ^0.6.1
-        version: 0.6.1(linkedom@0.18.12)
+        specifier: ^0.6.2
+        version: 0.6.2(linkedom@0.18.12)
       '@domternal/theme':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       rxjs:
         specifier: ~7.8.0
         version: 7.8.2
@@ -370,8 +370,8 @@ importers:
   examples/core:
     dependencies:
       '@domternal/core':
-        specifier: ^0.6.1
-        version: 0.6.1(linkedom@0.18.12)
+        specifier: ^0.6.2
+        version: 0.6.2(linkedom@0.18.12)
     devDependencies:
       typescript:
         specifier: ~5.9.3
@@ -383,11 +383,11 @@ importers:
   examples/core-ui:
     dependencies:
       '@domternal/core':
-        specifier: ^0.6.1
-        version: 0.6.1(linkedom@0.18.12)
+        specifier: ^0.6.2
+        version: 0.6.2(linkedom@0.18.12)
       '@domternal/theme':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
     devDependencies:
       typescript:
         specifier: ~5.9.3
@@ -399,14 +399,14 @@ importers:
   examples/react:
     dependencies:
       '@domternal/core':
-        specifier: ^0.6.1
-        version: 0.6.1(linkedom@0.18.12)
+        specifier: ^0.6.2
+        version: 0.6.2(linkedom@0.18.12)
       '@domternal/react':
-        specifier: ^0.6.1
-        version: 0.6.1(@domternal/core@0.6.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@domternal/theme':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -454,14 +454,14 @@ importers:
   examples/vue:
     dependencies:
       '@domternal/core':
-        specifier: ^0.6.1
-        version: 0.6.1(linkedom@0.18.12)
+        specifier: ^0.6.2
+        version: 0.6.2(linkedom@0.18.12)
       '@domternal/theme':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       '@domternal/vue':
-        specifier: ^0.6.1
-        version: 0.6.1(@domternal/core@0.6.1(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))
+        specifier: ^0.6.2
+        version: 0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))
       vue:
         specifier: ^3.5.31
         version: 3.5.32(typescript@6.0.2)
@@ -1679,22 +1679,15 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@domternal/angular@0.6.0':
-    resolution: {integrity: sha512-7tojao0xfKUJvoL7jEyhRzkhkz+nlTnX7y71LrFFWpYGrwVJ8G93A5SsNz6ya0VBfYJAhP7urklKc3Q6agbfjA==}
-    peerDependencies:
-      '@angular/core': ^21.2.5
-      '@angular/forms': ^21.2.5
-      '@domternal/core': '>=0.6.0'
-
-  '@domternal/angular@0.6.1':
-    resolution: {integrity: sha512-y5Ytm2/v6N8WeezrH76saq//uPVW8tAsH9yQE4DFihVR+LkK1hFtNxRM+kfHudT/AQIRvA9haGPhm8w5bXns7w==}
+  '@domternal/angular@0.6.2':
+    resolution: {integrity: sha512-K662LcdMHXm10l6T39Z38H/Qj/BEORYbEhOzzMt/syijJtylA4AH9mxN5ZbxCwLLpt0Vjk6kvkKGNx14mj+evw==}
     peerDependencies:
       '@angular/core': ^21.2.5
       '@angular/forms': ^21.2.5
       '@domternal/core': '>=0.6.1'
 
-  '@domternal/core@0.6.0':
-    resolution: {integrity: sha512-5Hb6qUzrUf6fLY8gXx4L6jrzrkLQVdWq70TsH2UhuKIPnmy2ZVzJycsNQk/Eow5bWhmd2mbz03X3NjBsaU8Q9Q==}
+  '@domternal/core@0.6.2':
+    resolution: {integrity: sha512-64KqeNBupxrPWuUsOa3eOGYVrJ+vhObKRyMXx79+6vtT1pwstRnxlG9Q+xnj6m6L4kdpM2+FARQuxjgB7m48SA==}
     engines: {node: '>=20'}
     peerDependencies:
       linkedom: ^0.18.0
@@ -1702,94 +1695,66 @@ packages:
       linkedom:
         optional: true
 
-  '@domternal/core@0.6.1':
-    resolution: {integrity: sha512-B4X4nbgnjr0hJ9UuOSnz6Q0itbtUejn8zWjNymzUT5tLGSwggimul/IdMCjpi2PFIMQLDYaAxinAp3dy00aAZw==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      linkedom: ^0.18.0
-    peerDependenciesMeta:
-      linkedom:
-        optional: true
-
-  '@domternal/extension-code-block-lowlight@0.6.0':
-    resolution: {integrity: sha512-C1BS1FyRJkM0fg8Ls8vuJMLE0b0gLTS/rmURn5q1baKhXy1x5eJ9jjaXgSxFiHGDr1TFjzvJAnf00kfemiHC2A==}
+  '@domternal/extension-code-block-lowlight@0.6.2':
+    resolution: {integrity: sha512-X5KmvBn8qK+G9aQSP1PTT0p9Bmnn3Pi8Dh5d+a+wg9Akyr/l+td3SQI4GFeO33LSDOB5m8RjYSBSzNTfPfg6QA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
       lowlight: ^3.0.0
 
-  '@domternal/extension-details@0.6.0':
-    resolution: {integrity: sha512-AY/9oAUTS5rfDDfzQ7R5jh5wWwvV8Gn9wk8vMBBwJNbo2yiV9MG5jzfCpPNqm2j+CJxFvccuWNUSCrqIXI/7vg==}
+  '@domternal/extension-details@0.6.2':
+    resolution: {integrity: sha512-U20J8YB4cwtLrs/bRbFUnrygx3EdBGIh/TurFKo6UcdrHgNN3dq0rVr/2Wo3JUHWEAIdSTlcgVPir9K/+ppDgQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
 
-  '@domternal/extension-emoji@0.6.0':
-    resolution: {integrity: sha512-QFsbZEmPgBE74hznQXoxFdgdwuz9szXG+cxF5TlmAMfvHoDSRWij+YA7nTAbVmHjZx4BmMdt8h9bncWlwkNO3g==}
+  '@domternal/extension-emoji@0.6.2':
+    resolution: {integrity: sha512-uR+m1se3ND3lJn+wRqaq6apDfxyc6ZiyvDwisd7J1Pa2BhtibiIDMvv/Lisoj+nQl8tKLSzML8OM7Jx1G3+OzA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
 
-  '@domternal/extension-image@0.6.0':
-    resolution: {integrity: sha512-keHXkFRyxCZOsEttpIJpNXlzQQaDt+bdR+m3TxT+f4Lg30sEigCUXvhN3+rKGsNFtHs9mmAdZa/+5MmPaf1TaQ==}
+  '@domternal/extension-image@0.6.2':
+    resolution: {integrity: sha512-UUKIumHUCmuouPhNYFw6CD/IIyTbC5g3A4eaVu7cEK5Ci4/cBeXPpMqiuVGlZEm9KPK4J7mxDKPVM+OHHvE6tQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
 
-  '@domternal/extension-mention@0.6.0':
-    resolution: {integrity: sha512-smH39D/iMEg3j2wdaewhOovys45F5NSVU4LFqQ38SrOFx2GFU81A0ZVKt1c+Fg7BHktB+qoXEp58Mb1hr0ibqg==}
+  '@domternal/extension-mention@0.6.2':
+    resolution: {integrity: sha512-QynXydB8tTMbU1p5j9FGSX5i/RHoCig3TYp47mf2rRlt6oyqMLYLXuKpZmSNrJFsCyWXmagBxhBuX13dCDGiGg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
 
-  '@domternal/extension-table@0.6.0':
-    resolution: {integrity: sha512-NOrrY4P8Dw5xI31X2fPvpl/i4cAzfY/gYoB/XFLqw7TjiuFBYiStoO/0hoTuaEkm6exZDH2iy70Yz4PPrF5AoQ==}
+  '@domternal/extension-table@0.6.2':
+    resolution: {integrity: sha512-gRidJ7YSB7EeansBxeEaC6iDgzAu/bLxEUdFXU5VSxmU8kn4QSDPbV+n7CGL9WBtisplIUb5SXSuLJ3SL3i1pw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       '@domternal/pm': '>=0.6.0'
 
-  '@domternal/pm@0.6.0':
-    resolution: {integrity: sha512-5OoCrU/VWEB/PIlKz0ojcq8+6mCFynKDbJ/m+JUD1yJm7jiqThxG++55hQtL0Nun6Bf/kptX9dDKlmf2IUWpUw==}
+  '@domternal/pm@0.6.2':
+    resolution: {integrity: sha512-YNwsVrc8M8PsNEnpmW4CXI7UB1XWlv9Fh1+p0wgg0KxQgDcicnhETtqszo0dIwxb8wDlFJ/QjXUPRALb0uYiMw==}
 
-  '@domternal/pm@0.6.1':
-    resolution: {integrity: sha512-Lb91HDavGmKIYB5mIlq260wuvL3PZa3D2LsaflFNiLzCJDRPqRXqp4gJkhMdvdKOD7bAwtZiMwM01jqsF4i/HA==}
-
-  '@domternal/react@0.6.0':
-    resolution: {integrity: sha512-T9y8AcSG0xCqEGTGRge6a8C93HAKN9sUiRoz9Rv0SU6ylcWTYKKszoNNo61hSBcxpVngh8Z/gIXI5neupcX9xw==}
+  '@domternal/react@0.6.2':
+    resolution: {integrity: sha512-GizlpiGzqvb7cGKEzVdUNH3kJoV8DT++xDDwToD8BLMjFf+jPdrY8DwJL+GoXdMPrrYUdsgFjWXTsZ/NLy8cfQ==}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
       react: '>=18'
       react-dom: '>=18'
 
-  '@domternal/react@0.6.1':
-    resolution: {integrity: sha512-ddUriV5K875q6ZyAdcEIUwCZu0oI+vEGTaAfHy8se/P9fKfAIhVQrp+QSTpKF/PqqbhNsJeo/YGLWAQTsszvEA==}
-    peerDependencies:
-      '@domternal/core': '>=0.6.1'
-      react: '>=18'
-      react-dom: '>=18'
+  '@domternal/theme@0.6.2':
+    resolution: {integrity: sha512-dOezxQwmakDBpx6sgwr6tGL/DP55Pu+NNDVsgUa5guTsYaWi7NS5LI0ymCdoSWnLI40oqKYClOo33ZPF4JB/Og==}
 
-  '@domternal/theme@0.6.0':
-    resolution: {integrity: sha512-fd1M2rpOOwWoS6od/g/H0Fi0PotMT5dZHQqXzrJzWgC7yAzfBCRpWr5MirK+fte8mKUXsoO0QJlRXGjbQHg9sg==}
-
-  '@domternal/theme@0.6.1':
-    resolution: {integrity: sha512-Il2rSrnF0vDgZGFc1kcc+vbDajNPq6lgHCmKFhb65cYZMvHKCC3xGxU/A/Ot3KfjccGX7VUBOsw9H0KSrfluSw==}
-
-  '@domternal/vue@0.6.0':
-    resolution: {integrity: sha512-5UKAnZMfz20Ukz9WD297fPQeTbkDzJT/Mv3aLy6acYsZd4wsDQWOmigyj094wfoP17/DaJAmAhFDsjgv2ozXUQ==}
+  '@domternal/vue@0.6.2':
+    resolution: {integrity: sha512-JeCCOaiorlFx29+ya7O+MN9mP/T5abnl03foCVAOrxMA/U7GhORgr3RtIRtgTDj8UkelLflR2qjcWq9fOdCCnA==}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
-      vue: '>=3.3'
-
-  '@domternal/vue@0.6.1':
-    resolution: {integrity: sha512-fV8eKHqXWPmJUnIRQ8QYwZX6xbu5lEIa7snJpkJ97Ajenc2T95UWqCAjR748hlfKNYIZ1+6jLxS2Afcjhrvigg==}
-    peerDependencies:
-      '@domternal/core': '>=0.6.1'
       vue: '>=3.3'
 
   '@emnapi/core@1.8.1':
@@ -9676,84 +9641,54 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@domternal/angular@0.6.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.0(linkedom@0.18.12))':
+  '@domternal/angular@0.6.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.2(linkedom@0.18.12))':
     dependencies:
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/forms': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
       tslib: 2.8.1
 
-  '@domternal/angular@0.6.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.1(linkedom@0.18.12))':
+  '@domternal/core@0.6.2(linkedom@0.18.12)':
     dependencies:
-      '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/forms': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@domternal/core': 0.6.1(linkedom@0.18.12)
-      tslib: 2.8.1
-
-  '@domternal/core@0.6.0(linkedom@0.18.12)':
-    dependencies:
-      '@domternal/pm': 0.6.0
+      '@domternal/pm': 0.6.2
       '@floating-ui/dom': 1.7.5
       linkifyjs: 4.3.2
     optionalDependencies:
       linkedom: 0.18.12
 
-  '@domternal/core@0.6.1(linkedom@0.18.12)':
+  '@domternal/extension-code-block-lowlight@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)(lowlight@3.3.0)':
     dependencies:
-      '@domternal/pm': 0.6.1
-      '@floating-ui/dom': 1.7.5
-      linkifyjs: 4.3.2
-    optionalDependencies:
-      linkedom: 0.18.12
-
-  '@domternal/extension-code-block-lowlight@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)(lowlight@3.3.0)':
-    dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
       hast-util-to-html: 9.0.5
       lowlight: 3.3.0
 
-  '@domternal/extension-details@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)':
+  '@domternal/extension-details@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
 
-  '@domternal/extension-emoji@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)':
+  '@domternal/extension-emoji@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
 
-  '@domternal/extension-image@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)':
+  '@domternal/extension-image@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
 
-  '@domternal/extension-mention@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)':
+  '@domternal/extension-mention@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
 
-  '@domternal/extension-table@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(@domternal/pm@0.6.0)':
+  '@domternal/extension-table@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(@domternal/pm@0.6.2)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
-      '@domternal/pm': 0.6.0
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
+      '@domternal/pm': 0.6.2
 
-  '@domternal/pm@0.6.0':
-    dependencies:
-      prosemirror-commands: 1.7.1
-      prosemirror-dropcursor: 1.8.2
-      prosemirror-gapcursor: 1.4.0
-      prosemirror-history: 1.5.0
-      prosemirror-inputrules: 1.5.1
-      prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.4
-      prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.4
-      prosemirror-tables: 1.8.5
-      prosemirror-transform: 1.10.5
-      prosemirror-view: 1.41.5
-
-  '@domternal/pm@0.6.1':
+  '@domternal/pm@0.6.2':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-dropcursor: 1.8.2
@@ -9768,30 +9703,22 @@ snapshots:
       prosemirror-transform: 1.10.5
       prosemirror-view: 1.41.5
 
-  '@domternal/react@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@domternal/react@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@domternal/react@0.6.1(@domternal/core@0.6.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@domternal/theme@0.6.2': {}
+
+  '@domternal/vue@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      '@domternal/core': 0.6.1(linkedom@0.18.12)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@domternal/theme@0.6.0': {}
-
-  '@domternal/theme@0.6.1': {}
-
-  '@domternal/vue@0.6.0(@domternal/core@0.6.0(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@domternal/core': 0.6.0(linkedom@0.18.12)
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
       vue: 3.5.32(typescript@5.9.3)
 
-  '@domternal/vue@0.6.1(@domternal/core@0.6.1(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))':
+  '@domternal/vue@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))':
     dependencies:
-      '@domternal/core': 0.6.1(linkedom@0.18.12)
+      '@domternal/core': 0.6.2(linkedom@0.18.12)
       vue: 3.5.32(typescript@6.0.2)
 
   '@emnapi/core@1.8.1':


### PR DESCRIPTION
## Summary
Two small improvements across framework wrappers: the image bubble menu now appears by default when the Image extension is loaded, and the emoji toolbar button can be hidden via a new `toolbar` option.

## Changes
- **`@domternal/angular`, `@domternal/react`, `@domternal/vue`**: Image bubble menu is now shown by default when the Image extension is loaded - consumers no longer need to configure it manually in all three framework wrappers.
- **`@domternal/extension-emoji`**: Added `toolbar` option (default `true`) to hide the emoji button from the main toolbar while keeping the `:` suggestion trigger working.

## Features
- New `Emoji.configure({ toolbar: false })` option to hide the emoji button from toolbar layouts.

## What
Image bubble menu previously required manual opt-in across all three framework wrappers, leading to confusion when users loaded the Image extension but didn't see the popover. Emoji button lacked a way to be removed from the toolbar without dropping the whole extension.

## Verified
- Built all packages (`pnpm build`)
- Ran unit tests (`pnpm test`)
- Typecheck passed (`pnpm typecheck`)
- Tested image bubble menu visibility in `demo-angular`, `demo-react`, `demo-vue`
- Verified emoji toolbar hide option in demo apps