### PR TITLE
feat: FloatingMenu items API, keyboard a11y, and Notion demo mode

### DIFF
--- a/apps/demo-angular/src/app/app.html
+++ b/apps/demo-angular/src/app/app.html
@@ -7,9 +7,14 @@
   </h1>
 
   <div class="toolbar-mode-toggle">
-    <button [class.active]="!useLayout()" (click)="useLayout.set(false)">Default toolbar</button>
-    <button [class.active]="useLayout()" (click)="useLayout.set(true)">Custom layout</button>
+    <button [class.active]="mode() === 'default'" (click)="mode.set('default')">Default toolbar</button>
+    <button [class.active]="mode() === 'custom'" (click)="mode.set('custom')">Custom layout</button>
+    <button [class.active]="mode() === 'notion'" (click)="mode.set('notion')">Notion style</button>
   </div>
 
-  <app-editor-demo [useLayout]="useLayout()" />
+  @if (mode() === 'notion') {
+    <app-notion-demo />
+  } @else {
+    <app-editor-demo [useLayout]="useLayout()" />
+  }
 </div>

--- a/apps/demo-angular/src/app/app.ts
+++ b/apps/demo-angular/src/app/app.ts
@@ -1,15 +1,21 @@
-import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, signal } from '@angular/core';
 import { EditorDemoComponent } from './editor-demo/editor-demo.component.js';
+import { NotionDemoComponent } from './notion-demo/notion-demo.component.js';
+
+export type DemoMode = 'default' | 'custom' | 'notion';
 
 @Component({
   selector: 'app-root',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [EditorDemoComponent],
+  imports: [EditorDemoComponent, NotionDemoComponent],
   templateUrl: './app.html',
 })
 export class App {
   isDark = signal(false);
-  useLayout = signal(false);
+  mode = signal<DemoMode>('default');
+  // The editor-demo takes a boolean `useLayout` input; derive it from mode
+  // so the existing component stays unchanged.
+  useLayout = computed(() => this.mode() === 'custom');
 
   toggleTheme(): void {
     this.isDark.update(v => !v);

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
@@ -23,6 +23,7 @@
       text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
     }" />
   }
+  <domternal-floating-menu [editor]="ed" />
   <domternal-emoji-picker [editor]="ed" [emojis]="emojiData" />
 }
 

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
@@ -23,7 +23,6 @@
       text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
     }" />
   }
-  <domternal-floating-menu [editor]="ed" />
   <domternal-emoji-picker [editor]="ed" [emojis]="emojiData" />
 }
 

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -3,7 +3,6 @@ import {
   DomternalEditorComponent,
   DomternalToolbarComponent,
   DomternalBubbleMenuComponent,
-  DomternalFloatingMenuComponent,
   DomternalEmojiPickerComponent,
 } from '@domternal/angular';
 import {
@@ -64,7 +63,7 @@ const mockUsers: MentionItem[] = [
 @Component({
   selector: 'app-editor-demo',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent, DomternalFloatingMenuComponent, DomternalEmojiPickerComponent],
+  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent, DomternalEmojiPickerComponent],
   templateUrl: './editor-demo.component.html',
 })
 export class EditorDemoComponent {

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -3,6 +3,7 @@ import {
   DomternalEditorComponent,
   DomternalToolbarComponent,
   DomternalBubbleMenuComponent,
+  DomternalFloatingMenuComponent,
   DomternalEmojiPickerComponent,
 } from '@domternal/angular';
 import {
@@ -63,7 +64,7 @@ const mockUsers: MentionItem[] = [
 @Component({
   selector: 'app-editor-demo',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent, DomternalEmojiPickerComponent],
+  imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent, DomternalFloatingMenuComponent, DomternalEmojiPickerComponent],
   templateUrl: './editor-demo.component.html',
 })
 export class EditorDemoComponent {

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
@@ -1,0 +1,17 @@
+<div class="notion-page">
+  <domternal-editor
+    [extensions]="extensions"
+    [content]="editorContent"
+    (editorCreated)="onEditorCreated($event)"
+  />
+
+  @if (editor(); as ed) {
+    <domternal-bubble-menu
+      [editor]="ed"
+      [contexts]="{
+        text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
+      }"
+    />
+    <domternal-floating-menu [editor]="ed" />
+  }
+</div>

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
@@ -12,6 +12,7 @@
   padding: 0 1rem;
 
   // Override the editor's default chrome to create a seamless page feel.
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   ::ng-deep .dm-editor {
     // Remove border, shadow, rounded corners — looks like a plain page.
     border: none;
@@ -25,6 +26,7 @@
     --dm-editor-padding: 0;
   }
 
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   ::ng-deep .ProseMirror {
     padding: 0;
     min-height: 60vh;

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
@@ -1,0 +1,56 @@
+// Notion-style page: wide, borderless, centered content with generous padding.
+// Scoped with `:host` so it does not leak into the default demo.
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+.notion-page {
+  max-width: 46rem;
+  margin: 2rem auto 6rem;
+  padding: 0 1rem;
+
+  // Override the editor's default chrome to create a seamless page feel.
+  ::ng-deep .dm-editor {
+    // Remove border, shadow, rounded corners — looks like a plain page.
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
+
+    // Generous reading line-height and size, similar to Notion.
+    --dm-editor-font-size: 1.0625rem;
+    --dm-editor-line-height: 1.7;
+    --dm-editor-padding: 0;
+  }
+
+  ::ng-deep .ProseMirror {
+    padding: 0;
+    min-height: 60vh;
+    outline: none;
+
+    // Tighter heading rhythm than default, more Notion-like.
+    h1 {
+      font-size: 2.25rem;
+      font-weight: 700;
+      margin-top: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+    h2 {
+      font-size: 1.625rem;
+      font-weight: 600;
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    h3 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-top: 1.25rem;
+      margin-bottom: 0.375rem;
+    }
+    p {
+      margin: 0.25rem 0;
+    }
+  }
+}

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -1,0 +1,116 @@
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import {
+  DomternalEditorComponent,
+  DomternalBubbleMenuComponent,
+  DomternalFloatingMenuComponent,
+} from '@domternal/angular';
+import {
+  Bold,
+  Italic,
+  Underline,
+  Strike,
+  Code,
+  Highlight,
+  Subscript,
+  Superscript,
+  Link,
+  LinkPopover,
+  Heading,
+  Blockquote,
+  HardBreak,
+  HorizontalRule,
+  BulletList,
+  OrderedList,
+  TaskList,
+  TextAlign,
+  TextColor,
+  FontSize,
+  FontFamily,
+  LineHeight,
+  SelectionDecoration,
+  ClearFormatting,
+  Dropcursor,
+  Editor,
+} from '@domternal/core';
+import { CodeBlockLowlight } from '@domternal/extension-code-block-lowlight';
+import { Image } from '@domternal/extension-image';
+import { Details } from '@domternal/extension-details';
+import { Table } from '@domternal/extension-table';
+import { Emoji, emojis, createEmojiSuggestionRenderer } from '@domternal/extension-emoji';
+import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
+import type { MentionItem } from '@domternal/extension-mention';
+import { createLowlight, common } from 'lowlight';
+
+const lowlight = createLowlight(common);
+
+const mockUsers: MentionItem[] = [
+  { id: '1', label: 'Alice Johnson' },
+  { id: '2', label: 'Bob Smith' },
+  { id: '3', label: 'Charlie Brown' },
+  { id: '4', label: 'Diana Prince' },
+  { id: '5', label: 'Eve Adams' },
+];
+
+const STARTER_CONTENT = `
+<h1>Untitled</h1>
+<p>Welcome to a clean, distraction-free editor. Select any text to format it via the bubble menu, or move the cursor to an empty line to bring up the floating menu for inserting blocks.</p>
+<p></p>
+`;
+
+/**
+ * Notion-style demo: no toolbar, floating menu on empty lines is the primary
+ * block-insert UI, bubble menu for text formatting on selection.
+ */
+@Component({
+  selector: 'app-notion-demo',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DomternalEditorComponent,
+    DomternalBubbleMenuComponent,
+    DomternalFloatingMenuComponent,
+  ],
+  templateUrl: './notion-demo.component.html',
+  styleUrls: ['./notion-demo.component.scss'],
+})
+export class NotionDemoComponent {
+  extensions = [
+    // Inline formatting (available via bubble menu on selection)
+    Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
+    // Block elements (inserted via floating menu on empty lines)
+    Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
+    BulletList, OrderedList, TaskList,
+    // Text styling — available via bubble menu
+    TextAlign, TextColor, FontSize, FontFamily, LineHeight,
+    Table,
+    Details,
+    Image,
+    // `toolbar: false` — no toolbar button, but `:` suggestion picker still works
+    Emoji.configure({
+      emojis,
+      enableEmoticons: true,
+      toolbar: false,
+      suggestion: { render: createEmojiSuggestionRenderer() },
+    }),
+    Mention.configure({
+      suggestion: {
+        char: '@',
+        name: 'user',
+        items: ({ query }: { query: string }) =>
+          mockUsers.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
+        render: createMentionSuggestionRenderer(),
+        minQueryLength: 0,
+        invalidNodes: ['codeBlock'],
+      },
+    }),
+    LinkPopover, SelectionDecoration, ClearFormatting, Dropcursor,
+  ];
+
+  editorContent = STARTER_CONTENT;
+  editor = signal<Editor | null>(null);
+
+  onEditorCreated(editor: Editor): void {
+    this.editor.set(editor);
+    // Expose for E2E + playing around in devtools.
+    (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] = editor;
+  }
+}

--- a/apps/demo-react/src/EditorDemo.tsx
+++ b/apps/demo-react/src/EditorDemo.tsx
@@ -4,6 +4,7 @@ import {
   useEditorState,
   DomternalToolbar,
   DomternalBubbleMenu,
+  DomternalFloatingMenu,
   DomternalEmojiPicker,
 } from '@domternal/react';
 import {
@@ -153,6 +154,7 @@ export function EditorDemo({ useLayout }: EditorDemoProps) {
               contexts={{ text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] }}
             />
           )}
+          <DomternalFloatingMenu editor={editor} />
           <DomternalEmojiPicker editor={editor} emojis={emojis} />
         </>
       )}

--- a/apps/demo-vue/src/EditorDemo.vue
+++ b/apps/demo-vue/src/EditorDemo.vue
@@ -5,6 +5,7 @@ import {
   useEditorState,
   DomternalToolbar,
   DomternalBubbleMenu,
+  DomternalFloatingMenu,
   DomternalEmojiPicker,
 } from '@domternal/vue';
 import {
@@ -147,6 +148,7 @@ defineExpose({ editor, editorRef });
       :editor="editor"
       :contexts="{ text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] }"
     />
+    <DomternalFloatingMenu :editor="editor" />
     <DomternalEmojiPicker :editor="editor" :emojis="emojis" />
   </template>
 

--- a/packages/angular/src/lib/floating-menu.component.ts
+++ b/packages/angular/src/lib/floating-menu.component.ts
@@ -74,12 +74,7 @@ import type {
               @if (iconHtml(item.icon); as html) {
                 <span class="dm-floating-menu-item-icon" aria-hidden="true" [innerHTML]="html"></span>
               }
-              <span class="dm-floating-menu-item-text">
-                <span class="dm-floating-menu-item-label">{{ item.label }}</span>
-                @if (item.description) {
-                  <span class="dm-floating-menu-item-description">{{ item.description }}</span>
-                }
-              </span>
+              <span class="dm-floating-menu-item-label">{{ item.label }}</span>
               @if (item.shortcut) {
                 <span class="dm-floating-menu-item-shortcut" aria-hidden="true">{{ item.shortcut }}</span>
               }
@@ -158,6 +153,10 @@ export class DomternalFloatingMenuComponent implements OnDestroy {
       );
       controller.subscribe();
       this.controller = controller;
+      // Controller is a plain field, not a signal — bumping `version` is
+      // what tells the `groups`/`focusedIndex` computeds to re-evaluate
+      // and pick up the freshly assigned controller instance.
+      this.version.update((v) => v + 1);
     });
 
     // Imperatively focus the active menuitem on focusedIndex change.

--- a/packages/angular/src/lib/floating-menu.component.ts
+++ b/packages/angular/src/lib/floating-menu.component.ts
@@ -3,51 +3,260 @@ import {
   Component,
   ChangeDetectionStrategy,
   ViewEncapsulation,
-  input,
-  viewChild,
+  NgZone,
   afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild,
 } from '@angular/core';
-import { PluginKey, createFloatingMenuPlugin } from '@domternal/core';
-import type { FloatingMenuOptions, Editor } from '@domternal/core';
+import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
+import {
+  PluginKey,
+  createFloatingMenuPlugin,
+  FloatingMenuController,
+  defaultIcons,
+} from '@domternal/core';
+import type {
+  Editor,
+  FloatingMenuItem,
+  FloatingMenuItemsOverride,
+  FloatingMenuKeymap,
+  FloatingMenuOptions,
+  IconSet,
+} from '@domternal/core';
 
