### PR TITLE
ci: Codecov integration, publint + Nx e2e setup, playwright port fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Validate packages
         run: |
-          for pkg in packages/pm packages/core packages/theme packages/angular packages/extension-table packages/extension-image packages/extension-emoji packages/extension-mention packages/extension-details packages/extension-code-block-lowlight; do
+          for pkg in packages/pm packages/core packages/theme packages/angular packages/react packages/vue packages/extension-table packages/extension-image packages/extension-emoji packages/extension-mention packages/extension-details packages/extension-code-block-lowlight; do
             echo "--- Validating $pkg ---"
             cd "$pkg"
             npx publint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,22 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Test
-        run: pnpm test
+      - name: Test with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          files: >-
+            ./packages/core/coverage/lcov.info,
+            ./packages/extension-code-block-lowlight/coverage/lcov.info,
+            ./packages/extension-details/coverage/lcov.info,
+            ./packages/extension-emoji/coverage/lcov.info,
+            ./packages/extension-image/coverage/lcov.info,
+            ./packages/extension-mention/coverage/lcov.info,
+            ./packages/extension-table/coverage/lcov.info
 
       - name: Validate packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,11 @@ jobs:
             cd "$pkg"
             npx publint
             if [ "$pkg" != "packages/theme" ] && [ "$pkg" != "packages/angular" ]; then
-              npx @arethetypeswrong/cli --pack
+              if [ "$pkg" = "packages/react" ] || [ "$pkg" = "packages/vue" ]; then
+                npx @arethetypeswrong/cli --pack --profile esm-only
+              else
+                npx @arethetypeswrong/cli --pack
+              fi
             fi
             cd "$GITHUB_WORKSPACE"
           done

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A lightweight, extensible rich text editor toolkit built on [ProseMirror](https:
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/domternal/domternal/actions/workflows/ci.yml/badge.svg)](https://github.com/domternal/domternal/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/domternal/domternal/graph/badge.svg)](https://codecov.io/gh/domternal/domternal)
 [![npm](https://img.shields.io/npm/v/@domternal/core.svg?label=%40domternal%2Fcore)](https://www.npmjs.com/package/@domternal/core)
 
 **[Website](https://domternal.dev)** · **[Getting Started](https://domternal.dev/v1/getting-started)** · **[Packages & Bundle Size](https://domternal.dev/v1/packages)**

--- a/apps/demo-vue/playwright.config.ts
+++ b/apps/demo-vue/playwright.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 30000,
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:5174',
     headless: true,
   },
   webServer: {
-    command: 'pnpm build && pnpm preview --port 5173',
-    url: 'http://localhost:5173',
+    command: 'pnpm build && pnpm preview --port 5174',
+    url: 'http://localhost:5174',
     reuseExistingServer: true,
     timeout: 120000,
   },

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,52 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+comment:
+  layout: "header, diff, flags, components, footer"
+  behavior: default
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: core
+      paths:
+        - packages/core/src/
+    - name: extension-code-block-lowlight
+      paths:
+        - packages/extension-code-block-lowlight/src/
+    - name: extension-details
+      paths:
+        - packages/extension-details/src/
+    - name: extension-emoji
+      paths:
+        - packages/extension-emoji/src/
+    - name: extension-image
+      paths:
+        - packages/extension-image/src/
+    - name: extension-mention
+      paths:
+        - packages/extension-mention/src/
+    - name: extension-table
+      paths:
+        - packages/extension-table/src/
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/index.ts"
+  - "packages/*/src/types/"
+  - "packages/*/src/icons/index.ts"
+  - "apps/"
+  - "examples/"
+  - "domternal.dev/"

--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,9 @@
     },
     "typecheck": {
       "dependsOn": ["^build"]
+    },
+    "test:e2e": {
+      "dependsOn": ["^build"]
     }
   },
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "nx run-many --target=build --all",
     "dev": "nx run-many --target=dev --all",
     "test": "nx run-many --target=test --all",
+    "test:e2e": "nx run-many --target=test:e2e --all",
     "lint": "nx run-many --target=lint --all",
     "typecheck": "nx run-many --target=typecheck --all"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "nx run-many --target=build --all",
     "dev": "nx run-many --target=dev --all",
     "test": "nx run-many --target=test --all",
+    "test:coverage": "nx run-many --target=test --all -- --coverage",
     "test:e2e": "nx run-many --target=test:e2e --all",
     "lint": "nx run-many --target=lint --all",
     "typecheck": "nx run-many --target=typecheck --all"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-code-block-lowlight/vitest.config.ts
+++ b/packages/extension-code-block-lowlight/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-details/vitest.config.ts
+++ b/packages/extension-details/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-emoji/vitest.config.ts
+++ b/packages/extension-emoji/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-image/vitest.config.ts
+++ b/packages/extension-image/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-mention/vitest.config.ts
+++ b/packages/extension-mention/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },

--- a/packages/extension-table/vitest.config.ts
+++ b/packages/extension-table/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
     },


### PR DESCRIPTION
## Summary
CI/infrastructure improvements: Codecov integration for coverage tracking, expanded publint validation to cover react/vue packages, wiring `test:e2e` target to rebuild framework dist via Nx, and resolving a playwright port collision between demo-react and demo-vue.

## Changes
- **Codecov integration**
  - Added `codecov/codecov-action@v5` step to CI workflow uploading per-package `lcov.info`
  - New `codecov.yml` with individual flags for each package (`core`, `extension-emoji`, `extension-image`, `extension-table`, `extension-details`, `extension-mention`, `extension-code-block-lowlight`)
  - All 7 vitest configs now emit `lcov` + `json-summary` reporters alongside existing `text` + `html`
  - New `pnpm test:coverage` root script (`nx run-many --target=test --all -- --coverage`)
  - Codecov badge added to README.md
- **publint validation**
  - Added `packages/react` and `packages/vue` to the validation loop (previously missing)
- **Nx test:e2e dependency graph**
  - New `test:e2e: { dependsOn: ['^build'] }` target default in `nx.json`
  - Running `nx run demo-angular:test:e2e` (or `pnpm test:e2e` at root) now rebuilds framework wrapper packages before running playwright
- **Playwright port conflict**
  - demo-vue `playwright.config.ts` switched from port `5173` to `5174`
  - Resolves collision with demo-react (both previously bound to 5173, causing parallel `nx run-many --target=test:e2e` to fail)

## Features
- Codecov PR comments on every PR (coverage delta, uncovered new lines, per-flag breakdown)
- Codecov badge in README showing live project coverage percentage
- Monorepo-wide `pnpm test:coverage` command that writes Codecov-ready reports

## What
- Coverage was previously local-only via `pnpm vitest run --coverage` in each package. No shared dashboard, no CI visibility, no PR-level regression alerts. Codecov fills this gap at no cost for public repos.
- `publint` was validating 10 of 12 publishable packages. `react` and `vue` were silently skipped, meaning broken `exports`/`types` fields could ship undetected.
- `pnpm test:e2e` (and individual `nx run demo-*:test:e2e` commands) relied on stale `packages/{angular,react,vue}/dist/` from a prior build. When a wrapper source changed without a rebuild, E2E tests would run against old dist silently. Nx task graph now enforces freshness.
- demo-react and demo-vue both bound to `5173`, so `nx run-many --target=test:e2e --all` (default parallel execution) would have one demo fail on port collision.

## Verified
- `pnpm test:coverage` runs locally, generates `lcov.info` + `coverage-summary.json` in all 7 packages
- All existing tests pass (no test logic changes)
- `nx show project demo-{angular,react,vue}` confirms `test:e2e` target has `dependsOn: ["^build"]`
- demo-vue playwright config uses port 5174 (verified no other references to 5173 remain)
- CODECOV_TOKEN secret configured on the repo; Codecov will auto-discover and comment on this PR after first CI run