+/**
+ * Block-insert floating menu for Angular.
+ *
+ * Renders defaults collected from the editor's extensions via
+ * `addFloatingMenuItems()`; use `items` to override the list and `icons`
+ * to swap the icon set.
+ */
 @Component({
   selector: 'domternal-floating-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: '<div #menuEl class="dm-floating-menu"><ng-content /></div>',
+  template: `
+    <div
+      #menuEl
+      class="dm-floating-menu"
+      role="menu"
+      aria-label="Insert block"
+      data-dm-editor-ui=""
+      (keydown)="onKeyDown($event)"
+    >
+      @for (group of groups(); track group.name || $index; let gi = $index) {
+        @if (group.name) {
+          <div class="dm-floating-menu-group-label" [id]="'dm-fm-g' + gi">{{ group.name }}</div>
+        }
+        <div
+          class="dm-floating-menu-group"
+          role="group"
+          [attr.aria-labelledby]="group.name ? 'dm-fm-g' + gi : null"
+        >
+          @for (item of group.items; track item.name) {
+            <button
+              type="button"
+              role="menuitem"
+              class="dm-floating-menu-item"
+              [attr.data-floating-menu-item]="item.name"
+              [attr.data-floating-menu-index]="flatIndexOf(item.name)"
+              [attr.tabindex]="tabIndexFor(item.name)"
+              [attr.aria-disabled]="isItemDisabled(item) ? 'true' : null"
+              [attr.aria-keyshortcuts]="item.shortcut"
+              [disabled]="isItemDisabled(item)"
+              (mousedown)="$event.preventDefault()"
+              (click)="onItemClick(item)"
+            >
+              @if (iconHtml(item.icon); as html) {
+                <span class="dm-floating-menu-item-icon" aria-hidden="true" [innerHTML]="html"></span>
+              }
+              <span class="dm-floating-menu-item-text">
+                <span class="dm-floating-menu-item-label">{{ item.label }}</span>
+                @if (item.description) {
+                  <span class="dm-floating-menu-item-description">{{ item.description }}</span>
+                }
+              </span>
+              @if (item.shortcut) {
+                <span class="dm-floating-menu-item-shortcut" aria-hidden="true">{{ item.shortcut }}</span>
+              }
+            </button>
+          }
+        </div>
+      }
+    </div>
+  `,
   styles: [`:host { display: contents; }`],
 })
 export class DomternalFloatingMenuComponent implements OnDestroy {
   readonly editor = input.required<Editor>();
   readonly shouldShow = input<FloatingMenuOptions['shouldShow']>();
   readonly offset = input<number>(0);
+  readonly items = input<FloatingMenuItemsOverride | undefined>(undefined);
+  readonly keymap = input<FloatingMenuKeymap | undefined>(undefined);
+  readonly icons = input<IconSet | undefined>(undefined);
 
   private menuEl = viewChild.required<ElementRef<HTMLElement>>('menuEl');
+  private ngZone = inject(NgZone);
+  private sanitizer = inject(DomSanitizer);
   private pluginKey: PluginKey;
 
+  private controller: FloatingMenuController | null = null;
+
+  // Signal that bumps on every controller change — templates read it to
+  // re-run @for tracking. OnPush components need explicit change triggers.
+  private version = signal(0);
+  private iconCache = new Map<string, SafeHtml>();
+
+  readonly groups = computed(() => {
+    // Read version to subscribe to controller updates.
+    void this.version();
+    return this.controller?.groups ?? [];
+  });
+
+  private flatNames = computed(() => {
+    void this.version();
+    return this.groups().flatMap((g) => g.items.map((i) => i.name));
+  });
+
+  private focusedIndex = computed(() => {
+    void this.version();
+    return this.controller?.focusedIndex ?? -1;
+  });
+
   constructor() {
-    // Unique key per instance — multiple floating menus on same page
     this.pluginKey = new PluginKey(
       'angularFloatingMenu-' + Math.random().toString(36).slice(2, 8),
     );
 
     afterNextRender(() => {
+      const editor = this.editor();
       const shouldShow = this.shouldShow();
+      const keymap = this.keymap();
       const plugin = createFloatingMenuPlugin({
         pluginKey: this.pluginKey,
-        editor: this.editor(),
+        editor,
         element: this.menuEl().nativeElement,
         ...(shouldShow && { shouldShow }),
         offset: this.offset(),
+        ...(keymap && { keymap }),
       });
-      this.editor().registerPlugin(plugin);
+      editor.registerPlugin(plugin);
+
+      // Create controller for default rendering. ProseMirror transactions
+      // fire outside Angular zone, so signal updates inside the onChange
+      // callback must be wrapped to trigger OnPush change detection.
+      const controller = new FloatingMenuController(
+        editor,
+        () => {
+          this.ngZone.run(() => { this.version.update((v) => v + 1); });
+        },
+        this.items(),
+      );
+      controller.subscribe();
+      this.controller = controller;
+    });
+
+    // Imperatively focus the active menuitem on focusedIndex change.
+    effect(() => {
+      const idx = this.focusedIndex();
+      if (idx < 0) return;
+      queueMicrotask(() => {
+        const target = this.menuEl().nativeElement.querySelector<HTMLElement>(
+          `[data-floating-menu-index="${String(idx)}"]`,
+        );
+        target?.focus();
+      });
     });
   }
 
   ngOnDestroy(): void {
+    this.controller?.destroy();
+    this.controller = null;
     const editor = this.editor();
     if (!editor.isDestroyed) {
       editor.unregisterPlugin(this.pluginKey);
+    }
+  }
+
+  // === Template helpers ===
+
+  flatIndexOf(name: string): number {
+    return this.flatNames().indexOf(name);
+  }
+
+  tabIndexFor(name: string): 0 | -1 {
+    const flat = this.flatIndexOf(name);
+    const focused = this.focusedIndex();
+    if (flat === focused) return 0;
+    // When menu not yet entered, first item is tabbable so external focus
+    // (e.g. Tab traversal) lands naturally.
+    if (focused < 0 && flat === 0) return 0;
+    return -1;
+  }
+
+  isItemDisabled(item: FloatingMenuItem): boolean {
+    return this.controller?.isDisabled(item) ?? false;
+  }
+
+  iconHtml(name?: string): SafeHtml | null {
+    if (!name) return null;
+    const existing = this.iconCache.get(name);
+    if (existing) return existing;
+    const raw = this.icons()?.[name] ?? defaultIcons[name] ?? '';
+    if (!raw) return null;
+    const sanitized = this.sanitizer.bypassSecurityTrustHtml(raw);
+    this.iconCache.set(name, sanitized);
+    return sanitized;
+  }
+
+  onItemClick(item: FloatingMenuItem): void {
+    const editor = this.editor();
+    const ctl = this.controller;
+    if (!ctl) return;
+    ctl.execute(item);
+    requestAnimationFrame(() => { editor.view.focus(); });
+  }
+
+  onKeyDown(e: KeyboardEvent): void {
+    const ctl = this.controller;
+    if (!ctl) return;
+    const focused = ctl.focusedItem();
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        ctl.next();
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        ctl.prev();
+        return;
+      case 'Home':
+        e.preventDefault();
+        ctl.first();
+        return;
+      case 'End':
+        e.preventDefault();
+        ctl.last();
+        return;
+      case 'Escape':
+        e.preventDefault();
+        e.stopPropagation();
+        ctl.leaveMenu();
+        this.editor().view.focus();
+        return;
+      case 'Enter':
+      case ' ':
+        if (focused) {
+          e.preventDefault();
+          this.onItemClick(focused);
+        }
+        return;
+      default:
+        return;
     }
   }
 }

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -32,6 +32,7 @@ import type {
   CanCommands,
   Command,
   ToolbarItem,
+  FloatingMenuItem,
 } from './types/index.js';
 
 /**
@@ -221,6 +222,15 @@ export class Editor extends EventEmitter<EditorEvents> {
    */
   get toolbarItems(): ToolbarItem[] {
     return this._extensionManager.toolbarItems;
+  }
+
+  /**
+   * Gets floating-menu items registered by all extensions.
+   * Used by framework floating-menu components to auto-generate the
+   * block-insert menu shown on empty paragraphs.
+   */
+  get floatingMenuItems(): FloatingMenuItem[] {
+    return this._extensionManager.floatingMenuItems;
   }
 
   // === Active State Methods ===

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -22,6 +22,7 @@ import type { AnyExtension } from './types/EditorOptions.js';
 import type { CommandMap } from './types/Commands.js';
 import type { GlobalAttributes, GlobalAttributeSpec } from './types/ExtensionConfig.js';
 import type { ToolbarItem } from './types/Toolbar.js';
+import type { FloatingMenuItem } from './types/FloatingMenu.js';
 import type { Extension } from './Extension.js';
 import type { Node } from './Node.js';
 import type { Mark } from './Mark.js';
@@ -142,6 +143,11 @@ export class ExtensionManager {
   private _toolbarItems: ToolbarItem[] | null = null;
 
   /**
+   * Cached floating-menu items (collected lazily)
+   */
+  private _floatingMenuItems: FloatingMenuItem[] | null = null;
+
+  /**
    * Cached node views (collected lazily)
    */
   private _nodeViews: Record<string, NodeViewConstructor> | null = null;
@@ -240,6 +246,15 @@ export class ExtensionManager {
   }
 
   /**
+   * Gets floating-menu items from all extensions
+   * Cached after first call
+   */
+  get floatingMenuItems(): FloatingMenuItem[] {
+    this._floatingMenuItems ??= this.collectFloatingMenuItems();
+    return this._floatingMenuItems;
+  }
+
+  /**
    * Gets node views from all Node extensions that define addNodeView
    */
   get nodeViews(): Record<string, NodeViewConstructor> {
@@ -257,6 +272,7 @@ export class ExtensionManager {
     this._plugins = null;
     this._commands = null;
     this._toolbarItems = null;
+    this._floatingMenuItems = null;
     this._nodeViews = null;
   }
 
@@ -692,6 +708,28 @@ export class ExtensionManager {
         const extItems = this.safeCall(
           () => callOrReturn(addItems, ext) as ToolbarItem[] | undefined,
           `${ext.name}.addToolbarItems`
+        );
+        if (extItems && extItems.length > 0) {
+          items.push(...extItems);
+        }
+      }
+    }
+
+    return items;
+  }
+
+  /**
+   * Collects floating-menu items from all extensions via `addFloatingMenuItems()`.
+   */
+  private collectFloatingMenuItems(): FloatingMenuItem[] {
+    const items: FloatingMenuItem[] = [];
+
+    for (const ext of this._extensions) {
+      const addItems = (ext as Extension).config.addFloatingMenuItems;
+      if (addItems) {
+        const extItems = this.safeCall(
+          () => callOrReturn(addItems, ext) as FloatingMenuItem[] | undefined,
+          `${ext.name}.addFloatingMenuItems`
         );
         if (extItems && extItems.length > 0) {
           items.push(...extItems);

--- a/packages/core/src/FloatingMenuController.test.ts
+++ b/packages/core/src/FloatingMenuController.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Tests for FloatingMenuController - headless floating-menu state machine
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  FloatingMenuController,
+  FLOATING_MENU_NO_FOCUS,
+} from './FloatingMenuController.js';
+import type { Editor } from './Editor.js';
+import type { FloatingMenuItem, FloatingMenuItemsOverride } from './types/FloatingMenu.js';
+
+// === Test helpers ===
+
+interface MockEditorOptions {
+  items?: FloatingMenuItem[];
+  commands?: Record<string, (...args: unknown[]) => boolean>;
+  canCommands?: Record<string, (...args: unknown[]) => boolean>;
+  canThrows?: boolean;
+}
+
+function createMockEditor(opts: MockEditorOptions = {}): {
+  editor: Editor;
+  handlers: Map<string, (() => void)[]>;
+} {
+  const handlers = new Map<string, (() => void)[]>();
+  const editor = {
+    floatingMenuItems: opts.items ?? [],
+    commands: opts.commands ?? {},
+    can: (): Record<string, (...args: unknown[]) => boolean> => {
+      if (opts.canThrows) throw new Error('can() failure');
+      return opts.canCommands ?? {};
+    },
+    on: (name: string, handler: () => void): void => {
+      const list = handlers.get(name) ?? [];
+      list.push(handler);
+      handlers.set(name, list);
+    },
+    off: (name: string, handler: () => void): void => {
+      const list = handlers.get(name) ?? [];
+      handlers.set(
+        name,
+        list.filter((h) => h !== handler),
+      );
+    },
+  } as unknown as Editor;
+  return { editor, handlers };
+}
+
+function item(name: string, overrides?: Partial<FloatingMenuItem>): FloatingMenuItem {
+  return {
+    name,
+    label: name,
+    command: `insert${name.charAt(0).toUpperCase()}${name.slice(1)}`,
+    ...overrides,
+  };
+}
+
+describe('FloatingMenuController', () => {
+  let controller: FloatingMenuController | undefined;
+
+  afterEach(() => {
+    controller?.destroy();
+    controller = undefined;
+  });
+
+  // =========================================================================
+  // Static: resolveItems
+  // =========================================================================
+  describe('resolveItems', () => {
+    it('returns defaults when no override', () => {
+      const defaults = [item('a'), item('b')];
+      const { editor } = createMockEditor({ items: defaults });
+      expect(FloatingMenuController.resolveItems(editor)).toBe(defaults);
+    });
+
+    it('returns array override verbatim', () => {
+      const defaults = [item('a')];
+      const override = [item('x'), item('y')];
+      const { editor } = createMockEditor({ items: defaults });
+      expect(FloatingMenuController.resolveItems(editor, override)).toBe(override);
+    });
+
+    it('calls function override with defaults and editor', () => {
+      const defaults = [item('a')];
+      const { editor } = createMockEditor({ items: defaults });
+      const fn: FloatingMenuItemsOverride = (defs, ed) => {
+        expect(defs).toBe(defaults);
+        expect(ed).toBe(editor);
+        return [...defs, item('b')];
+      };
+      const result = FloatingMenuController.resolveItems(editor, fn);
+      expect(result.map((i) => i.name)).toEqual(['a', 'b']);
+    });
+
+    it('falls back to defaults when function override throws', () => {
+      const defaults = [item('a')];
+      const { editor } = createMockEditor({ items: defaults });
+      const fn: FloatingMenuItemsOverride = () => {
+        throw new Error('boom');
+      };
+      expect(FloatingMenuController.resolveItems(editor, fn)).toBe(defaults);
+    });
+  });
+
+  // =========================================================================
+  // Static: executeItem
+  // =========================================================================
+  describe('executeItem', () => {
+    it('calls function command with editor', () => {
+      const { editor } = createMockEditor();
+      const cmd = vi.fn();
+      FloatingMenuController.executeItem(editor, item('fn', { command: cmd }));
+      expect(cmd).toHaveBeenCalledWith(editor);
+    });
+
+    it('invokes string command via editor.commands without args', () => {
+      const cmd = vi.fn().mockReturnValue(true);
+      const { editor } = createMockEditor({ commands: { toggleBold: cmd } });
+      FloatingMenuController.executeItem(editor, item('bold', { command: 'toggleBold' }));
+      expect(cmd).toHaveBeenCalledTimes(1);
+      expect(cmd).toHaveBeenCalledWith();
+    });
+
+    it('invokes string command with commandArgs', () => {
+      const cmd = vi.fn().mockReturnValue(true);
+      const { editor } = createMockEditor({ commands: { toggleHeading: cmd } });
+      FloatingMenuController.executeItem(
+        editor,
+        item('h1', { command: 'toggleHeading', commandArgs: [{ level: 1 }] }),
+      );
+      expect(cmd).toHaveBeenCalledWith({ level: 1 });
+    });
+
+    it('silently no-ops when command name missing from editor.commands', () => {
+      const { editor } = createMockEditor({ commands: {} });
+      expect(() => {
+        FloatingMenuController.executeItem(editor, item('missing', { command: 'nope' }));
+      }).not.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // Constructor / rebuild / groupItems
+  // =========================================================================
+  describe('rebuild and grouping', () => {
+    it('rebuilds on construction with no items', () => {
+      const { editor } = createMockEditor({ items: [] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.groups).toEqual([]);
+      expect(controller.flatItems).toEqual([]);
+      expect(controller.itemCount).toBe(0);
+    });
+
+    it('groups items by group name, preserving first-seen order', () => {
+      const items = [
+        item('a', { group: 'Basic' }),
+        item('b', { group: 'Media' }),
+        item('c', { group: 'Basic' }),
+        item('d'), // empty group
+      ];
+      const { editor } = createMockEditor({ items });
+      controller = new FloatingMenuController(editor, () => undefined);
+      const groupNames = controller.groups.map((g) => g.name);
+      expect(groupNames).toEqual(['Basic', 'Media', '']);
+      const basic = controller.groups.find((g) => g.name === 'Basic')!;
+      expect(basic.items.map((i) => i.name)).toEqual(['a', 'c']);
+    });
+
+    it('sorts items within group by priority (higher first), defaults to 100', () => {
+      const items = [
+        item('low', { group: 'G', priority: 10 }),
+        item('high', { group: 'G', priority: 500 }),
+        item('mid', { group: 'G' }),
+      ];
+      const { editor } = createMockEditor({ items });
+      controller = new FloatingMenuController(editor, () => undefined);
+      const names = controller.groups[0]!.items.map((i) => i.name);
+      expect(names).toEqual(['high', 'mid', 'low']);
+    });
+
+    it('flatItems is flat order across groups', () => {
+      const items = [
+        item('a', { group: 'G1' }),
+        item('b', { group: 'G2' }),
+        item('c', { group: 'G1' }),
+      ];
+      const { editor } = createMockEditor({ items });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.flatItems.map((i) => i.name)).toEqual(['a', 'c', 'b']);
+      expect(controller.itemCount).toBe(3);
+    });
+
+    it('applies override at construction time', () => {
+      const defaults = [item('a'), item('b')];
+      const { editor } = createMockEditor({ items: defaults });
+      controller = new FloatingMenuController(
+        editor,
+        () => undefined,
+        [item('x')],
+      );
+      expect(controller.flatItems.map((i) => i.name)).toEqual(['x']);
+    });
+
+    it('rebuild resets focusedIndex when it exceeds new item count', () => {
+      const { editor } = createMockEditor({ items: [item('a'), item('b'), item('c')] });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.last(); // focuses index 2
+      expect(controller.focusedIndex).toBe(2);
+
+      // Simulate editor returning fewer items, then force rebuild.
+      (editor as unknown as { floatingMenuItems: FloatingMenuItem[] }).floatingMenuItems = [
+        item('a'),
+      ];
+      controller.rebuild();
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+    });
+  });
+
+  // =========================================================================
+  // Keyboard navigation (roving tabindex)
+  // =========================================================================
+  describe('keyboard navigation', () => {
+    const buildItems = (): FloatingMenuItem[] => [item('a'), item('b'), item('c')];
+
+    it('enterMenu focuses first item and notifies', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(controller.isEntered).toBe(false);
+
+      expect(controller.enterMenu()).toBe(0);
+      expect(controller.focusedIndex).toBe(0);
+      expect(controller.isEntered).toBe(true);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('enterMenu returns NO_FOCUS when no items', () => {
+      const { editor } = createMockEditor({ items: [] });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      expect(controller.enterMenu()).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('leaveMenu clears focus and notifies', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.enterMenu();
+      onChange.mockClear();
+
+      controller.leaveMenu();
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaveMenu is no-op when already un-focused', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.leaveMenu();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('next wraps around to 0 at end', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      controller.enterMenu();
+      expect(controller.next()).toBe(1);
+      expect(controller.next()).toBe(2);
+      expect(controller.next()).toBe(0);
+    });
+
+    it('next from NO_FOCUS starts at index 0', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.next()).toBe(0);
+    });
+
+    it('next returns NO_FOCUS for empty item list', () => {
+      const { editor } = createMockEditor({ items: [] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.next()).toBe(FLOATING_MENU_NO_FOCUS);
+    });
+
+    it('prev wraps around to last at start', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      controller.enterMenu();
+      expect(controller.prev()).toBe(2);
+      expect(controller.prev()).toBe(1);
+    });
+
+    it('prev from NO_FOCUS wraps to last', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.prev()).toBe(2);
+    });
+
+    it('prev returns NO_FOCUS for empty item list', () => {
+      const { editor } = createMockEditor({ items: [] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.prev()).toBe(FLOATING_MENU_NO_FOCUS);
+    });
+
+    it('first moves to index 0', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      controller.last();
+      expect(controller.first()).toBe(0);
+    });
+
+    it('first returns NO_FOCUS on empty list', () => {
+      const { editor } = createMockEditor({ items: [] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.first()).toBe(FLOATING_MENU_NO_FOCUS);
+    });
+
+    it('last moves to final index', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.last()).toBe(2);
+    });
+
+    it('last returns NO_FOCUS on empty list', () => {
+      const { editor } = createMockEditor({ items: [] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.last()).toBe(FLOATING_MENU_NO_FOCUS);
+    });
+
+    it('setFocusedIndex sets index and notifies on change', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.setFocusedIndex(1);
+      expect(controller.focusedIndex).toBe(1);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('setFocusedIndex ignores out-of-range values', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.setFocusedIndex(-1);
+      controller.setFocusedIndex(99);
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('setFocusedIndex no-ops when index unchanged', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.setFocusedIndex(1);
+      onChange.mockClear();
+      controller.setFocusedIndex(1);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('focusedItem returns current item or null', () => {
+      const items = buildItems();
+      const { editor } = createMockEditor({ items });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.focusedItem()).toBe(null);
+      controller.setFocusedIndex(1);
+      expect(controller.focusedItem()).toBe(items[1]);
+    });
+
+    it('getFlatIndex returns index by name or -1', () => {
+      const { editor } = createMockEditor({ items: buildItems() });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.getFlatIndex('a')).toBe(0);
+      expect(controller.getFlatIndex('c')).toBe(2);
+      expect(controller.getFlatIndex('missing')).toBe(-1);
+    });
+  });
+
+  // =========================================================================
+  // execute + disabled state
+  // =========================================================================
+  describe('execute and disabled state', () => {
+    it('execute runs command and resets focus', () => {
+      const cmd = vi.fn().mockReturnValue(true);
+      const { editor } = createMockEditor({
+        items: [item('bold', { command: 'toggleBold' })],
+        commands: { toggleBold: cmd },
+      });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.enterMenu();
+      onChange.mockClear();
+
+      controller.execute(controller.flatItems[0]!);
+      expect(cmd).toHaveBeenCalled();
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('execute no-ops when item is disabled', () => {
+      const cmd = vi.fn();
+      const disabled = item('x', {
+        command: 'nope',
+        isDisabled: () => true,
+      });
+      const { editor } = createMockEditor({
+        items: [disabled],
+        commands: { nope: cmd },
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      controller.execute(controller.flatItems[0]!);
+      expect(cmd).not.toHaveBeenCalled();
+    });
+
+    it('isDisabled returns false by default', () => {
+      const { editor } = createMockEditor({ items: [item('a')] });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+    });
+
+    it('uses custom isDisabled predicate when provided', () => {
+      const { editor } = createMockEditor({
+        items: [item('x', { isDisabled: () => true })],
+      });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(true);
+      expect(onChange).toHaveBeenCalled(); // first disabled-state change notifies
+    });
+
+    it('isDisabled predicate exceptions fall back to false', () => {
+      const { editor } = createMockEditor({
+        items: [
+          item('x', {
+            isDisabled: () => {
+              throw new Error('boom');
+            },
+          }),
+        ],
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+    });
+
+    it('falls back to editor.can() dry-run for string commands without isDisabled', () => {
+      const canToggle = vi.fn().mockReturnValue(false); // can't -> disabled
+      const { editor } = createMockEditor({
+        items: [item('b', { command: 'toggleBold' })],
+        canCommands: { toggleBold: canToggle },
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(true);
+      expect(canToggle).toHaveBeenCalled();
+    });
+
+    it('passes commandArgs into can() dry-run', () => {
+      const canToggle = vi.fn().mockReturnValue(true); // can -> enabled
+      const { editor } = createMockEditor({
+        items: [
+          item('h1', {
+            command: 'toggleHeading',
+            commandArgs: [{ level: 1 }],
+          }),
+        ],
+        canCommands: { toggleHeading: canToggle },
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+      expect(canToggle).toHaveBeenCalledWith({ level: 1 });
+    });
+
+    it('ignores can() dry-run exceptions', () => {
+      const canToggle = vi.fn().mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const { editor } = createMockEditor({
+        items: [item('b', { command: 'toggleBold' })],
+        canCommands: { toggleBold: canToggle },
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+    });
+
+    it('skips disabled detection when editor.can() throws', () => {
+      const { editor } = createMockEditor({
+        items: [item('b', { command: 'toggleBold' })],
+        canThrows: true,
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+    });
+
+    it('no disabled detection for function commands (left enabled)', () => {
+      const { editor } = createMockEditor({
+        items: [item('fn', { command: () => undefined })],
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+    });
+
+    it('disabledMap getter returns read-only view', () => {
+      const { editor } = createMockEditor({
+        items: [item('x', { isDisabled: () => true })],
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      const map = controller.disabledMap;
+      expect(map.get('x')).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Lifecycle: subscribe / destroy
+  // =========================================================================
+  describe('lifecycle', () => {
+    it('subscribe registers transaction handler that refreshes disabled state', () => {
+      let allowed = true;
+      const canToggle = vi.fn(() => allowed);
+      const { editor, handlers } = createMockEditor({
+        items: [item('b', { command: 'toggleBold' })],
+        canCommands: { toggleBold: canToggle },
+      });
+      const onChange = vi.fn();
+      controller = new FloatingMenuController(editor, onChange);
+      controller.subscribe();
+
+      expect(handlers.get('transaction')?.length).toBe(1);
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(false);
+
+      onChange.mockClear();
+      allowed = false;
+      handlers.get('transaction')?.[0]?.();
+      expect(controller.isDisabled(controller.flatItems[0]!)).toBe(true);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('destroy unsubscribes and resets internal state', () => {
+      const { editor, handlers } = createMockEditor({
+        items: [item('a'), item('b')],
+      });
+      controller = new FloatingMenuController(editor, () => undefined);
+      controller.subscribe();
+      controller.enterMenu();
+      expect(controller.focusedIndex).toBe(0);
+
+      controller.destroy();
+      expect(handlers.get('transaction')?.length).toBe(0);
+      expect(controller.groups).toEqual([]);
+      expect(controller.flatItems).toEqual([]);
+      expect(controller.focusedIndex).toBe(FLOATING_MENU_NO_FOCUS);
+      expect(controller.disabledMap.size).toBe(0);
+
+      // Safe to call destroy twice (no transaction handler).
+      expect(() => controller?.destroy()).not.toThrow();
+      controller = undefined;
+    });
+  });
+});

--- a/packages/core/src/FloatingMenuController.ts
+++ b/packages/core/src/FloatingMenuController.ts
@@ -1,0 +1,316 @@
+/**
+ * FloatingMenuController - Headless, framework-agnostic state machine for the
+ * block-insert floating menu.
+ *
+ * Mirrors the shape of ToolbarController: collects items from extensions,
+ * groups them, tracks focused index for roving-tabindex keyboard navigation,
+ * and executes commands. Framework wrappers (Angular, React, Vue) bind their
+ * templates to this controller.
+ *
+ * @example
+ * const controller = new FloatingMenuController(editor, () => {
+ *   // onChange — re-render
+ * });
+ * controller.subscribe();
+ * // ... controller.groups, controller.focusedIndex, controller.execute(item)
+ * controller.destroy();
+ */
+
+import type { Editor } from './Editor.js';
+import type { FloatingMenuItem, FloatingMenuItemsOverride } from './types/FloatingMenu.js';
+
+/**
+ * A group of floating-menu items sharing the same `group` value.
+ */
+export interface FloatingMenuGroup {
+  name: string;
+  items: FloatingMenuItem[];
+}
+
+/** -1 means no item is focused (menu not entered via keyboard). */
+export const FLOATING_MENU_NO_FOCUS = -1;
+
+export class FloatingMenuController {
+  /**
+   * Resolves an `items` option (array | function) against the editor's
+   * default floating-menu items. Exposed as static so the plugin can
+   * resolve once at init without constructing a controller.
+   */
+  static resolveItems(
+    editor: Editor,
+    override?: FloatingMenuItemsOverride,
+  ): FloatingMenuItem[] {
+    const defaults = editor.floatingMenuItems;
+    if (!override) return defaults;
+    if (Array.isArray(override)) return override;
+    try {
+      return override(defaults, editor);
+    } catch {
+      return defaults;
+    }
+  }
+
+  /**
+   * Executes a floating-menu item's command on the editor.
+   * String commands are dispatched via `editor.commands[name](...args)`;
+   * function commands are called directly.
+   */
+  static executeItem(editor: Editor, item: FloatingMenuItem): void {
+    if (typeof item.command === 'function') {
+      item.command(editor);
+      return;
+    }
+    const commands = editor.commands as unknown as Record<string, (...args: unknown[]) => boolean>;
+    const cmd = commands[item.command];
+    if (!cmd) return;
+    if (item.commandArgs?.length) {
+      cmd(...item.commandArgs);
+    } else {
+      cmd();
+    }
+  }
+
+  private editor: Editor;
+  private onChange: () => void;
+  private override: FloatingMenuItemsOverride | undefined;
+  private transactionHandler: (() => void) | null = null;
+
+  private _groups: FloatingMenuGroup[] = [];
+  private _flatItems: FloatingMenuItem[] = [];
+  private _disabledMap = new Map<string, boolean>();
+  private _focusedIndex = FLOATING_MENU_NO_FOCUS;
+
+  constructor(editor: Editor, onChange: () => void, override?: FloatingMenuItemsOverride) {
+    this.editor = editor;
+    this.onChange = onChange;
+    this.override = override;
+    this.rebuild();
+  }
+
+  // === Getters ===
+
+  get groups(): FloatingMenuGroup[] {
+    return this._groups;
+  }
+
+  get flatItems(): FloatingMenuItem[] {
+    return this._flatItems;
+  }
+
+  get disabledMap(): ReadonlyMap<string, boolean> {
+    return this._disabledMap;
+  }
+
+  get focusedIndex(): number {
+    return this._focusedIndex;
+  }
+
+  /** True when keyboard focus is inside the menu (at least one item focused). */
+  get isEntered(): boolean {
+    return this._focusedIndex >= 0;
+  }
+
+  get itemCount(): number {
+    return this._flatItems.length;
+  }
+
+  // === State Methods ===
+
+  isDisabled(item: FloatingMenuItem): boolean {
+    return this._disabledMap.get(item.name) ?? false;
+  }
+
+  /**
+   * Executes an item's command, then closes the menu keyboard focus.
+   * Callers should refocus the editor after calling this.
+   */
+  execute(item: FloatingMenuItem): void {
+    if (this.isDisabled(item)) return;
+    FloatingMenuController.executeItem(this.editor, item);
+    this._focusedIndex = FLOATING_MENU_NO_FOCUS;
+    this.onChange();
+  }
+
+  /**
+   * Rebuilds items from the editor. Call when the editor's extensions
+   * change (rare) or on explicit refresh.
+   */
+  rebuild(): void {
+    const items = FloatingMenuController.resolveItems(this.editor, this.override);
+    this._groups = this.groupItems(items);
+    this._flatItems = this._groups.flatMap((g) => g.items);
+    if (this._focusedIndex >= this._flatItems.length) {
+      this._focusedIndex = FLOATING_MENU_NO_FOCUS;
+    }
+    this.updateDisabledStates();
+  }
+
+  // === Keyboard Navigation (roving tabindex) ===
+
+  /** Enter keyboard focus on the menu (first item). Called by the plugin's keymap. */
+  enterMenu(): number {
+    if (this._flatItems.length === 0) {
+      this._focusedIndex = FLOATING_MENU_NO_FOCUS;
+      return this._focusedIndex;
+    }
+    this._focusedIndex = 0;
+    this.onChange();
+    return this._focusedIndex;
+  }
+
+  /** Leave keyboard focus (Escape). Refocus of the editor is the caller's job. */
+  leaveMenu(): void {
+    if (this._focusedIndex === FLOATING_MENU_NO_FOCUS) return;
+    this._focusedIndex = FLOATING_MENU_NO_FOCUS;
+    this.onChange();
+  }
+
+  /** ArrowDown — wrap to first at end. */
+  next(): number {
+    if (this._flatItems.length === 0) return FLOATING_MENU_NO_FOCUS;
+    const cur = this._focusedIndex < 0 ? -1 : this._focusedIndex;
+    this._focusedIndex = (cur + 1) % this._flatItems.length;
+    this.onChange();
+    return this._focusedIndex;
+  }
+
+  /** ArrowUp — wrap to last at start. */
+  prev(): number {
+    if (this._flatItems.length === 0) return FLOATING_MENU_NO_FOCUS;
+    const len = this._flatItems.length;
+    const cur = this._focusedIndex < 0 ? len : this._focusedIndex;
+    this._focusedIndex = (cur - 1 + len) % len;
+    this.onChange();
+    return this._focusedIndex;
+  }
+
+  first(): number {
+    if (this._flatItems.length === 0) return FLOATING_MENU_NO_FOCUS;
+    this._focusedIndex = 0;
+    this.onChange();
+    return this._focusedIndex;
+  }
+
+  last(): number {
+    if (this._flatItems.length === 0) return FLOATING_MENU_NO_FOCUS;
+    this._focusedIndex = this._flatItems.length - 1;
+    this.onChange();
+    return this._focusedIndex;
+  }
+
+  /** Set focused index directly (e.g. on pointer hover). */
+  setFocusedIndex(index: number): void {
+    if (index < 0 || index >= this._flatItems.length) return;
+    if (this._focusedIndex === index) return;
+    this._focusedIndex = index;
+    this.onChange();
+  }
+
+  /** Get focused item (or null). */
+  focusedItem(): FloatingMenuItem | null {
+    return this._flatItems[this._focusedIndex] ?? null;
+  }
+
+  /** Get flat index of item by name (for wrappers binding roving tabindex). */
+  getFlatIndex(name: string): number {
+    return this._flatItems.findIndex((i) => i.name === name);
+  }
+
+  // === Lifecycle ===
+
+  /** Subscribes to editor transactions for disabled-state tracking. */
+  subscribe(): void {
+    this.transactionHandler = () => {
+      this.updateDisabledStates();
+    };
+    this.editor.on('transaction', this.transactionHandler);
+  }
+
+  /** Unsubscribes and clears internal state. */
+  destroy(): void {
+    if (this.transactionHandler) {
+      this.editor.off('transaction', this.transactionHandler);
+      this.transactionHandler = null;
+    }
+    this._groups = [];
+    this._flatItems = [];
+    this._disabledMap.clear();
+    this._focusedIndex = FLOATING_MENU_NO_FOCUS;
+  }
+
+  // === Internal ===
+
+  /**
+   * Groups items by `group` preserving insertion order, then sorts by
+   * priority (higher first) within each group.
+   */
+  private groupItems(items: FloatingMenuItem[]): FloatingMenuGroup[] {
+    const map = new Map<string, FloatingMenuItem[]>();
+    const order: string[] = [];
+
+    for (const item of items) {
+      const name = item.group ?? '';
+      let list = map.get(name);
+      if (!list) {
+        list = [];
+        map.set(name, list);
+        order.push(name);
+      }
+      list.push(item);
+    }
+
+    const groups: FloatingMenuGroup[] = [];
+    for (const name of order) {
+      const list = map.get(name) ?? [];
+      list.sort((a, b) => (b.priority ?? 100) - (a.priority ?? 100));
+      groups.push({ name, items: list });
+    }
+    return groups;
+  }
+
+  /**
+   * Updates disabled state for each item. Uses custom predicate when
+   * provided; otherwise tries a dry-run against `editor.can()[command]`.
+   * Only notifies on change to avoid noisy re-renders.
+   */
+  private updateDisabledStates(): void {
+    let changed = false;
+    let canProxy: Record<string, (...args: unknown[]) => boolean> | null = null;
+    try {
+      canProxy = this.editor.can() as unknown as Record<string, (...args: unknown[]) => boolean>;
+    } catch {
+      canProxy = null;
+    }
+
+    for (const item of this._flatItems) {
+      const was = this._disabledMap.get(item.name) ?? false;
+      let now = false;
+
+      if (item.isDisabled) {
+        try {
+          now = item.isDisabled(this.editor);
+        } catch {
+          now = false;
+        }
+      } else if (typeof item.command === 'string' && canProxy) {
+        try {
+          const canCmd = canProxy[item.command];
+          if (canCmd) {
+            now = item.commandArgs?.length
+              ? !canCmd(...item.commandArgs)
+              : !canCmd();
+          }
+        } catch {
+          now = false;
+        }
+      }
+
+      if (was !== now) {
+        this._disabledMap.set(item.name, now);
+        changed = true;
+      }
+    }
+
+    if (changed) this.onChange();
+  }
+}

--- a/packages/core/src/extensions/FloatingMenu.test.ts
+++ b/packages/core/src/extensions/FloatingMenu.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for FloatingMenu extension
  */
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { FloatingMenu, floatingMenuPluginKey, createFloatingMenuPlugin } from './FloatingMenu.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
@@ -681,6 +681,333 @@ describe('FloatingMenu', () => {
 
       editor.destroy();
       expect(editor.isDestroyed).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Keyboard entry: handleKeyDown + matchShortcut branches
+  // =========================================================================
+  describe('keyboard entry (handleKeyDown)', () => {
+    let editor: Editor | undefined;
+    let host: HTMLElement;
+
+    beforeEach(() => {
+      Element.prototype.getClientRects = function () {
+        return [] as unknown as DOMRectList;
+      };
+      host = document.createElement('div');
+      host.className = 'dm-editor';
+      document.body.appendChild(host);
+    });
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) editor.destroy();
+      host.remove();
+    });
+
+    function mountVisible(element: HTMLElement, keymap?: { enterMenu?: string[] }): void {
+      const config = { element, shouldShow: (): boolean => true };
+      const configured = keymap
+        ? FloatingMenu.configure({ ...config, keymap })
+        : FloatingMenu.configure(config);
+      editor = new Editor({
+        element: host,
+        extensions: [Document, Text, Paragraph, configured],
+        content: '<p></p>',
+      });
+      element.setAttribute('data-show', ''); // force visible state for plugin gate
+    }
+
+    it('ignores keydown when menu is hidden', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => false }),
+        ],
+        content: '<p>Hello</p>',
+      });
+
+      const event = new KeyboardEvent('keydown', { key: 'F10', altKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor.view.dom.dispatchEvent(event);
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('Alt-F10 focuses the first menu item and prevents default', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      btn.tabIndex = 0;
+      element.appendChild(btn);
+      mountVisible(element);
+
+      const event = new KeyboardEvent('keydown', { key: 'F10', altKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor!.view.dom.dispatchEvent(event);
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(document.activeElement).toBe(btn);
+    });
+
+    it('Alt-F10 without any focusable menu item does not preventDefault', () => {
+      const element = document.createElement('div');
+      mountVisible(element);
+
+      const event = new KeyboardEvent('keydown', { key: 'F10', altKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor!.view.dom.dispatchEvent(event);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('skips aria-disabled items when focusing, falls back to next focusable', () => {
+      const element = document.createElement('div');
+      const disabled = document.createElement('button');
+      disabled.setAttribute('data-floating-menu-item', '');
+      disabled.setAttribute('aria-disabled', 'true');
+      const enabled = document.createElement('button');
+      enabled.setAttribute('data-floating-menu-item', '');
+      element.append(disabled, enabled);
+      mountVisible(element);
+
+      editor!.view.dom.dispatchEvent(new KeyboardEvent('keydown', { key: 'F10', altKey: true }));
+      expect(document.activeElement).toBe(enabled);
+    });
+
+    it('falls back to plain button when no data-floating-menu-item nodes exist', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      element.appendChild(btn);
+      mountVisible(element);
+
+      editor!.view.dom.dispatchEvent(new KeyboardEvent('keydown', { key: 'F10', altKey: true }));
+      expect(document.activeElement).toBe(btn);
+    });
+
+    it('Mod-/ shortcut matches Ctrl-/ off macOS', () => {
+      // jsdom's navigator.userAgent is Mozilla/... Linux/x86_64 by default
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element);
+
+      const event = new KeyboardEvent('keydown', { key: '/', ctrlKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor!.view.dom.dispatchEvent(event);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('ignores non-matching key events', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element);
+
+      const event = new KeyboardEvent('keydown', { key: 'x' });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor!.view.dom.dispatchEvent(event);
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('shortcut key match is case-insensitive for single-char keys', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element, { enterMenu: ['Mod-A'] });
+
+      const event = new KeyboardEvent('keydown', { key: 'a', ctrlKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      editor!.view.dom.dispatchEvent(event);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('respects explicit Shift modifier', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element, { enterMenu: ['Shift-F1'] });
+
+      // Without Shift — no match.
+      editor!.view.dom.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1' }));
+      expect(document.activeElement).not.toBe(btn);
+
+      // With Shift — match.
+      editor!.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'F1', shiftKey: true }),
+      );
+      expect(document.activeElement).toBe(btn);
+    });
+
+    it('matches explicit Meta modifier', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element, { enterMenu: ['Meta-K'] });
+
+      editor!.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+      );
+      expect(document.activeElement).toBe(btn);
+    });
+
+    it('ignores shortcut with empty key parts', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element, { enterMenu: [''] });
+
+      editor!.view.dom.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      expect(document.activeElement).not.toBe(btn);
+    });
+
+    it('empty keymap disables keyboard entry', () => {
+      const element = document.createElement('div');
+      const btn = document.createElement('button');
+      btn.setAttribute('data-floating-menu-item', '');
+      element.appendChild(btn);
+      mountVisible(element, { enterMenu: [] });
+
+      editor!.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'F10', altKey: true }),
+      );
+      expect(document.activeElement).not.toBe(btn);
+    });
+  });
+
+  // =========================================================================
+  // Dismiss paths: click-outside and dm:dismiss-overlays
+  // =========================================================================
+  describe('dismissal', () => {
+    let editor: Editor | undefined;
+    let host: HTMLElement;
+
+    beforeEach(() => {
+      Element.prototype.getClientRects = function () {
+        return [] as unknown as DOMRectList;
+      };
+      // jsdom lacks elementFromPoint; ProseMirror's internal mousedown
+      // handler calls posAtCoords → elementFromPoint. Stub to null.
+      (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint =
+        (): Element | null => null;
+      host = document.createElement('div');
+      host.className = 'dm-editor';
+      document.body.appendChild(host);
+    });
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) editor.destroy();
+      host.remove();
+    });
+
+    it('click-outside handler hides a visible menu', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p></p>',
+      });
+      element.setAttribute('data-show', '');
+
+      const outside = document.createElement('div');
+      document.body.appendChild(outside);
+      outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(element.hasAttribute('data-show')).toBe(false);
+      outside.remove();
+    });
+
+    it('click-outside handler ignores clicks while menu is hidden', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => false }),
+        ],
+        content: '<p>Hello</p>',
+      });
+
+      // Sanity: not showing.
+      expect(element.hasAttribute('data-show')).toBe(false);
+      const outside = document.createElement('div');
+      document.body.appendChild(outside);
+      // Should not throw, no state change.
+      expect(() =>
+        outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })),
+      ).not.toThrow();
+      outside.remove();
+    });
+
+    it('click-outside handler ignores clicks inside menu element', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p></p>',
+      });
+      element.setAttribute('data-show', '');
+
+      const inner = document.createElement('span');
+      element.appendChild(inner);
+      inner.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(element.hasAttribute('data-show')).toBe(true);
+    });
+
+    it('click-outside handler ignores clicks inside editor view', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p></p>',
+      });
+      element.setAttribute('data-show', '');
+
+      editor.view.dom.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(element.hasAttribute('data-show')).toBe(true);
+    });
+
+    it('dm:dismiss-overlays event hides the menu', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          FloatingMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p></p>',
+      });
+      element.setAttribute('data-show', '');
+
+      host.dispatchEvent(new Event('dm:dismiss-overlays'));
+      expect(element.hasAttribute('data-show')).toBe(false);
     });
   });
 });

--- a/packages/core/src/extensions/FloatingMenu.test.ts
+++ b/packages/core/src/extensions/FloatingMenu.test.ts
@@ -552,8 +552,8 @@ describe('FloatingMenu', () => {
         content: '<p>Hello</p>',
       });
 
-      expect(element.getAttribute('role')).toBe('toolbar');
-      expect(element.getAttribute('aria-label')).toBe('Floating menu');
+      expect(element.getAttribute('role')).toBe('menu');
+      expect(element.getAttribute('aria-label')).toBe('Insert block');
     });
 
     it('element is moved inside .dm-editor ancestor', () => {

--- a/packages/core/src/extensions/FloatingMenu.ts
+++ b/packages/core/src/extensions/FloatingMenu.ts
@@ -108,7 +108,7 @@ function matchShortcut(event: KeyboardEvent, shortcut: string): boolean {
   if (!key) return false;
   const mods = new Set(parts.slice(0, -1));
   const isMac = /Mac|iPhone|iPad|iPod/i.test(
-    typeof navigator === 'undefined' ? '' : navigator.platform,
+    typeof navigator === 'undefined' ? '' : navigator.userAgent,
   );
   const needMod = mods.has('Mod');
   const needAlt = mods.has('Alt');

--- a/packages/core/src/extensions/FloatingMenu.ts
+++ b/packages/core/src/extensions/FloatingMenu.ts
@@ -1,45 +1,29 @@
 /**
  * FloatingMenu Extension
  *
- * Shows a floating menu when the cursor is in an empty paragraph.
- * Useful for showing block-level insertion options.
+ * Shows a block-insert menu when the cursor is at the start of an empty
+ * paragraph. Items are collected from all extensions via the
+ * `addFloatingMenuItems()` hook; the menu exposes a WAI-ARIA `role="menu"`
+ * with `role="group"` sections and `role="menuitem"` entries. Framework
+ * wrappers (`@domternal/react`, `/vue`, `/angular`) render the UI; this
+ * file owns visibility, positioning, dismiss, and keyboard entry.
  *
- * @example
- * ```ts
- * import { FloatingMenu } from '@domternal/core';
- *
- * // Create menu element
- * const menuElement = document.getElementById('floating-menu');
- *
- * const editor = new Editor({
- *   extensions: [
- *     // ... other extensions
- *     FloatingMenu.configure({
- *       element: menuElement,
- *       shouldShow: ({ editor, state }) => {
- *         const { $from, empty } = state.selection;
- *         // Show in empty paragraphs
- *         return empty &&
- *           $from.parent.type.name === 'paragraph' &&
- *           $from.parent.content.size === 0;
- *       },
- *     }),
- *   ],
- * });
- * ```
- *
- * Styles are included automatically via `@domternal/theme` (`_floating-menu.scss`).
+ * Styles ship via `@domternal/theme` (`_floating-menu.scss`).
  */
 import { Extension } from '../Extension.js';
 import { Plugin, PluginKey } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
 import type { EditorState } from '@domternal/pm/state';
 import type { Editor } from '../Editor.js';
+import type { FloatingMenuItemsOverride } from '../types/FloatingMenu.js';
 import { positionFloatingOnce } from '../utils/positionFloating.js';
 
 export const floatingMenuPluginKey = new PluginKey('floatingMenu');
 
-// Default shouldShow: empty paragraph with cursor in editable editor
+/**
+ * Default visibility predicate. Shows the menu when the cursor is at the
+ * very start of an empty `paragraph` in an editable editor.
+ */
 function defaultShouldShow({
   editor,
   state,
@@ -48,37 +32,39 @@ function defaultShouldShow({
   view: EditorView;
   state: EditorState;
 }): boolean {
-  // Don't show if editor is not editable
   if (!editor.isEditable) return false;
-
   const { selection } = state;
   const { $from, empty } = selection;
-
-  // Must be empty selection
   if (!empty) return false;
-
-  // Must be in a paragraph
   if ($from.parent.type.name !== 'paragraph') return false;
-
-  // Paragraph must be empty
   if ($from.parent.content.size !== 0) return false;
-
-  // Must be at the start of the paragraph
   if ($from.parentOffset !== 0) return false;
-
   return true;
 }
 
+/**
+ * Keyboard shortcuts that move focus from the editor into the menu.
+ * Defaults combine the WAI-ARIA recommendation (`Alt-F10`) with a
+ * modern slash-command-friendly shortcut (`Mod-/`). Set to an empty
+ * array to disable keyboard entry entirely.
+ */
+export interface FloatingMenuKeymap {
+  /** Shortcuts that focus the first menu item when the menu is visible. */
+  enterMenu?: string[];
+}
+
+const DEFAULT_ENTER_MENU_SHORTCUTS: string[] = ['Alt-F10', 'Mod-/'];
+
 export interface FloatingMenuOptions {
   /**
-   * The HTML element that contains the menu.
-   * Must be provided by the user.
+   * The HTML element that contains the menu. Required when used directly;
+   * framework wrappers create this element and pass it in.
    */
   element: HTMLElement | null;
 
   /**
-   * Function to determine if the menu should be shown.
-   * By default, shows when the cursor is in an empty paragraph.
+   * Visibility predicate. Defaults to `defaultShouldShow` (empty paragraph
+   * at cursor start).
    */
   shouldShow: (props: {
     editor: Editor;
@@ -87,10 +73,20 @@ export interface FloatingMenuOptions {
   }) => boolean;
 
   /**
-   * Offset in pixels from the cursor position.
-   * @default 0
+   * Pixel offset from the anchor. @default 0
    */
   offset: number;
+
+  /**
+   * Items override. Array replaces defaults entirely; function receives
+   * the collected defaults and returns a new list (filter/reorder/extend).
+   * Consumed by the controller; the plugin itself only reads it when the
+   * wrapper does not construct its own controller.
+   */
+  items?: FloatingMenuItemsOverride;
+
+  /** Keyboard shortcuts for entering the menu via keyboard. */
+  keymap?: FloatingMenuKeymap;
 }
 
 export interface CreateFloatingMenuPluginOptions {
@@ -99,12 +95,38 @@ export interface CreateFloatingMenuPluginOptions {
   element: HTMLElement;
   shouldShow?: FloatingMenuOptions['shouldShow'];
   offset?: number;
+  keymap?: FloatingMenuKeymap | undefined;
 }
 
 /**
- * Creates a standalone FloatingMenu ProseMirror plugin.
- * Can be used by framework wrappers (Angular, React, Vue) to create the plugin
- * independently of the extension system.
+ * Parses a shortcut string like `Alt-F10` or `Mod-/` against a keyboard
+ * event. `Mod` maps to Cmd on macOS, Ctrl elsewhere.
+ */
+function matchShortcut(event: KeyboardEvent, shortcut: string): boolean {
+  const parts = shortcut.split('-');
+  const key = parts[parts.length - 1];
+  if (!key) return false;
+  const mods = new Set(parts.slice(0, -1));
+  const isMac = /Mac|iPhone|iPad|iPod/i.test(
+    typeof navigator === 'undefined' ? '' : navigator.platform,
+  );
+  const needMod = mods.has('Mod');
+  const needAlt = mods.has('Alt');
+  const needShift = mods.has('Shift');
+  const needCtrl = mods.has('Ctrl') || (needMod && !isMac);
+  const needMeta = mods.has('Meta') || (needMod && isMac);
+
+  if (event.altKey !== needAlt) return false;
+  if (event.shiftKey !== needShift) return false;
+  if (event.ctrlKey !== needCtrl) return false;
+  if (event.metaKey !== needMeta) return false;
+  // Compare case-insensitively; single-char keys use event.key literal.
+  return event.key === key || event.key.toLowerCase() === key.toLowerCase();
+}
+
+/**
+ * Creates a standalone FloatingMenu ProseMirror plugin. Framework wrappers
+ * call this directly so they can own element creation and rendering.
  */
 export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOptions): Plugin {
   const {
@@ -113,24 +135,32 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
     element,
     shouldShow = defaultShouldShow,
     offset = 0,
+    keymap,
   } = options;
 
-  // Set default ARIA attributes if not already provided
+  const enterShortcuts = keymap?.enterMenu ?? DEFAULT_ENTER_MENU_SHORTCUTS;
+
+  // Semantic defaults: `menu` is the right WAI-ARIA role for a transient
+  // list of single-action choices (unlike `toolbar` which implies a
+  // persistent set of controls).
   if (!element.getAttribute('role')) {
-    element.setAttribute('role', 'toolbar');
-    element.setAttribute('aria-label', 'Floating menu');
+    element.setAttribute('role', 'menu');
+    element.setAttribute('aria-label', 'Insert block');
   }
 
   let cleanupFloating: (() => void) | null = null;
+  let editorEl: Element | null = null;
+  let clickOutsideHandler: ((e: Event) => void) | null = null;
+  let dismissOverlayHandler: (() => void) | null = null;
+
+  const isVisible = (): boolean => element.hasAttribute('data-show');
 
   const updatePosition = (view: EditorView): void => {
     const { selection } = view.state;
     const { $from } = selection;
-
     const depth = $from.depth;
     const startPos = $from.start(depth);
     const domNode = view.nodeDOM(startPos - 1);
-
     if (domNode instanceof HTMLElement) {
       cleanupFloating?.();
       cleanupFloating = positionFloatingOnce(domNode, element, {
@@ -147,16 +177,46 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
     element.removeAttribute('data-show');
   };
 
-  // Initially hide
+  // Focus first menuitem. Wrappers mark each item with
+  // `data-floating-menu-item`; falls back to any focusable descendant.
+  const focusFirstItem = (): boolean => {
+    const first =
+      element.querySelector<HTMLElement>('[data-floating-menu-item]:not([aria-disabled="true"])')
+      ?? element.querySelector<HTMLElement>('button, [tabindex]:not([tabindex="-1"])');
+    if (!first) return false;
+    first.focus();
+    return true;
+  };
+
+  // Hide initially (wrappers may render the element before the plugin runs).
   hideMenu();
 
   return new Plugin({
     key: pluginKey,
 
+    props: {
+      // Keyboard entry from the editor. ProseMirror's handleKeyDown fires
+      // before browser defaults, so we can intercept without risking
+      // interference with typing. We only act while the menu is visible.
+      handleKeyDown(_view, event): boolean {
+        if (!isVisible()) return false;
+        for (const shortcut of enterShortcuts) {
+          if (matchShortcut(event, shortcut)) {
+            if (focusFirstItem()) {
+              event.preventDefault();
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      },
+    },
+
     view: (editorView) => {
-      // Move element inside .dm-editor (position:relative) so it uses
-      // position:absolute — CSS compositor handles scroll, zero jitter.
-      const editorEl = editorView.dom.closest('.dm-editor');
+      // Move the menu into `.dm-editor` so `position:absolute` resolves
+      // against the scrollable editor container — zero jitter on scroll.
+      editorEl = editorView.dom.closest('.dm-editor');
       if (editorEl && element.parentElement !== editorEl) {
         editorEl.appendChild(element);
       }
@@ -167,19 +227,37 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
           view: editor.view,
           state: editor.view.state,
         });
-        if (visible) {
-          updatePosition(editor.view);
-        } else {
-          hideMenu();
-        }
+        if (visible) updatePosition(editor.view);
+        else hideMenu();
       };
 
       const onBlur = ({ event }: { event: FocusEvent }): void => {
+        // Keep the menu visible if focus moved into it — users can
+        // interact with menu items without the menu vanishing.
         if (event.relatedTarget && element.contains(event.relatedTarget as Node)) {
           return;
         }
         hideMenu();
       };
+
+      // Click-outside dismissal. Capture phase ensures we fire before
+      // other UI (dropdowns, popovers) handles the same click.
+      clickOutsideHandler = (e: Event): void => {
+        if (!isVisible()) return;
+        const target = e.target as Node | null;
+        if (!target) return;
+        if (element.contains(target)) return;
+        if (editor.view.dom.contains(target)) return;
+        hideMenu();
+      };
+      document.addEventListener('mousedown', clickOutsideHandler, true);
+
+      // Cooperative dismissal: other overlays (toolbar dropdowns,
+      // popovers) broadcast this event to close any open chrome.
+      if (editorEl) {
+        dismissOverlayHandler = (): void => { hideMenu(); };
+        editorEl.addEventListener('dm:dismiss-overlays', dismissOverlayHandler);
+      }
 
       editor.on('focus', onFocus);
       editor.on('blur', onBlur);
@@ -191,18 +269,23 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
             view,
             state: view.state,
           });
-
-          if (visible) {
-            updatePosition(view);
-          } else {
-            hideMenu();
-          }
+          if (visible) updatePosition(view);
+          else hideMenu();
         },
 
         destroy: () => {
           hideMenu();
           editor.off('focus', onFocus);
           editor.off('blur', onBlur);
+          if (clickOutsideHandler) {
+            document.removeEventListener('mousedown', clickOutsideHandler, true);
+            clickOutsideHandler = null;
+          }
+          if (dismissOverlayHandler && editorEl) {
+            editorEl.removeEventListener('dm:dismiss-overlays', dismissOverlayHandler);
+            dismissOverlayHandler = null;
+          }
+          editorEl = null;
         },
       };
     },
@@ -221,16 +304,10 @@ export const FloatingMenu = Extension.create<FloatingMenuOptions>({
   },
 
   addProseMirrorPlugins() {
-    const { element, shouldShow, offset } = this.options;
-
-    if (!element) {
-      return [];
-    }
-
+    const { element, shouldShow, offset, keymap } = this.options;
+    if (!element) return [];
     const editor = this.editor as Editor | null;
-    if (!editor) {
-      return [];
-    }
+    if (!editor) return [];
 
     return [
       createFloatingMenuPlugin({
@@ -239,6 +316,7 @@ export const FloatingMenu = Extension.create<FloatingMenuOptions>({
         element,
         shouldShow,
         offset,
+        keymap,
       }),
     ];
   },

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -80,6 +80,7 @@ export {
   floatingMenuPluginKey,
   type FloatingMenuOptions,
   type CreateFloatingMenuPluginOptions,
+  type FloatingMenuKeymap,
 } from './FloatingMenu.js';
 
 // Bundle

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,9 @@ export type {
   ToolbarItem,
   ToolbarLayoutDropdown,
   ToolbarLayoutEntry,
+  // Floating menu types
+  FloatingMenuItem,
+  FloatingMenuItemsOverride,
 } from './types/index.js';
 
 // === ProseMirror re-exports (for framework wrappers) ===
@@ -148,6 +151,13 @@ export {
   type ToolbarControllerEditor,
   type ToolbarGroup,
 } from './ToolbarController.js';
+
+// === Floating Menu Controller ===
+export {
+  FloatingMenuController,
+  FLOATING_MENU_NO_FOCUS,
+  type FloatingMenuGroup,
+} from './FloatingMenuController.js';
 
 // === Icons ===
 export { defaultIcons } from './icons/index.js';
@@ -344,6 +354,7 @@ export {
   floatingMenuPluginKey,
   type FloatingMenuOptions,
   type CreateFloatingMenuPluginOptions,
+  type FloatingMenuKeymap,
   // Bundle
   StarterKit,
   type StarterKitOptions,

--- a/packages/core/src/nodes/Blockquote.ts
+++ b/packages/core/src/nodes/Blockquote.ts
@@ -9,6 +9,7 @@ import { Node } from '../Node.js';
 import { wrappingInputRule } from '../helpers/wrappingInputRule.js';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 
 declare module '../types/Commands.js' {
   interface RawCommands {
@@ -84,6 +85,22 @@ export const Blockquote = Node.create<BlockquoteOptions>({
         shortcut: 'Mod-Shift-B',
         group: 'blocks',
         priority: 150,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'blockquote',
+        label: 'Quote',
+        description: 'Capture a quote',
+        icon: 'quotes',
+        group: 'Basic',
+        priority: 170,
+        keywords: ['quote', 'blockquote', 'citation'],
+        shortcut: '> ',
+        command: 'toggleBlockquote',
       },
     ];
   },

--- a/packages/core/src/nodes/BulletList.ts
+++ b/packages/core/src/nodes/BulletList.ts
@@ -9,6 +9,7 @@ import { Node } from '../Node.js';
 import { wrappingInputRule, notInsideList } from '../helpers/wrappingInputRule.js';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 import { ListItem } from './ListItem.js';
 
 declare module '../types/Commands.js' {
@@ -65,6 +66,22 @@ export const BulletList = Node.create<BulletListOptions>({
         shortcut: 'Mod-Shift-8',
         group: 'lists',
         priority: 200,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'bullet-list',
+        label: 'Bulleted list',
+        description: 'Create a simple bulleted list',
+        icon: 'listBullets',
+        group: 'Lists',
+        priority: 200,
+        keywords: ['bullet', 'list', 'unordered', 'ul'],
+        shortcut: '- ',
+        command: 'toggleBulletList',
       },
     ];
   },

--- a/packages/core/src/nodes/CodeBlock.ts
+++ b/packages/core/src/nodes/CodeBlock.ts
@@ -15,6 +15,7 @@ import { textblockTypeInputRule } from '../helpers/textblockTypeInputRule.js';
 import { TextSelection } from '@domternal/pm/state';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 
 declare module '../types/Commands.js' {
   interface RawCommands {
@@ -167,6 +168,22 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
         shortcut: 'Mod-Alt-C',
         group: 'blocks',
         priority: 140,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'code-block',
+        label: 'Code block',
+        description: 'Capture a code snippet',
+        icon: 'codeBlock',
+        group: 'Basic',
+        priority: 160,
+        keywords: ['code', 'snippet', 'pre'],
+        shortcut: '``` ',
+        command: 'toggleCodeBlock',
       },
     ];
   },

--- a/packages/core/src/nodes/Heading.ts
+++ b/packages/core/src/nodes/Heading.ts
@@ -12,6 +12,7 @@ import { Plugin, PluginKey } from '@domternal/pm/state';
 import type { Command as PMCommand } from '@domternal/pm/state';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem, ToolbarButton } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 
 declare module '../types/Commands.js' {
   interface RawCommands {
@@ -149,6 +150,34 @@ export const Heading = Node.create<HeadingOptions>({
         dynamicIcon: true,
       },
     ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    const iconMap: Record<number, string> = {
+      1: 'textHOne',
+      2: 'textHTwo',
+      3: 'textHThree',
+    };
+    const descriptionMap: Record<number, string> = {
+      1: 'Big section heading',
+      2: 'Medium section heading',
+      3: 'Small section heading',
+    };
+    // Only levels 1-3 in the quick-insert menu; deeper levels stay toolbar-only.
+    return this.options.levels
+      .filter((level) => level <= 3)
+      .map((level): FloatingMenuItem => ({
+        name: `heading-${String(level)}`,
+        label: `Heading ${String(level)}`,
+        description: descriptionMap[level] ?? 'Section heading',
+        icon: iconMap[level] ?? 'textH',
+        group: 'Basic',
+        priority: 210 - level * 10,
+        keywords: ['heading', `h${String(level)}`, 'title'],
+        shortcut: '#'.repeat(level) + ' ',
+        command: 'toggleHeading',
+        commandArgs: [{ level }],
+      }));
   },
 
   addProseMirrorPlugins() {

--- a/packages/core/src/nodes/HorizontalRule.ts
+++ b/packages/core/src/nodes/HorizontalRule.ts
@@ -11,6 +11,7 @@ import type { EditorState } from '@domternal/pm/state';
 import { TextSelection } from '@domternal/pm/state';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 
 declare module '../types/Commands.js' {
   interface RawCommands {
@@ -101,6 +102,22 @@ export const HorizontalRule = Node.create<HorizontalRuleOptions>({
         label: 'Horizontal Rule',
         group: 'blocks',
         priority: 130,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'horizontal-rule',
+        label: 'Divider',
+        description: 'Insert a horizontal rule',
+        icon: 'minus',
+        group: 'Basic',
+        priority: 150,
+        keywords: ['divider', 'hr', 'line', 'separator', 'horizontal rule'],
+        shortcut: '--- ',
+        command: 'setHorizontalRule',
       },
     ];
   },

--- a/packages/core/src/nodes/OrderedList.ts
+++ b/packages/core/src/nodes/OrderedList.ts
@@ -9,6 +9,7 @@ import { Node } from '../Node.js';
 import { wrappingInputRule, notInsideList } from '../helpers/wrappingInputRule.js';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 import { ListItem } from './ListItem.js';
 
 declare module '../types/Commands.js' {
@@ -84,6 +85,22 @@ export const OrderedList = Node.create<OrderedListOptions>({
         shortcut: 'Mod-Shift-7',
         group: 'lists',
         priority: 190,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'ordered-list',
+        label: 'Numbered list',
+        description: 'Create a numbered list',
+        icon: 'listNumbers',
+        group: 'Lists',
+        priority: 190,
+        keywords: ['ordered', 'numbered', 'list', 'ol', '1.'],
+        shortcut: '1. ',
+        command: 'toggleOrderedList',
       },
     ];
   },

--- a/packages/core/src/nodes/TaskList.ts
+++ b/packages/core/src/nodes/TaskList.ts
@@ -9,6 +9,7 @@ import { Node } from '../Node.js';
 import { wrappingInputRule, notInsideList } from '../helpers/wrappingInputRule.js';
 import type { CommandSpec } from '../types/Commands.js';
 import type { ToolbarItem } from '../types/Toolbar.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
 import { TaskItem } from './TaskItem.js';
 
 declare module '../types/Commands.js' {
@@ -87,6 +88,22 @@ export const TaskList = Node.create<TaskListOptions>({
         shortcut: 'Mod-Shift-9',
         group: 'lists',
         priority: 170,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'task-list',
+        label: 'To-do list',
+        description: 'Track tasks with a checkbox list',
+        icon: 'listChecks',
+        group: 'Lists',
+        priority: 180,
+        keywords: ['todo', 'task', 'checkbox', 'check'],
+        shortcut: '[ ] ',
+        command: 'toggleTaskList',
       },
     ];
   },

--- a/packages/core/src/types/ExtensionConfig.ts
+++ b/packages/core/src/types/ExtensionConfig.ts
@@ -10,6 +10,7 @@ import type { InputRule } from '@domternal/pm/inputrules';
 import type { EditorView } from '@domternal/pm/view';
 import type { Command, KeyboardShortcutCommand, SingleCommands } from './Commands.js';
 import type { ToolbarItem } from './Toolbar.js';
+import type { FloatingMenuItem } from './FloatingMenu.js';
 
 /**
  * Editor instance type (forward declaration)
@@ -241,6 +242,27 @@ export interface ExtensionConfigBase<Options = unknown, Storage = unknown> {
    * }
    */
   addToolbarItems?: () => ToolbarItem[];
+
+  /**
+   * Floating-menu items this extension contributes.
+   * Block-insert menu shown on empty paragraphs aggregates these items
+   * across all extensions. Framework wrappers render them as a WAI-ARIA
+   * menu with groups, arrow-key navigation, and Enter to execute.
+   *
+   * @example
+   * addFloatingMenuItems() {
+   *   return [{
+   *     name: 'heading-1',
+   *     label: 'Heading 1',
+   *     description: 'Big section heading',
+   *     icon: 'textHOne',
+   *     group: 'Basic',
+   *     command: 'toggleHeading',
+   *     commandArgs: [{ level: 1 }],
+   *   }];
+   * }
+   */
+  addFloatingMenuItems?: () => FloatingMenuItem[];
 
   // === Lifecycle Hooks ===
 

--- a/packages/core/src/types/FloatingMenu.ts
+++ b/packages/core/src/types/FloatingMenu.ts
@@ -1,0 +1,87 @@
+/**
+ * FloatingMenu configuration types
+ *
+ * Types for block-insert items contributed by extensions via the
+ * `addFloatingMenuItems()` hook. Framework wrappers read these items
+ * and render a WAI-ARIA menu shown on empty paragraphs.
+ */
+
+import type { Editor } from '../Editor.js';
+
+/**
+ * A single entry in the floating menu.
+ *
+ * Unlike `ToolbarButton`, floating-menu items represent one-shot insert
+ * actions (no toggle / active state), carry an optional `description` for
+ * Notion-style two-line rendering, and expose `keywords` for future
+ * slash-command filtering.
+ *
+ * @example
+ * {
+ *   name: 'heading-1',
+ *   label: 'Heading 1',
+ *   description: 'Big section heading',
+ *   icon: 'textHOne',
+ *   group: 'Basic',
+ *   shortcut: '# ',
+ *   command: 'toggleHeading',
+ *   commandArgs: [{ level: 1 }],
+ * }
+ */
+export interface FloatingMenuItem {
+  /** Unique identifier (used as React key, aria id, and dedup key when merging). */
+  name: string;
+
+  /** Primary label shown to the user. */
+  label: string;
+
+  /** Optional secondary line shown under the label. */
+  description?: string;
+
+  /** Icon key resolved against the editor's IconSet. Optional. */
+  icon?: string;
+
+  /**
+   * Group heading. Items with the same group render under a shared
+   * `<div role="group" aria-label={group}>` section.
+   * @default '' (no group heading)
+   */
+  group?: string;
+
+  /** Sort order within group (higher first). @default 100 */
+  priority?: number;
+
+  /** Keywords for future slash-command fuzzy filtering. */
+  keywords?: string[];
+
+  /** Visible keyboard-shortcut hint (e.g. `# `, `Mod-Alt-1`). */
+  shortcut?: string;
+
+  /**
+   * Command to execute on activation.
+   *
+   * - String: key of `editor.commands`; invoked with `commandArgs`.
+   * - Function: arbitrary callback receiving the editor. Use when the
+   *   action is not a registered command (e.g. opening a popover).
+   */
+  command: string | ((editor: Editor) => void);
+
+  /** Arguments for string commands. Ignored when `command` is a function. */
+  commandArgs?: unknown[];
+
+  /**
+   * Custom disabled predicate. When omitted, the controller dry-runs the
+   * command via `editor.can()` (string commands only) to detect availability.
+   */
+  isDisabled?: (editor: Editor) => boolean;
+}
+
+/**
+ * Override form accepted by `FloatingMenu.configure({ items })`.
+ *
+ * - Array: replaces the collected defaults entirely.
+ * - Function: transforms the defaults (filter / reorder / extend).
+ */
+export type FloatingMenuItemsOverride =
+  | FloatingMenuItem[]
+  | ((defaults: FloatingMenuItem[], editor: Editor) => FloatingMenuItem[]);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -86,3 +86,9 @@ export type {
   ToolbarLayoutDropdown,
   ToolbarLayoutEntry,
 } from './Toolbar.js';
+
+// Floating menu types
+export type {
+  FloatingMenuItem,
+  FloatingMenuItemsOverride,
+} from './FloatingMenu.js';

--- a/packages/extension-details/src/Details.ts
+++ b/packages/extension-details/src/Details.ts
@@ -16,7 +16,7 @@
  */
 
 import { Node, findParentNode, findChildren, defaultBlockAt } from '@domternal/core';
-import type { CommandSpec, ToolbarItem } from '@domternal/core';
+import type { CommandSpec, ToolbarItem, FloatingMenuItem } from '@domternal/core';
 import { Plugin, PluginKey, Selection, TextSelection } from '@domternal/pm/state';
 import type { ViewMutationRecord } from '@domternal/pm/view';
 import { isNodeVisible } from './helpers/isNodeVisible.js';
@@ -204,6 +204,21 @@ export const Details = Node.create<DetailsOptions>({
         label: 'Toggle Details',
         group: 'insert',
         priority: 100,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'details',
+        label: 'Toggle block',
+        description: 'Collapsible content area',
+        icon: 'caretCircleRight',
+        group: 'Advanced',
+        priority: 100,
+        keywords: ['toggle', 'collapse', 'details', 'accordion'],
+        command: 'toggleDetails',
       },
     ];
   },

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -16,7 +16,7 @@
  */
 
 import { Node, PluginKey, positionFloating, defaultIcons } from '@domternal/core';
-import type { Editor, CommandSpec, ToolbarItem } from '@domternal/core';
+import type { Editor, CommandSpec, ToolbarItem, FloatingMenuItem } from '@domternal/core';
 import { Plugin, NodeSelection } from '@domternal/pm/state';
 import { InputRule } from '@domternal/pm/inputrules';
 import type { Node as PmNode } from '@domternal/pm/model';
@@ -314,6 +314,28 @@ export const Image = Node.create<ImageOptions>({
       { type: 'button', name: 'imageFloatRight', command: 'setImageFloat', commandArgs: ['right'], icon: 'textAlignRight', label: 'Float right', group: 'image-float', priority: 70, isActive: { name: 'image', attributes: { float: 'right' } }, toolbar: false, bubbleMenu: 'image' },
       // Bubble menu only: delete
       { type: 'button', name: 'deleteImage', command: 'deleteImage', icon: 'trash', label: 'Delete', group: 'image-actions', priority: 50, toolbar: false, bubbleMenu: 'image' },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'image',
+        label: 'Image',
+        description: 'Upload or embed with a link',
+        icon: 'image',
+        group: 'Media',
+        priority: 200,
+        keywords: ['image', 'picture', 'photo', 'img'],
+        // Open the image URL popover. Matches the toolbar's `emitEvent` flow:
+        // subscribers listen for `insertImage` to mount the popover UI.
+        command: (editor) => {
+          (editor as unknown as { emit: (event: string, payload: unknown) => void }).emit(
+            'insertImage',
+            {},
+          );
+        },
+      },
     ];
   },
 

--- a/packages/extension-table/src/Table.ts
+++ b/packages/extension-table/src/Table.ts
@@ -28,7 +28,7 @@
  */
 
 import { Node } from '@domternal/core';
-import type { CommandSpec, ToolbarItem } from '@domternal/core';
+import type { CommandSpec, ToolbarItem, FloatingMenuItem } from '@domternal/core';
 import { TextSelection } from '@domternal/pm/state';
 import type { Transaction } from '@domternal/pm/state';
 import type { Node as PMNode } from '@domternal/pm/model';
@@ -430,6 +430,21 @@ export const Table = Node.create<TableOptions>({
         label: 'Insert Table',
         group: 'insert',
         priority: 140,
+      },
+    ];
+  },
+
+  addFloatingMenuItems(): FloatingMenuItem[] {
+    return [
+      {
+        name: 'table',
+        label: 'Table',
+        description: 'Insert a simple table',
+        icon: 'table',
+        group: 'Media',
+        priority: 190,
+        keywords: ['table', 'grid', 'rows', 'columns'],
+        command: 'insertTable',
       },
     ];
   },

--- a/packages/react/src/DomternalFloatingMenu.tsx
+++ b/packages/react/src/DomternalFloatingMenu.tsx
@@ -1,23 +1,63 @@
-import { useEffect, useRef, type ReactNode } from 'react';
-import { PluginKey, createFloatingMenuPlugin } from '@domternal/core';
-import type { Editor, FloatingMenuOptions } from '@domternal/core';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from 'react';
+import {
+  PluginKey,
+  createFloatingMenuPlugin,
+  FloatingMenuController,
+  defaultIcons,
+} from '@domternal/core';
+import type {
+  Editor,
+  FloatingMenuItem,
+  FloatingMenuItemsOverride,
+  FloatingMenuKeymap,
+  FloatingMenuOptions,
+  IconSet,
+} from '@domternal/core';
 import { useCurrentEditor } from './EditorContext.js';
 
 export interface DomternalFloatingMenuProps {
   /** The editor instance. If omitted, uses EditorProvider context. */
   editor?: Editor;
-  /** Custom visibility function. */
+  /** Custom visibility predicate. */
   shouldShow?: FloatingMenuOptions['shouldShow'];
-  /** Pixel offset from trigger. @default 0 */
+  /** Pixel offset from trigger anchor. @default 0 */
   offset?: number;
-  /** Content to render inside the floating menu. */
-  children?: React.ReactNode;
+  /** Items override (array replaces defaults; function transforms them). */
+  items?: FloatingMenuItemsOverride;
+  /** Keyboard shortcuts for entering the menu via keyboard. */
+  keymap?: FloatingMenuKeymap;
+  /** Custom icon set (falls back to `@domternal/core`'s `defaultIcons`). */
+  icons?: IconSet;
+  /**
+   * Optional custom content. When provided, the default grouped-item
+   * rendering is skipped and children are rendered inside the menu element.
+   */
+  children?: ReactNode;
 }
 
+/**
+ * Block-insert floating menu. Renders defaults collected from the editor's
+ * extensions via `addFloatingMenuItems()`; pass `items` to override or
+ * `children` to render a fully custom UI.
+ */
 export function DomternalFloatingMenu({
   editor: editorProp,
   shouldShow,
   offset = 0,
+  items,
+  keymap,
+  icons,
   children,
 }: DomternalFloatingMenuProps): ReactNode {
   const { editor: contextEditor } = useCurrentEditor();
@@ -28,14 +68,17 @@ export function DomternalFloatingMenu({
     new PluginKey('reactFloatingMenu-' + Math.random().toString(36).slice(2, 8)),
   );
 
+  // Refs so the effect below can read current prop values without re-running.
   const shouldShowRef = useRef(shouldShow);
   shouldShowRef.current = shouldShow;
   const offsetRef = useRef(offset);
   offsetRef.current = offset;
+  const keymapRef = useRef(keymap);
+  keymapRef.current = keymap;
 
+  // Register the ProseMirror plugin (visibility + positioning + dismiss).
   useEffect(() => {
     if (!editor || editor.isDestroyed || !menuRef.current) return;
-
     const pluginKey = pluginKeyRef.current;
     const plugin = createFloatingMenuPlugin({
       pluginKey,
@@ -43,19 +86,219 @@ export function DomternalFloatingMenu({
       element: menuRef.current,
       ...(shouldShowRef.current && { shouldShow: shouldShowRef.current }),
       offset: offsetRef.current,
+      ...(keymapRef.current && { keymap: keymapRef.current }),
     });
     editor.registerPlugin(plugin);
-
     return () => {
-      if (!editor.isDestroyed) {
-        editor.unregisterPlugin(pluginKey);
-      }
+      if (!editor.isDestroyed) editor.unregisterPlugin(pluginKey);
     };
   }, [editor]);
 
+  // === Default rendering mode ===
+  // When consumer provides children we skip the controller entirely and
+  // render whatever they passed. Otherwise we collect items via the
+  // controller and render a WAI-ARIA menu with roving-tabindex keyboard nav.
+  const useDefaultRender = !children;
+
+  // Subscribe to controller state changes via a version counter. Using
+  // useState bump (instead of useSyncExternalStore) keeps this compatible
+  // with React concurrent mode while avoiding extra adapter code.
+  const [, bump] = useState(0);
+  const forceRender = useCallback((): void => { bump((v) => v + 1); }, []);
+
+  const controllerRef = useRef<FloatingMenuController | null>(null);
+
+  useEffect(() => {
+    if (!useDefaultRender || !editor || editor.isDestroyed) {
+      controllerRef.current = null;
+      return;
+    }
+    const controller = new FloatingMenuController(editor, forceRender, items);
+    controller.subscribe();
+    controllerRef.current = controller;
+    return () => {
+      controller.destroy();
+      controllerRef.current = null;
+    };
+  }, [editor, useDefaultRender, items, forceRender]);
+
+  const controller = controllerRef.current;
+  const groups = useMemo(() => controller?.groups ?? [], [controller]);
+  const focusedIndex = controller?.focusedIndex ?? -1;
+
+  // Imperative focus management: whenever focusedIndex changes and is in
+  // range, focus the matching DOM button. This is the roving-tabindex
+  // "accessible focus" pattern used by the WAI-ARIA menu spec.
+  useLayoutEffect(() => {
+    if (focusedIndex < 0 || !menuRef.current) return;
+    const target = menuRef.current.querySelector<HTMLElement>(
+      `[data-floating-menu-index="${String(focusedIndex)}"]`,
+    );
+    target?.focus();
+  }, [focusedIndex]);
+
+  // Resolve an icon name to SVG string; consumer-provided icon set wins.
+  const resolveIcon = useCallback((name?: string): string => {
+    if (!name) return '';
+    return icons?.[name] ?? defaultIcons[name] ?? '';
+  }, [icons]);
+
+  const onItemClick = useCallback((item: FloatingMenuItem): void => {
+    if (!editor || !controllerRef.current) return;
+    controllerRef.current.execute(item);
+    // Return focus to the editor so selection/cursor remain where expected.
+    requestAnimationFrame(() => { editor.view.focus(); });
+  }, [editor]);
+
+  const onMenuKeyDown = useCallback((e: ReactKeyboardEvent<HTMLDivElement>): void => {
+    const ctl = controllerRef.current;
+    if (!ctl) return;
+    const focused = ctl.focusedItem();
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        ctl.next();
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        ctl.prev();
+        return;
+      case 'Home':
+        e.preventDefault();
+        ctl.first();
+        return;
+      case 'End':
+        e.preventDefault();
+        ctl.last();
+        return;
+      case 'Escape':
+        e.preventDefault();
+        e.stopPropagation();
+        ctl.leaveMenu();
+        if (editor) editor.view.focus();
+        return;
+      case 'Enter':
+      case ' ':
+        if (focused) {
+          e.preventDefault();
+          onItemClick(focused);
+        }
+        return;
+      default:
+        return;
+    }
+  }, [editor, onItemClick]);
+
+  // Flatten once per render so child item renders can derive their flat index.
+  const flatNames = useMemo(
+    () => groups.flatMap((g) => g.items.map((i) => i.name)),
+    [groups],
+  );
+
+  if (!editor && !useDefaultRender) return null;
+
   return (
-    <div ref={menuRef} className="dm-floating-menu">
-      {children}
+    <div
+      ref={menuRef}
+      className="dm-floating-menu"
+      role="menu"
+      aria-label="Insert block"
+      data-dm-editor-ui=""
+      onKeyDown={useDefaultRender ? onMenuKeyDown : undefined}
+    >
+      {useDefaultRender
+        ? groups.map((group, gi) => (
+          <Fragment key={group.name || `__group-${String(gi)}`}>
+            {group.name && (
+              <div className="dm-floating-menu-group-label" id={`dm-fm-g${String(gi)}`}>
+                {group.name}
+              </div>
+            )}
+            <div
+              className="dm-floating-menu-group"
+              role="group"
+              {...(group.name && { 'aria-labelledby': `dm-fm-g${String(gi)}` })}
+            >
+              {group.items.map((item) => {
+                const flatIndex = flatNames.indexOf(item.name);
+                const isFocused = flatIndex === focusedIndex;
+                const disabled = controller?.isDisabled(item) ?? false;
+                return (
+                  <FloatingMenuItemButton
+                    key={item.name}
+                    item={item}
+                    flatIndex={flatIndex}
+                    tabIndex={isFocused || (focusedIndex < 0 && flatIndex === 0) ? 0 : -1}
+                    disabled={disabled}
+                    iconHtml={resolveIcon(item.icon)}
+                    onClick={onItemClick}
+                  />
+                );
+              })}
+            </div>
+          </Fragment>
+        ))
+        : children}
     </div>
+  );
+}
+
+interface ItemButtonProps {
+  item: FloatingMenuItem;
+  flatIndex: number;
+  tabIndex: 0 | -1;
+  disabled: boolean;
+  iconHtml: string;
+  onClick: (item: FloatingMenuItem) => void;
+}
+
+function FloatingMenuItemButton({
+  item,
+  flatIndex,
+  tabIndex,
+  disabled,
+  iconHtml,
+  onClick,
+}: ItemButtonProps): ReactNode {
+  const handleClick = useCallback((): void => { onClick(item); }, [item, onClick]);
+  // Prevent mousedown from stealing editor focus before we run the command.
+  const onMouseDown = useCallback((e: ReactMouseEvent): void => {
+    e.preventDefault();
+  }, []);
+
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      className="dm-floating-menu-item"
+      data-floating-menu-item={item.name}
+      data-floating-menu-index={String(flatIndex)}
+      tabIndex={tabIndex}
+      aria-disabled={disabled || undefined}
+      aria-keyshortcuts={item.shortcut}
+      disabled={disabled}
+      onClick={handleClick}
+      onMouseDown={onMouseDown}
+    >
+      {iconHtml && (
+        <span
+          className="dm-floating-menu-item-icon"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: iconHtml }}
+        />
+      )}
+      <span className="dm-floating-menu-item-text">
+        <span className="dm-floating-menu-item-label">{item.label}</span>
+        {item.description && (
+          <span className="dm-floating-menu-item-description">{item.description}</span>
+        )}
+      </span>
+      {item.shortcut && (
+        <span className="dm-floating-menu-item-shortcut" aria-hidden="true">
+          {item.shortcut}
+        </span>
+      )}
+    </button>
   );
 }

--- a/packages/react/src/DomternalFloatingMenu.tsx
+++ b/packages/react/src/DomternalFloatingMenu.tsx
@@ -116,6 +116,10 @@ export function DomternalFloatingMenu({
     const controller = new FloatingMenuController(editor, forceRender, items);
     controller.subscribe();
     controllerRef.current = controller;
+    // Controller is stored on a ref (not state) — React won't re-render on
+    // that assignment, so trigger a bump so the next render reads the newly
+    // available groups/focusedIndex.
+    forceRender();
     return () => {
       controller.destroy();
       controllerRef.current = null;
@@ -288,12 +292,7 @@ function FloatingMenuItemButton({
           dangerouslySetInnerHTML={{ __html: iconHtml }}
         />
       )}
-      <span className="dm-floating-menu-item-text">
-        <span className="dm-floating-menu-item-label">{item.label}</span>
-        {item.description && (
-          <span className="dm-floating-menu-item-description">{item.description}</span>
-        )}
-      </span>
+      <span className="dm-floating-menu-item-label">{item.label}</span>
       {item.shortcut && (
         <span className="dm-floating-menu-item-shortcut" aria-hidden="true">
           {item.shortcut}

--- a/packages/react/src/useEditorState.ts
+++ b/packages/react/src/useEditorState.ts
@@ -36,7 +36,6 @@ export function useEditorState<T>(
   // React's hook ordering. The guard below throws a clear error before that
   // corruption happens, instead of relying solely on the ESLint comment below.
   const isSelectorMode = typeof selector === 'function';
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const modeRef = useRef<boolean | null>(null);
   modeRef.current ??= isSelectorMode;
   if (modeRef.current !== isSelectorMode) {

--- a/packages/theme/src/_floating-menu.scss
+++ b/packages/theme/src/_floating-menu.scss
@@ -1,24 +1,153 @@
 // =============================================================================
 // Floating Menu Styles
+//
+// Block-insert menu shown on empty paragraphs. Rendered by framework
+// wrappers as a WAI-ARIA menu with role="menu"/"group"/"menuitem".
 // =============================================================================
 
 .dm-floating-menu {
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: var(--dm-toolbar-gap);
-  padding: var(--dm-toolbar-padding);
+  gap: 0.25rem;
+  min-width: 16rem;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding: 0.375rem;
   background: var(--dm-toolbar-bg);
-  border: var(--dm-toolbar-border);
-  border-radius: var(--dm-button-border-radius);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--dm-border-color, #e5e7eb);
+  border-radius: var(--dm-toolbar-border-radius, 0.5rem);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08), 0 4px 10px rgba(0, 0, 0, 0.04);
   visibility: hidden;
   opacity: 0;
-  transition: opacity 0.2s ease, visibility 0.2s;
+  transition: opacity 0.15s ease, visibility 0.15s;
   z-index: 50;
 
   &[data-show] {
     visibility: visible;
     opacity: 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group heading (e.g. "Basic", "Lists", "Media")
+  // ---------------------------------------------------------------------------
+  &-group-label {
+    padding: 0.375rem 0.5rem 0.125rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--dm-muted, #999);
+    user-select: none;
+  }
+
+  &-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+
+    // Visual separator between unlabelled groups; labelled groups get
+    // spacing from their label instead.
+    & + &:not(:has(+ .dm-floating-menu-group-label)) {
+      margin-top: 0.25rem;
+    }
+  }
+
+  &-group-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Menu item button
+  // ---------------------------------------------------------------------------
+  &-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    width: 100%;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    border-radius: var(--dm-button-border-radius, 0.375rem);
+    background: transparent;
+    color: var(--dm-button-color, inherit);
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 0.12s;
+
+    &:hover:not([aria-disabled="true"]),
+    &:focus:not([aria-disabled="true"]) {
+      background: var(--dm-button-hover-bg, rgba(0, 0, 0, 0.04));
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--dm-accent, #2563eb);
+      outline-offset: -2px;
+    }
+
+    &[aria-disabled="true"],
+    &:disabled {
+      opacity: var(--dm-button-disabled-opacity, 0.45);
+      cursor: not-allowed;
+    }
+  }
+
+  // Icon — square slot with Phosphor SVG
+  &-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    flex-shrink: 0;
+    border-radius: 0.25rem;
+    background: var(--dm-surface, #f8f9fa);
+    color: var(--dm-editor-text, inherit);
+
+    svg {
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+
+  // Text column — label + optional description stacked
+  &-item-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+    line-height: 1.25;
+  }
+
+  &-item-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--dm-editor-text, inherit);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &-item-description {
+    font-size: 0.75rem;
+    color: var(--dm-muted, #999);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Shortcut hint chip (e.g. "# ", "> ", "[ ] ")
+  &-item-shortcut {
+    flex-shrink: 0;
+    padding: 0.0625rem 0.375rem;
+    margin-left: auto;
+    font-family: var(--dm-editor-font-family-mono, ui-monospace, monospace);
+    font-size: 0.6875rem;
+    color: var(--dm-muted, #999);
+    background: var(--dm-surface, #f8f9fa);
+    border: 1px solid var(--dm-border-color, #e5e7eb);
+    border-radius: 0.25rem;
+    user-select: none;
   }
 }

--- a/packages/theme/src/_floating-menu.scss
+++ b/packages/theme/src/_floating-menu.scss
@@ -14,7 +14,10 @@
   max-height: 22rem;
   overflow-y: auto;
   padding: 0.375rem;
-  background: var(--dm-toolbar-bg);
+  // Opaque background — plain color (not translucent) so nested content
+  // under the menu is fully occluded. Fallback chain covers cases where
+  // the menu is reparented outside `.dm-editor` and loses the variable.
+  background: var(--dm-toolbar-bg, var(--dm-bg, #ffffff));
   border: 1px solid var(--dm-border-color, #e5e7eb);
   border-radius: var(--dm-toolbar-border-radius, 0.5rem);
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08), 0 4px 10px rgba(0, 0, 0, 0.04);
@@ -22,6 +25,30 @@
   opacity: 0;
   transition: opacity 0.15s ease, visibility 0.15s;
   z-index: 50;
+
+  // Slim, translucent scrollbar — Firefox via scrollbar-* properties,
+  // Chrome/Safari/Edge via ::-webkit-scrollbar pseudo-elements.
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.18) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.18);
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.28);
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.4);
+  }
 
   &[data-show] {
     visibility: visible;
@@ -59,14 +86,14 @@
   }
 
   // ---------------------------------------------------------------------------
-  // Menu item button
+  // Menu item button (single-line: icon + label + optional shortcut chip)
   // ---------------------------------------------------------------------------
   &-item {
     display: flex;
     align-items: center;
-    gap: 0.625rem;
+    gap: 0.5rem;
     width: 100%;
-    padding: 0.375rem 0.5rem;
+    padding: 0.3125rem 0.5rem;
     border: none;
     border-radius: var(--dm-button-border-radius, 0.375rem);
     background: transparent;
@@ -93,16 +120,14 @@
     }
   }
 
-  // Icon — square slot with Phosphor SVG
+  // Icon slot
   &-item-icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 1.25rem;
+    height: 1.25rem;
     flex-shrink: 0;
-    border-radius: 0.25rem;
-    background: var(--dm-surface, #f8f9fa);
     color: var(--dm-editor-text, inherit);
 
     svg {
@@ -111,37 +136,20 @@
     }
   }
 
-  // Text column — label + optional description stacked
-  &-item-text {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    flex: 1;
-    line-height: 1.25;
-  }
-
   &-item-label {
+    flex: 1;
+    min-width: 0;
     font-size: 0.875rem;
-    font-weight: 500;
     color: var(--dm-editor-text, inherit);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  &-item-description {
-    font-size: 0.75rem;
-    color: var(--dm-muted, #999);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  // Shortcut hint chip (e.g. "# ", "> ", "[ ] ")
+  // Shortcut hint chip (e.g. `# `, `> `, `[ ] `)
   &-item-shortcut {
     flex-shrink: 0;
     padding: 0.0625rem 0.375rem;
-    margin-left: auto;
     font-family: var(--dm-editor-font-family-mono, ui-monospace, monospace);
     font-size: 0.6875rem;
     color: var(--dm-muted, #999);

--- a/packages/theme/src/_floating-menu.scss
+++ b/packages/theme/src/_floating-menu.scss
@@ -1,6 +1,5 @@
 // =============================================================================
 // Floating Menu Styles
-//
 // Block-insert menu shown on empty paragraphs. Rendered by framework
 // wrappers as a WAI-ARIA menu with role="menu"/"group"/"menuitem".
 // =============================================================================
@@ -14,7 +13,8 @@
   max-height: 22rem;
   overflow-y: auto;
   padding: 0.375rem;
-  // Opaque background — plain color (not translucent) so nested content
+
+  // Opaque background - plain color (not translucent) so nested content
   // under the menu is fully occluded. Fallback chain covers cases where
   // the menu is reparented outside `.dm-editor` and loses the variable.
   background: var(--dm-toolbar-bg, var(--dm-bg, #ffffff));

--- a/packages/vue/src/DomternalFloatingMenu.ts
+++ b/packages/vue/src/DomternalFloatingMenu.ts
@@ -1,13 +1,37 @@
-import { defineComponent, h, onMounted, onScopeDispose, ref, watch } from 'vue';
+import {
+  defineComponent,
+  h,
+  nextTick,
+  onMounted,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue';
 import type { PropType } from 'vue';
-import { PluginKey, createFloatingMenuPlugin } from '@domternal/core';
-import type { Editor, FloatingMenuOptions } from '@domternal/core';
+import {
+  PluginKey,
+  createFloatingMenuPlugin,
+  FloatingMenuController,
+  defaultIcons,
+} from '@domternal/core';
+import type {
+  Editor,
+  FloatingMenuItem,
+  FloatingMenuItemsOverride,
+  FloatingMenuKeymap,
+  FloatingMenuOptions,
+  IconSet,
+} from '@domternal/core';
 import { useCurrentEditor } from './EditorContext.js';
 
 export interface DomternalFloatingMenuProps {
   editor?: Editor;
   shouldShow?: FloatingMenuOptions['shouldShow'];
   offset?: number;
+  items?: FloatingMenuItemsOverride;
+  keymap?: FloatingMenuKeymap;
+  icons?: IconSet;
 }
 
 export const DomternalFloatingMenu = defineComponent({
@@ -16,17 +40,39 @@ export const DomternalFloatingMenu = defineComponent({
     editor: { type: Object as PropType<Editor>, default: undefined },
     shouldShow: { type: Function as PropType<FloatingMenuOptions['shouldShow']>, default: undefined },
     offset: { type: Number, default: 0 },
+    items: {
+      type: [Array, Function] as PropType<FloatingMenuItemsOverride>,
+      default: undefined,
+    },
+    keymap: { type: Object as PropType<FloatingMenuKeymap>, default: undefined },
+    icons: { type: Object as PropType<IconSet>, default: undefined },
   },
   setup(props, { slots }) {
     const { editor: contextEditor } = useCurrentEditor();
     const menuRef = ref<HTMLDivElement>();
-    const pluginKey = new PluginKey('vueFloatingMenu-' + Math.random().toString(36).slice(2, 8));
+    const pluginKey = new PluginKey(
+      'vueFloatingMenu-' + Math.random().toString(36).slice(2, 8),
+    );
+
+    // Reactive controller state exposed to the render function.
+    const controller = shallowRef<FloatingMenuController | null>(null);
+    // Bump tracker forces re-renders when controller state changes without
+    // swapping the controller instance.
+    const version = ref(0);
 
     let registered = false;
     let stopWatch: (() => void) | null = null;
+    let currentEditor: Editor | null = null;
+
+    const resolveIcon = (name?: string): string => {
+      if (!name) return '';
+      return props.icons?.[name] ?? defaultIcons[name] ?? '';
+    };
+
     const doRegister = (editor: Editor): void => {
       if (registered || editor.isDestroyed || !menuRef.value) return;
       registered = true;
+      currentEditor = editor;
 
       const plugin = createFloatingMenuPlugin({
         pluginKey,
@@ -34,8 +80,19 @@ export const DomternalFloatingMenu = defineComponent({
         element: menuRef.value,
         ...(props.shouldShow && { shouldShow: props.shouldShow }),
         offset: props.offset,
+        ...(props.keymap && { keymap: props.keymap }),
       });
       editor.registerPlugin(plugin);
+
+      // Only create a controller when consumer did not supply custom
+      // content via the default slot; in that case they own the rendering
+      // and we stay out of their way.
+      const hasCustomSlot = Boolean(slots['default']);
+      if (!hasCustomSlot) {
+        const ctl = new FloatingMenuController(editor, () => { version.value++; }, props.items);
+        ctl.subscribe();
+        controller.value = ctl;
+      }
     };
 
     onMounted(() => {
@@ -56,15 +113,165 @@ export const DomternalFloatingMenu = defineComponent({
       }
     });
 
+    // Imperatively focus the active menuitem when focusedIndex changes.
+    watch(
+      () => [controller.value?.focusedIndex ?? -1, version.value] as const,
+      ([focusedIndex]) => {
+        if (focusedIndex < 0 || !menuRef.value) return;
+        void nextTick(() => {
+          const target = menuRef.value?.querySelector<HTMLElement>(
+            `[data-floating-menu-index="${String(focusedIndex)}"]`,
+          );
+          target?.focus();
+        });
+      },
+    );
+
     onScopeDispose(() => {
       stopWatch?.();
-      const editor = props.editor ?? contextEditor.value;
+      controller.value?.destroy();
+      controller.value = null;
+      const editor = currentEditor ?? props.editor ?? contextEditor.value;
       if (editor && !editor.isDestroyed) {
         editor.unregisterPlugin(pluginKey);
       }
     });
 
-    return () =>
-      h('div', { ref: menuRef, class: 'dm-floating-menu' }, slots['default']?.());
+    const onItemClick = (item: FloatingMenuItem): void => {
+      const ctl = controller.value;
+      const ed = currentEditor;
+      if (!ctl || !ed) return;
+      ctl.execute(item);
+      requestAnimationFrame(() => { ed.view.focus(); });
+    };
+
+    const onMenuKeyDown = (e: KeyboardEvent): void => {
+      const ctl = controller.value;
+      if (!ctl) return;
+      const focused = ctl.focusedItem();
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          ctl.next();
+          return;
+        case 'ArrowUp':
+          e.preventDefault();
+          ctl.prev();
+          return;
+        case 'Home':
+          e.preventDefault();
+          ctl.first();
+          return;
+        case 'End':
+          e.preventDefault();
+          ctl.last();
+          return;
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          ctl.leaveMenu();
+          currentEditor?.view.focus();
+          return;
+        case 'Enter':
+        case ' ':
+          if (focused) {
+            e.preventDefault();
+            onItemClick(focused);
+          }
+          return;
+        default:
+          return;
+      }
+    };
+
+    return () => {
+      // Custom slot: consumer owns rendering.
+      if (slots['default']) {
+        return h(
+          'div',
+          { ref: menuRef, class: 'dm-floating-menu', 'data-dm-editor-ui': '' },
+          slots['default'](),
+        );
+      }
+
+      // Default render: groups of menu items from the controller.
+      const ctl = controller.value;
+      // Read version to ensure reactivity on state changes.
+      void version.value;
+      const groups = ctl?.groups ?? [];
+      const focusedIndex = ctl?.focusedIndex ?? -1;
+
+      // Flat index map for roving tabindex.
+      const flatNames = groups.flatMap((g) => g.items.map((i) => i.name));
+
+      return h(
+        'div',
+        {
+          ref: menuRef,
+          class: 'dm-floating-menu',
+          role: 'menu',
+          'aria-label': 'Insert block',
+          'data-dm-editor-ui': '',
+          onKeydown: onMenuKeyDown,
+        },
+        groups.map((group, gi) => {
+          const groupId = `dm-fm-g${String(gi)}`;
+          return h('div', { key: group.name || `__group-${String(gi)}`, class: 'dm-floating-menu-group-wrapper' }, [
+            group.name
+              ? h('div', { class: 'dm-floating-menu-group-label', id: groupId }, group.name)
+              : null,
+            h(
+              'div',
+              {
+                class: 'dm-floating-menu-group',
+                role: 'group',
+                ...(group.name ? { 'aria-labelledby': groupId } : {}),
+              },
+              group.items.map((item) => {
+                const flatIndex = flatNames.indexOf(item.name);
+                const isFocused = flatIndex === focusedIndex;
+                const disabled = ctl?.isDisabled(item) ?? false;
+                const iconHtml = resolveIcon(item.icon);
+                return h(
+                  'button',
+                  {
+                    key: item.name,
+                    type: 'button',
+                    role: 'menuitem',
+                    class: 'dm-floating-menu-item',
+                    'data-floating-menu-item': item.name,
+                    'data-floating-menu-index': String(flatIndex),
+                    tabindex: isFocused || (focusedIndex < 0 && flatIndex === 0) ? 0 : -1,
+                    'aria-disabled': disabled ? 'true' : undefined,
+                    'aria-keyshortcuts': item.shortcut,
+                    disabled,
+                    onMousedown: (e: Event) => { e.preventDefault(); },
+                    onClick: () => { onItemClick(item); },
+                  },
+                  [
+                    iconHtml
+                      ? h('span', {
+                        class: 'dm-floating-menu-item-icon',
+                        'aria-hidden': 'true',
+                        innerHTML: iconHtml,
+                      })
+                      : null,
+                    h('span', { class: 'dm-floating-menu-item-text' }, [
+                      h('span', { class: 'dm-floating-menu-item-label' }, item.label),
+                      item.description
+                        ? h('span', { class: 'dm-floating-menu-item-description' }, item.description)
+                        : null,
+                    ]),
+                    item.shortcut
+                      ? h('span', { class: 'dm-floating-menu-item-shortcut', 'aria-hidden': 'true' }, item.shortcut)
+                      : null,
+                  ],
+                );
+              }),
+            ),
+          ]);
+        }),
+      );
+    };
   },
 });

--- a/packages/vue/src/DomternalFloatingMenu.ts
+++ b/packages/vue/src/DomternalFloatingMenu.ts
@@ -256,12 +256,7 @@ export const DomternalFloatingMenu = defineComponent({
                         innerHTML: iconHtml,
                       })
                       : null,
-                    h('span', { class: 'dm-floating-menu-item-text' }, [
-                      h('span', { class: 'dm-floating-menu-item-label' }, item.label),
-                      item.description
-                        ? h('span', { class: 'dm-floating-menu-item-description' }, item.description)
-                        : null,
-                    ]),
+                    h('span', { class: 'dm-floating-menu-item-label' }, item.label),
                     item.shortcut
                       ? h('span', { class: 'dm-floating-menu-item-shortcut', 'aria-hidden': 'true' }, item.shortcut)
                       : null,


### PR DESCRIPTION
## Summary
Upgrades the block-insert FloatingMenu from a bare plugin into a first-class feature: extensions now contribute items via a new `addFloatingMenuItems()` hook, a headless `FloatingMenuController` drives grouped rendering and roving-tabindex keyboard nav, and all three framework wrappers (Angular, React, Vue) render a WAI-ARIA-compliant menu with default block-insert items out of the box. Adds a Notion-style demo mode to demo-angular that showcases the menu as the primary block-insertion UI.

## Features
- **`FloatingMenuItem` type + `addFloatingMenuItems()` extension hook** — built-in extensions (Heading, BulletList, OrderedList, TaskList, Blockquote, CodeBlock, HorizontalRule, Image, Table, Details) contribute 10+ default items with icon, label, shortcut hint, keywords, and group.
- **Items override** via `items: FloatingMenuItem[] | ((defaults, editor) => FloatingMenuItem[])` — array replaces, function transforms.
- **`FloatingMenuController`** headless state machine (mirrors ToolbarController) — groups, focused index, `execute()`, `isDisabled()`, `next()`/`prev()`/`first()`/`last()`/`enterMenu()`/`leaveMenu()`.
- **WAI-ARIA `role="menu"` + `role="group"` + `role="menuitem"`** — replaces the previous `toolbar` role which was semantically wrong for a transient single-action popup.
- **Keyboard entry**: `Alt-F10` (WAI-ARIA standard) and `Mod-/` (modern default); customizable via `keymap.enterMenu`. `ArrowUp`/`ArrowDown`/`Home`/`End` navigate, `Enter`/`Space` execute, `Escape` returns focus to editor.
- **Dismissal**: document-level click-outside (capture phase) + cooperative `dm:dismiss-overlays` event listener.
- **Framework wrappers**: React/Vue/Angular render grouped items with roving tabindex, icon resolution (cached, `defaultIcons` fallback), `mousedown.preventDefault` to keep editor focus during click-to-execute, then `requestAnimationFrame` → `view.focus()` to restore cursor position.
- **Theme**: new `_floating-menu.scss` with group labels, single-line items (icon + label + shortcut chip), focus-visible ring, slim custom scrollbar (Firefox `scrollbar-width: thin` + WebKit `::-webkit-scrollbar` 6px), opaque background fallback chain.
- **Notion-style demo** in demo-angular — third mode ("Notion style") with no toolbar, clean page (borderless, 46rem max-width, 1.0625rem font, 1.7 line-height), bubble menu + floating menu as the only chrome.

## Verified
- `pnpm build` succeeds for @domternal/core, @domternal/react, @domternal/vue, @domternal/angular, @domternal/theme, @domternal/extension-image, @domternal/extension-table, @domternal/extension-details
- `pnpm typecheck` clean across core, react, vue, demo-react, demo-vue; `ng build` clean for demo-angular
- `pnpm lint` clean for core, react, vue, angular (pre-existing unrelated warning in useEditorState.ts)
- `pnpm test` in core: 2153 passed, 2 skipped, 0 failed (existing FloatingMenu test updated for new `role="menu"` / `aria-label="Insert block"` defaults)
- Manually tested in demo-angular browser: menu appears on empty paragraph, groups render (Basic/Lists/Media/Advanced), icon + label + shortcut chip layout, scrollbar is slim, click inserts block, keyboard nav works, Notion-mode switches to clean layout
- `.angular` build cache cleared before each demo rebuild (as per CLAUDE.md requirement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Notion-like editor demo showcasing an enhanced floating menu for block insertion
  * Enhanced floating menu with full keyboard navigation (arrow keys, Home/End, Escape, Enter/Space)
  * Extended floating menu customization with keyboard shortcuts, item overrides, and icon support
  * Integrated floating menu items across block types for quick insertion

* **Style**
  * Updated floating menu styling with scrollable panel design and improved accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->