### PR TITLE
feat(angular,react,vue,vanilla): add icons prop on DomternalBubbleMenu

### DIFF
--- a/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
@@ -1,0 +1,423 @@
+/**
+ * E2E coverage for the `icons` override on `DomternalBubbleMenu`.
+ *
+ * Fixtures: `src/bubble-icons-fixtures.ts`. Activated via URL params
+ * `?bubble-icons=full|partial|empty|malformed|html|default` and
+ * `?bubble-items=bold,italic,strike`. Runtime swap via
+ * `window.__DEMO_SET_BUBBLE_ICONS__('full' | null)`.
+ */
+
+import { test } from './fixtures.js';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const bubbleMenu = '.dm-bubble-menu';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function gotoDefault(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function gotoNotion(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as Record<string, { setContent: (h: string, e: boolean) => void; commands: { focus: () => void } }>).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(100);
+}
+
+async function selectInParagraph(page: Page, startOffset: number, endOffset: number, selector = `${editorSelector} p`): Promise<void> {
+  await page.evaluate(
+    ({ sel, edSel, startOffset, endOffset }) => {
+      const el = document.querySelector(sel);
+      if (!el || !el.firstChild) return;
+      const range = document.createRange();
+      range.setStart(el.firstChild, startOffset);
+      range.setEnd(el.firstChild, endOffset);
+      const s = window.getSelection();
+      s?.removeAllRanges();
+      s?.addRange(range);
+      const editor = document.querySelector(edSel);
+      if (editor instanceof HTMLElement) editor.focus();
+    },
+    { sel: selector, edSel: editorSelector, startOffset, endOffset },
+  );
+  await page.waitForTimeout(150);
+}
+
+function bubbleButton(page: Page, ariaLabel: string): Locator {
+  return page.locator(`${bubbleMenu} button[aria-label="${ariaLabel}"]`).first();
+}
+
+async function expectCustomIcon(page: Page, ariaLabel: string, expectedKey: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator(`svg[data-test-icon="custom-${expectedKey}"]`)).toHaveCount(1);
+}
+
+async function expectDefaultIcon(page: Page, ariaLabel: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator('svg[data-test-icon]')).toHaveCount(0);
+  await expect(button.locator('svg')).not.toHaveCount(0);
+}
+
+async function openBubble(page: Page, html = '<p>Hello custom icons</p>'): Promise<void> {
+  await setContentAndFocus(page, html);
+  await selectInParagraph(page, 0, 'Hello'.length);
+  await expect(page.locator(bubbleMenu)).toBeVisible();
+}
+
+test.describe('BubbleMenu icons - Group A: basic override', () => {
+  test('A1: format buttons use custom icons when ?bubble-icons=full', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Underline', 'underline');
+  });
+
+  test('A2: partial override, unmapped keys fall back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Underline');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+
+  test('A3: empty IconSet falls back to defaults for every button', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=empty');
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    const buttonCount = await page.locator(`${bubbleMenu} button`).count();
+    expect(buttonCount).toBeGreaterThan(0);
+  });
+
+  test('A4: no icons prop preserves default Phosphor rendering', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    await expectDefaultIcon(page, 'Bold');
+    await expectDefaultIcon(page, 'Italic');
+  });
+
+  test('A5: custom SVG attributes are preserved verbatim', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    const svg = bold.locator('svg[data-test-icon="custom-bold"]');
+    await expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    await expect(svg).toHaveAttribute('width', '16');
+    await expect(svg).toHaveAttribute('height', '16');
+    await expect(svg.locator('circle')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group B: sub-components', () => {
+  test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
+  });
+
+  test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignLeft"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignRight"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignJustify"]')).toHaveCount(1);
+  });
+
+  test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();
+    // Click typically closes the bubble: reopen via re-select.
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(dropdownTrigger.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+  });
+
+  test('B4: Notion mode "..." block-menu trigger uses custom icon', async ({ page }) => {
+    await gotoNotion(page, 'bubble-icons=full');
+    await openBubble(page);
+    const moreOptions = bubbleButton(page, 'More options');
+    await expect(moreOptions).toBeVisible();
+    await expect(moreOptions.locator('svg[data-test-icon="custom-dotsThree"]')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group C: reactivity', () => {
+  test('C1: setting icons at runtime swaps default to custom', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expectDefaultIcon(page, 'Bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('C2: unsetting icons at runtime restores defaults', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectDefaultIcon(page, 'Bold');
+  });
+
+  test('C3: rapid toggling does not detach duplicates and final state is correct', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      for (let i = 0; i < 5; i++) {
+        setter('full');
+        setter(null);
+      }
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group D: contexts', () => {
+  test('D1: text context (paragraph selection) uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page, '<p>Some text content for selection</p>');
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+  });
+
+  test('D2: heading context uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<h1>Heading title</h1>');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('D3: code block context hides bubble or shows custom-icon subset', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
+    await selectInParagraph(page, 0, 5, `${editorSelector} code`);
+    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
+    // if it IS visible, no default-icon SVGs should leak through.
+    const isVisible = await page.locator(bubbleMenu).isVisible();
+    if (isVisible) {
+      const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
+      expect(defaultIcons).toBe(0);
+    }
+  });
+
+  test('D4: context switch mid-session keeps custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p>Paragraph text</p><h1>Heading text</h1>');
+    await selectInParagraph(page, 0, 'Paragraph'.length, `${editorSelector} p`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group E: item filtering', () => {
+  test('E1: every item in a custom items list uses its custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Strikethrough', 'strike');
+  });
+
+  test('E2: item in custom list without override falls back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+});
+
+test.describe('BubbleMenu icons - Group F: active state', () => {
+  test('F1: bold-active button keeps custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p><strong>Bold text here</strong></p>');
+    await selectInParagraph(page, 0, 'Bold'.length, `${editorSelector} strong`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F2: activating bold via click does not revert icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.click();
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F3: aria attributes are preserved despite custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expect(page.locator(bubbleMenu)).toHaveAttribute('role', 'toolbar');
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-label', 'Bold');
+    await expect(bold).toHaveAttribute('title', /Bold/);
+    // Roving tabindex is optional per wrapper; cap at one focused button.
+    const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
+    expect(zeros).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group G: edge cases', () => {
+  test('G1: empty SVG string renders empty content, button still works', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=malformed');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toBeVisible();
+    await expect(bold.locator('svg')).toHaveCount(0);
+    await bold.click();
+    await page.waitForTimeout(50);
+    const ed = await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { isActive: (k: string) => boolean }>).__DEMO_EDITOR__;
+      return editor.isActive('bold');
+    });
+    expect(ed).toBe(true);
+  });
+
+  test('G2: arbitrary HTML in IconSet renders as HTML', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=html');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold.locator('.my-bold-icon')).toHaveText('B');
+  });
+
+  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
+      editor.destroy();
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
+    const leaks = await page.locator(`[data-test-icon]`).count();
+    expect(leaks).toBe(0);
+  });
+
+  test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {
+    await page.goto('/?bubble-icons=full');
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.click(modeToggleNotion);
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('G5: same IconSet content set twice does not detach buttons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await page.evaluate(() => {
+      const btn = document.querySelector('.dm-bubble-menu button[aria-label="Bold"]');
+      if (btn instanceof HTMLElement) btn.dataset.persistMarker = 'yes';
+    });
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await expect(bubbleButton(page, 'Bold')).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group H: keyboard a11y', () => {
+  test('H1: keyboard nav across buttons preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.focus();
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(50);
+    const focused = page.locator(`${bubbleMenu} button:focus`).first();
+    const focusedExists = await focused.count();
+    if (focusedExists > 0) {
+      await expect(focused.locator('svg[data-test-icon]')).toHaveCount(1);
+    }
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('H2: Escape closes bubble; reopen preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group I: theme smoke', () => {
+  test('I1: dark mode toggle does not affect custom icon rendering', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    const themeBtn = page.locator('.theme-toggle');
+    if (await themeBtn.count() > 0) await themeBtn.click();
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});

--- a/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
@@ -12,7 +12,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 const editorSelector = '.dm-editor .ProseMirror';
 const bubbleMenu = '.dm-bubble-menu';
-const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const modeToggleNotion = 'button:has-text("Notion style")';
 
 async function gotoDefault(page: Page, search = ''): Promise<void> {
   await page.goto('/' + (search ? `?${search}` : ''));
@@ -245,8 +245,7 @@ test.describe('BubbleMenu icons - Group D: contexts', () => {
     await gotoDefault(page, 'bubble-icons=full');
     await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
     await selectInParagraph(page, 0, 5, `${editorSelector} code`);
-    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
-    // if it IS visible, no default-icon SVGs should leak through.
+    // Bubble may hide inside codeBlock; if visible, no default icon should leak through.
     const isVisible = await page.locator(bubbleMenu).isVisible();
     if (isVisible) {
       const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
@@ -300,7 +299,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     await openBubble(page);
     const bold = bubbleButton(page, 'Bold');
     await bold.click();
-    await selectInParagraph(page, 0, 'Hello'.length);
+    await page.waitForTimeout(100);
     await expect(page.locator(bubbleMenu)).toBeVisible();
     await expect(bold).toHaveAttribute('aria-pressed', 'true');
     await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
@@ -313,7 +312,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     const bold = bubbleButton(page, 'Bold');
     await expect(bold).toHaveAttribute('aria-label', 'Bold');
     await expect(bold).toHaveAttribute('title', /Bold/);
-    // Roving tabindex is optional per wrapper; cap at one focused button.
+    // Roving tabindex is optional; assert at most one button has tabindex=0.
     const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
     expect(zeros).toBeLessThanOrEqual(1);
   });
@@ -342,18 +341,18 @@ test.describe('BubbleMenu icons - Group G: edge cases', () => {
     await expect(bold.locator('.my-bold-icon')).toHaveText('B');
   });
 
-  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+  test('G3: swapping icons removes the old custom SVG from the DOM', async ({ page }) => {
     await gotoDefault(page, 'bubble-icons=full');
     await openBubble(page);
     await expectCustomIcon(page, 'Bold', 'bold');
     await page.evaluate(() => {
-      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
-      editor.destroy();
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
     });
     await page.waitForTimeout(100);
-    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
-    const leaks = await page.locator(`[data-test-icon]`).count();
-    expect(leaks).toBe(0);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
   });
 
   test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {

--- a/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-angular/e2e/bubble-menu-icons.spec.ts
@@ -129,20 +129,16 @@ test.describe('BubbleMenu icons - Group A: basic override', () => {
 
 test.describe('BubbleMenu icons - Group B: sub-components', () => {
   test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
   });
 
   test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await expect(panel).toBeVisible();
@@ -153,11 +149,9 @@ test.describe('BubbleMenu icons - Group B: sub-components', () => {
   });
 
   test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();

--- a/apps/demo-angular/src/app/bubble-icons-fixtures.ts
+++ b/apps/demo-angular/src/app/bubble-icons-fixtures.ts
@@ -1,0 +1,78 @@
+/**
+ * Fixtures for the bubble menu `icons` override e2e suite.
+ *
+ * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Playwright can assert which icon was rendered for each button.
+ */
+
+import type { IconSet } from '@domternal/core';
+
+export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
+
+function customSvgFor(name: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+}
+
+export const FULL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+  underline: customSvgFor('underline'),
+  strike: customSvgFor('strike'),
+  code: customSvgFor('code'),
+  link: customSvgFor('link'),
+  highlight: customSvgFor('highlight'),
+  subscript: customSvgFor('subscript'),
+  superscript: customSvgFor('superscript'),
+  textAlignLeft: customSvgFor('textAlignLeft'),
+  textAlignCenter: customSvgFor('textAlignCenter'),
+  textAlignRight: customSvgFor('textAlignRight'),
+  textAlignJustify: customSvgFor('textAlignJustify'),
+  dotsThree: customSvgFor('dotsThree'),
+};
+
+export const PARTIAL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+};
+
+export const EMPTY_OVERRIDE: IconSet = {};
+
+export const MALFORMED_OVERRIDE: IconSet = {
+  bold: '',
+};
+
+export const HTML_OVERRIDE: IconSet = {
+  bold: '<span class="my-bold-icon">B</span>',
+};
+
+export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {
+  switch (param) {
+    case 'full': return FULL_OVERRIDE;
+    case 'partial': return PARTIAL_OVERRIDE;
+    case 'empty': return EMPTY_OVERRIDE;
+    case 'malformed': return MALFORMED_OVERRIDE;
+    case 'html': return HTML_OVERRIDE;
+    case 'default':
+    case null:
+    default:
+      return undefined;
+  }
+}
+
+export function parseBubbleIconsParam(): BubbleIconsParam | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-icons');
+  if (value === 'full' || value === 'partial' || value === 'empty' || value === 'malformed' || value === 'html' || value === 'default') {
+    return value;
+  }
+  return null;
+}
+
+export function parseBubbleItemsParam(): string[] | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-items');
+  if (!value) return undefined;
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/apps/demo-angular/src/app/bubble-icons-fixtures.ts
+++ b/apps/demo-angular/src/app/bubble-icons-fixtures.ts
@@ -1,28 +1,32 @@
 /**
  * Fixtures for the bubble menu `icons` override e2e suite.
  *
- * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Each fixture SVG carries a `data-test-icon="custom-<label>"` attribute so
  * Playwright can assert which icon was rendered for each button.
+ *
+ * IconSet keys must match core's actual icon names (e.g. Bold uses `textB`).
+ * The marker label stays user-readable (e.g. `custom-bold`) so tests stay
+ * readable.
  */
 
 import type { IconSet } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
-function customSvgFor(name: string): string {
-  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+function customSvgFor(label: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${label}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
 }
 
 export const FULL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
-  underline: customSvgFor('underline'),
-  strike: customSvgFor('strike'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
+  textUnderline: customSvgFor('underline'),
+  textStrikethrough: customSvgFor('strike'),
   code: customSvgFor('code'),
   link: customSvgFor('link'),
-  highlight: customSvgFor('highlight'),
-  subscript: customSvgFor('subscript'),
-  superscript: customSvgFor('superscript'),
+  highlighterCircle: customSvgFor('highlight'),
+  textSubscript: customSvgFor('subscript'),
+  textSuperscript: customSvgFor('superscript'),
   textAlignLeft: customSvgFor('textAlignLeft'),
   textAlignCenter: customSvgFor('textAlignCenter'),
   textAlignRight: customSvgFor('textAlignRight'),
@@ -31,18 +35,18 @@ export const FULL_OVERRIDE: IconSet = {
 };
 
 export const PARTIAL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
 };
 
 export const EMPTY_OVERRIDE: IconSet = {};
 
 export const MALFORMED_OVERRIDE: IconSet = {
-  bold: '',
+  textB: '',
 };
 
 export const HTML_OVERRIDE: IconSet = {
-  bold: '<span class="my-bold-icon">B</span>',
+  textB: '<span class="my-bold-icon">B</span>',
 };
 
 export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.html
@@ -17,11 +17,16 @@
 
 @if (editor(); as ed) {
   @if (bubbleAuto) {
-    <domternal-bubble-menu [editor]="ed" />
+    <domternal-bubble-menu
+      [editor]="ed"
+      [icons]="$any(bubbleIcons())"
+      [items]="$any(bubbleItems())" />
   } @else {
-    <domternal-bubble-menu [editor]="ed" [contexts]="{
-      text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'],
-    }" />
+    <domternal-bubble-menu
+      [editor]="ed"
+      [contexts]="$any(bubbleContexts())"
+      [items]="$any(bubbleItems())"
+      [icons]="$any(bubbleIcons())" />
   }
   <domternal-emoji-picker [editor]="ed" [emojis]="emojiData" />
 }

--- a/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
+++ b/apps/demo-angular/src/app/editor-demo/editor-demo.component.ts
@@ -1,4 +1,5 @@
-import { Component, ChangeDetectionStrategy, signal, input, effect, untracked, computed } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnDestroy, signal, input, effect, untracked, computed } from '@angular/core';
+import type { IconSet } from '@domternal/core';
 import {
   DomternalEditorComponent,
   DomternalToolbarComponent,
@@ -46,6 +47,12 @@ import { SmartPaste } from '@domternal/extension-block-menu';
 import type { MentionItem } from '@domternal/extension-mention';
 import { createLowlight, common } from 'lowlight';
 import { DEMO_CONTENT } from './demo-content.js';
+import {
+  parseBubbleIconsParam,
+  parseBubbleItemsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from '../bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -67,7 +74,7 @@ const mockUsers: MentionItem[] = [
   imports: [DomternalEditorComponent, DomternalToolbarComponent, DomternalBubbleMenuComponent, DomternalEmojiPickerComponent],
   templateUrl: './editor-demo.component.html',
 })
-export class EditorDemoComponent {
+export class EditorDemoComponent implements OnDestroy {
   private readonly params = new URLSearchParams(window.location.search);
   private readonly constrainTable = !this.params.has('constrainTable', 'false');
   private readonly resizeBehavior = (this.params.get('resizeBehavior') ?? 'neighbor') as 'neighbor' | 'independent' | 'redistribute';
@@ -127,6 +134,13 @@ export class EditorDemoComponent {
     return untracked(() => this.editor()?.isEmpty ?? true);
   });
   readonly useLayout = input(false);
+
+  // E2E fixture: ?bubble-icons= URL param + window.__DEMO_SET_BUBBLE_ICONS__ runtime hook.
+  readonly bubbleIcons = signal<IconSet | undefined>(resolveBubbleIcons(parseBubbleIconsParam()));
+  readonly bubbleItems = signal<string[] | undefined>(parseBubbleItemsParam());
+  readonly bubbleContexts = computed(() =>
+    this.bubbleItems() ? undefined : { text: ['bold', 'italic', 'underline', 'strike', 'code', '|', 'link'] },
+  );
   toolbarLayout: ToolbarLayoutEntry[] = [
     'bold', 'italic', 'underline', 'heading1',
     '|',
@@ -151,6 +165,16 @@ export class EditorDemoComponent {
         requestAnimationFrame(() => editor.commands.focus());
       }
     });
+
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+      this.bubbleIcons.set(resolveBubbleIcons(key));
+    };
+  }
+
+  ngOnDestroy(): void {
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = undefined;
   }
 
   getStyledHtml(html: string): string {

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
@@ -8,7 +8,7 @@
   />
 
   @if (editor(); as ed) {
-    <domternal-bubble-menu [editor]="ed" />
+    <domternal-bubble-menu [editor]="ed" [icons]="$any(bubbleIcons())" />
     <domternal-floating-menu [editor]="ed" [requireExplicitTrigger]="true" />
     <domternal-notion-color-picker [editor]="ed" />
   }

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -66,7 +66,13 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
   'blockquote', 'tableCell', 'tableHeader', 'tableRow', 'details', 'detailsContent',
 ]);
 import type { MentionItem } from '@domternal/extension-mention';
+import type { IconSet } from '@domternal/core';
 import { createLowlight, common } from 'lowlight';
+import {
+  parseBubbleIconsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from '../bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -175,6 +181,16 @@ export class NotionDemoComponent implements OnDestroy {
   editorContent = NOTION_DEMO_CONTENT;
   editor = signal<Editor | null>(null);
 
+  // E2E fixture for bubble menu icons override.
+  readonly bubbleIcons = signal<IconSet | undefined>(resolveBubbleIcons(parseBubbleIconsParam()));
+
+  constructor() {
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+      this.bubbleIcons.set(resolveBubbleIcons(key));
+    };
+  }
+
   // Tracked so `ngOnDestroy` and subsequent `onEditorCreated` calls can
   // remove listeners before adding new ones. Without this, repeatedly
   // mounting the component (HMR / route re-entry) would accumulate
@@ -222,6 +238,8 @@ export class NotionDemoComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.removeCopyLinkListeners();
     this.copyLinkHost = null;
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = undefined;
   }
 
   private removeCopyLinkListeners(): void {

--- a/apps/demo-react/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-react/e2e/bubble-menu-icons.spec.ts
@@ -1,0 +1,423 @@
+/**
+ * E2E coverage for the `icons` override on `DomternalBubbleMenu`.
+ *
+ * Fixtures: `src/bubble-icons-fixtures.ts`. Activated via URL params
+ * `?bubble-icons=full|partial|empty|malformed|html|default` and
+ * `?bubble-items=bold,italic,strike`. Runtime swap via
+ * `window.__DEMO_SET_BUBBLE_ICONS__('full' | null)`.
+ */
+
+import { test } from './fixtures.js';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const bubbleMenu = '.dm-bubble-menu';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function gotoDefault(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function gotoNotion(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as Record<string, { setContent: (h: string, e: boolean) => void; commands: { focus: () => void } }>).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(100);
+}
+
+async function selectInParagraph(page: Page, startOffset: number, endOffset: number, selector = `${editorSelector} p`): Promise<void> {
+  await page.evaluate(
+    ({ sel, edSel, startOffset, endOffset }) => {
+      const el = document.querySelector(sel);
+      if (!el || !el.firstChild) return;
+      const range = document.createRange();
+      range.setStart(el.firstChild, startOffset);
+      range.setEnd(el.firstChild, endOffset);
+      const s = window.getSelection();
+      s?.removeAllRanges();
+      s?.addRange(range);
+      const editor = document.querySelector(edSel);
+      if (editor instanceof HTMLElement) editor.focus();
+    },
+    { sel: selector, edSel: editorSelector, startOffset, endOffset },
+  );
+  await page.waitForTimeout(150);
+}
+
+function bubbleButton(page: Page, ariaLabel: string): Locator {
+  return page.locator(`${bubbleMenu} button[aria-label="${ariaLabel}"]`).first();
+}
+
+async function expectCustomIcon(page: Page, ariaLabel: string, expectedKey: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator(`svg[data-test-icon="custom-${expectedKey}"]`)).toHaveCount(1);
+}
+
+async function expectDefaultIcon(page: Page, ariaLabel: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator('svg[data-test-icon]')).toHaveCount(0);
+  await expect(button.locator('svg')).not.toHaveCount(0);
+}
+
+async function openBubble(page: Page, html = '<p>Hello custom icons</p>'): Promise<void> {
+  await setContentAndFocus(page, html);
+  await selectInParagraph(page, 0, 'Hello'.length);
+  await expect(page.locator(bubbleMenu)).toBeVisible();
+}
+
+test.describe('BubbleMenu icons - Group A: basic override', () => {
+  test('A1: format buttons use custom icons when ?bubble-icons=full', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Underline', 'underline');
+  });
+
+  test('A2: partial override, unmapped keys fall back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Underline');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+
+  test('A3: empty IconSet falls back to defaults for every button', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=empty');
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    const buttonCount = await page.locator(`${bubbleMenu} button`).count();
+    expect(buttonCount).toBeGreaterThan(0);
+  });
+
+  test('A4: no icons prop preserves default Phosphor rendering', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    await expectDefaultIcon(page, 'Bold');
+    await expectDefaultIcon(page, 'Italic');
+  });
+
+  test('A5: custom SVG attributes are preserved verbatim', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    const svg = bold.locator('svg[data-test-icon="custom-bold"]');
+    await expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    await expect(svg).toHaveAttribute('width', '16');
+    await expect(svg).toHaveAttribute('height', '16');
+    await expect(svg.locator('circle')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group B: sub-components', () => {
+  test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
+  });
+
+  test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignLeft"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignRight"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignJustify"]')).toHaveCount(1);
+  });
+
+  test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();
+    // Click typically closes the bubble: reopen via re-select.
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(dropdownTrigger.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+  });
+
+  test('B4: Notion mode "..." block-menu trigger uses custom icon', async ({ page }) => {
+    await gotoNotion(page, 'bubble-icons=full');
+    await openBubble(page);
+    const moreOptions = bubbleButton(page, 'More options');
+    await expect(moreOptions).toBeVisible();
+    await expect(moreOptions.locator('svg[data-test-icon="custom-dotsThree"]')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group C: reactivity', () => {
+  test('C1: setting icons at runtime swaps default to custom', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expectDefaultIcon(page, 'Bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('C2: unsetting icons at runtime restores defaults', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectDefaultIcon(page, 'Bold');
+  });
+
+  test('C3: rapid toggling does not detach duplicates and final state is correct', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      for (let i = 0; i < 5; i++) {
+        setter('full');
+        setter(null);
+      }
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group D: contexts', () => {
+  test('D1: text context (paragraph selection) uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page, '<p>Some text content for selection</p>');
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+  });
+
+  test('D2: heading context uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<h1>Heading title</h1>');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('D3: code block context hides bubble or shows custom-icon subset', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
+    await selectInParagraph(page, 0, 5, `${editorSelector} code`);
+    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
+    // if it IS visible, no default-icon SVGs should leak through.
+    const isVisible = await page.locator(bubbleMenu).isVisible();
+    if (isVisible) {
+      const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
+      expect(defaultIcons).toBe(0);
+    }
+  });
+
+  test('D4: context switch mid-session keeps custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p>Paragraph text</p><h1>Heading text</h1>');
+    await selectInParagraph(page, 0, 'Paragraph'.length, `${editorSelector} p`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group E: item filtering', () => {
+  test('E1: every item in a custom items list uses its custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Strikethrough', 'strike');
+  });
+
+  test('E2: item in custom list without override falls back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+});
+
+test.describe('BubbleMenu icons - Group F: active state', () => {
+  test('F1: bold-active button keeps custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p><strong>Bold text here</strong></p>');
+    await selectInParagraph(page, 0, 'Bold'.length, `${editorSelector} strong`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F2: activating bold via click does not revert icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.click();
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F3: aria attributes are preserved despite custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expect(page.locator(bubbleMenu)).toHaveAttribute('role', 'toolbar');
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-label', 'Bold');
+    await expect(bold).toHaveAttribute('title', /Bold/);
+    // Roving tabindex is optional per wrapper; cap at one focused button.
+    const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
+    expect(zeros).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group G: edge cases', () => {
+  test('G1: empty SVG string renders empty content, button still works', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=malformed');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toBeVisible();
+    await expect(bold.locator('svg')).toHaveCount(0);
+    await bold.click();
+    await page.waitForTimeout(50);
+    const ed = await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { isActive: (k: string) => boolean }>).__DEMO_EDITOR__;
+      return editor.isActive('bold');
+    });
+    expect(ed).toBe(true);
+  });
+
+  test('G2: arbitrary HTML in IconSet renders as HTML', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=html');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold.locator('.my-bold-icon')).toHaveText('B');
+  });
+
+  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
+      editor.destroy();
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
+    const leaks = await page.locator(`[data-test-icon]`).count();
+    expect(leaks).toBe(0);
+  });
+
+  test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {
+    await page.goto('/?bubble-icons=full');
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.click(modeToggleNotion);
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('G5: same IconSet content set twice does not detach buttons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await page.evaluate(() => {
+      const btn = document.querySelector('.dm-bubble-menu button[aria-label="Bold"]');
+      if (btn instanceof HTMLElement) btn.dataset.persistMarker = 'yes';
+    });
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await expect(bubbleButton(page, 'Bold')).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group H: keyboard a11y', () => {
+  test('H1: keyboard nav across buttons preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.focus();
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(50);
+    const focused = page.locator(`${bubbleMenu} button:focus`).first();
+    const focusedExists = await focused.count();
+    if (focusedExists > 0) {
+      await expect(focused.locator('svg[data-test-icon]')).toHaveCount(1);
+    }
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('H2: Escape closes bubble; reopen preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group I: theme smoke', () => {
+  test('I1: dark mode toggle does not affect custom icon rendering', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    const themeBtn = page.locator('.theme-toggle');
+    if (await themeBtn.count() > 0) await themeBtn.click();
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});

--- a/apps/demo-react/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-react/e2e/bubble-menu-icons.spec.ts
@@ -12,7 +12,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 const editorSelector = '.dm-editor .ProseMirror';
 const bubbleMenu = '.dm-bubble-menu';
-const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const modeToggleNotion = 'button:has-text("Notion style")';
 
 async function gotoDefault(page: Page, search = ''): Promise<void> {
   await page.goto('/' + (search ? `?${search}` : ''));
@@ -245,8 +245,7 @@ test.describe('BubbleMenu icons - Group D: contexts', () => {
     await gotoDefault(page, 'bubble-icons=full');
     await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
     await selectInParagraph(page, 0, 5, `${editorSelector} code`);
-    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
-    // if it IS visible, no default-icon SVGs should leak through.
+    // Bubble may hide inside codeBlock; if visible, no default icon should leak through.
     const isVisible = await page.locator(bubbleMenu).isVisible();
     if (isVisible) {
       const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
@@ -300,7 +299,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     await openBubble(page);
     const bold = bubbleButton(page, 'Bold');
     await bold.click();
-    await selectInParagraph(page, 0, 'Hello'.length);
+    await page.waitForTimeout(100);
     await expect(page.locator(bubbleMenu)).toBeVisible();
     await expect(bold).toHaveAttribute('aria-pressed', 'true');
     await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
@@ -313,7 +312,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     const bold = bubbleButton(page, 'Bold');
     await expect(bold).toHaveAttribute('aria-label', 'Bold');
     await expect(bold).toHaveAttribute('title', /Bold/);
-    // Roving tabindex is optional per wrapper; cap at one focused button.
+    // Roving tabindex is optional; assert at most one button has tabindex=0.
     const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
     expect(zeros).toBeLessThanOrEqual(1);
   });
@@ -342,18 +341,18 @@ test.describe('BubbleMenu icons - Group G: edge cases', () => {
     await expect(bold.locator('.my-bold-icon')).toHaveText('B');
   });
 
-  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+  test('G3: swapping icons removes the old custom SVG from the DOM', async ({ page }) => {
     await gotoDefault(page, 'bubble-icons=full');
     await openBubble(page);
     await expectCustomIcon(page, 'Bold', 'bold');
     await page.evaluate(() => {
-      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
-      editor.destroy();
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
     });
     await page.waitForTimeout(100);
-    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
-    const leaks = await page.locator(`[data-test-icon]`).count();
-    expect(leaks).toBe(0);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
   });
 
   test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {

--- a/apps/demo-react/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-react/e2e/bubble-menu-icons.spec.ts
@@ -129,20 +129,16 @@ test.describe('BubbleMenu icons - Group A: basic override', () => {
 
 test.describe('BubbleMenu icons - Group B: sub-components', () => {
   test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
   });
 
   test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await expect(panel).toBeVisible();
@@ -153,11 +149,9 @@ test.describe('BubbleMenu icons - Group B: sub-components', () => {
   });
 
   test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();

--- a/apps/demo-react/src/EditorDemo.tsx
+++ b/apps/demo-react/src/EditorDemo.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   useEditor,
   useEditorState,
@@ -44,8 +44,15 @@ import { Table } from '@domternal/extension-table';
 import { Emoji, emojis, createEmojiSuggestionRenderer } from '@domternal/extension-emoji';
 import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
 import type { MentionItem } from '@domternal/extension-mention';
+import type { IconSet } from '@domternal/core';
 import { createLowlight, common } from 'lowlight';
 import { DEMO_CONTENT } from './demo-content.js';
+import {
+  parseBubbleIconsParam,
+  parseBubbleItemsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -115,6 +122,20 @@ export function EditorDemo({ useLayout }: EditorDemoProps) {
     content: DEMO_CONTENT,
   });
 
+  // E2E fixture: ?bubble-icons= URL param + window.__DEMO_SET_BUBBLE_ICONS__ runtime hook.
+  const [bubbleIcons, setBubbleIcons] = useState<IconSet | undefined>(() =>
+    resolveBubbleIcons(parseBubbleIconsParam()),
+  );
+  const [bubbleItems] = useState<string[] | undefined>(() => parseBubbleItemsParam());
+
+  useEffect(() => {
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+      setBubbleIcons(resolveBubbleIcons(key));
+    };
+    return () => { w['__DEMO_SET_BUBBLE_ICONS__'] = undefined; };
+  }, []);
+
   const { htmlContent } = useEditorState(editor);
 
   // Selector mode (React-specific: memoized via useSyncExternalStore)
@@ -147,11 +168,13 @@ export function EditorDemo({ useLayout }: EditorDemoProps) {
       {editor && (
         <>
           {bubbleAuto ? (
-            <DomternalBubbleMenu editor={editor} />
+            <DomternalBubbleMenu editor={editor} icons={bubbleIcons} items={bubbleItems} />
           ) : (
             <DomternalBubbleMenu
               editor={editor}
-              contexts={{ text: ['bold', 'italic', 'underline', 'strike', 'code'] }}
+              contexts={bubbleItems ? undefined : { text: ['bold', 'italic', 'underline', 'strike', 'code'] }}
+              items={bubbleItems}
+              icons={bubbleIcons}
             />
           )}
           <DomternalFloatingMenu editor={editor} />

--- a/apps/demo-react/src/NotionDemo.tsx
+++ b/apps/demo-react/src/NotionDemo.tsx
@@ -56,8 +56,14 @@ import {
 } from '@domternal/extension-block-menu';
 import type { BlockMatcher, BlockCandidate } from '@domternal/extension-block-menu';
 import { TableOfContents, FloatingTocOutline, TableOfContentsBlock } from '@domternal/extension-toc';
+import type { IconSet } from '@domternal/core';
 import { createLowlight, common } from 'lowlight';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
+import {
+  parseBubbleIconsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -180,6 +186,19 @@ export function NotionDemo(): ReactNode {
 
   const [toasts, setToasts] = useState<Toast[]>([]);
 
+  // E2E fixture for bubble menu icons override.
+  const [bubbleIcons, setBubbleIcons] = useState<IconSet | undefined>(() =>
+    resolveBubbleIcons(parseBubbleIconsParam()),
+  );
+
+  useEffect(() => {
+    const w = window as unknown as Record<string, unknown>;
+    w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+      setBubbleIcons(resolveBubbleIcons(key));
+    };
+    return () => { w['__DEMO_SET_BUBBLE_ICONS__'] = undefined; };
+  }, []);
+
   // Expose editor + cursor-context util on window for e2e, and wire the
   // copy-link toast listeners. Cleanup detaches everything; StrictMode dev
   // double-mount is benign because the second mount re-sets the same editor.
@@ -233,7 +252,7 @@ export function NotionDemo(): ReactNode {
 
           {editor && (
             <>
-              <DomternalBubbleMenu editor={editor} />
+              <DomternalBubbleMenu editor={editor} icons={bubbleIcons} />
               <DomternalFloatingMenu editor={editor} requireExplicitTrigger />
               <DomternalNotionColorPicker editor={editor} />
             </>

--- a/apps/demo-react/src/bubble-icons-fixtures.ts
+++ b/apps/demo-react/src/bubble-icons-fixtures.ts
@@ -1,51 +1,52 @@
 /**
  * Fixtures for the bubble menu `icons` override e2e suite.
  *
- * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Each fixture SVG carries a `data-test-icon="custom-<label>"` attribute so
  * Playwright can assert which icon was rendered for each button.
+ *
+ * IconSet keys must match core's actual icon names (e.g. Bold uses `textB`).
+ * The marker label stays user-readable (e.g. `custom-bold`) so tests stay
+ * readable.
  */
 
 import type { IconSet } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
-function customSvgFor(name: string): string {
-  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+function customSvgFor(label: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${label}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
 }
 
 export const FULL_OVERRIDE: IconSet = {
-  // main format buttons
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
-  underline: customSvgFor('underline'),
-  strike: customSvgFor('strike'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
+  textUnderline: customSvgFor('underline'),
+  textStrikethrough: customSvgFor('strike'),
   code: customSvgFor('code'),
   link: customSvgFor('link'),
-  highlight: customSvgFor('highlight'),
-  subscript: customSvgFor('subscript'),
-  superscript: customSvgFor('superscript'),
-  // text-align dropdown
+  highlighterCircle: customSvgFor('highlight'),
+  textSubscript: customSvgFor('subscript'),
+  textSuperscript: customSvgFor('superscript'),
   textAlignLeft: customSvgFor('textAlignLeft'),
   textAlignCenter: customSvgFor('textAlignCenter'),
   textAlignRight: customSvgFor('textAlignRight'),
   textAlignJustify: customSvgFor('textAlignJustify'),
-  // Notion trailing
   dotsThree: customSvgFor('dotsThree'),
 };
 
 export const PARTIAL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
 };
 
 export const EMPTY_OVERRIDE: IconSet = {};
 
 export const MALFORMED_OVERRIDE: IconSet = {
-  bold: '',
+  textB: '',
 };
 
 export const HTML_OVERRIDE: IconSet = {
-  bold: '<span class="my-bold-icon">B</span>',
+  textB: '<span class="my-bold-icon">B</span>',
 };
 
 export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {

--- a/apps/demo-react/src/bubble-icons-fixtures.ts
+++ b/apps/demo-react/src/bubble-icons-fixtures.ts
@@ -1,0 +1,81 @@
+/**
+ * Fixtures for the bubble menu `icons` override e2e suite.
+ *
+ * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Playwright can assert which icon was rendered for each button.
+ */
+
+import type { IconSet } from '@domternal/core';
+
+export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
+
+function customSvgFor(name: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+}
+
+export const FULL_OVERRIDE: IconSet = {
+  // main format buttons
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+  underline: customSvgFor('underline'),
+  strike: customSvgFor('strike'),
+  code: customSvgFor('code'),
+  link: customSvgFor('link'),
+  highlight: customSvgFor('highlight'),
+  subscript: customSvgFor('subscript'),
+  superscript: customSvgFor('superscript'),
+  // text-align dropdown
+  textAlignLeft: customSvgFor('textAlignLeft'),
+  textAlignCenter: customSvgFor('textAlignCenter'),
+  textAlignRight: customSvgFor('textAlignRight'),
+  textAlignJustify: customSvgFor('textAlignJustify'),
+  // Notion trailing
+  dotsThree: customSvgFor('dotsThree'),
+};
+
+export const PARTIAL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+};
+
+export const EMPTY_OVERRIDE: IconSet = {};
+
+export const MALFORMED_OVERRIDE: IconSet = {
+  bold: '',
+};
+
+export const HTML_OVERRIDE: IconSet = {
+  bold: '<span class="my-bold-icon">B</span>',
+};
+
+export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {
+  switch (param) {
+    case 'full': return FULL_OVERRIDE;
+    case 'partial': return PARTIAL_OVERRIDE;
+    case 'empty': return EMPTY_OVERRIDE;
+    case 'malformed': return MALFORMED_OVERRIDE;
+    case 'html': return HTML_OVERRIDE;
+    case 'default':
+    case null:
+    default:
+      return undefined;
+  }
+}
+
+export function parseBubbleIconsParam(): BubbleIconsParam | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-icons');
+  if (value === 'full' || value === 'partial' || value === 'empty' || value === 'malformed' || value === 'html' || value === 'default') {
+    return value;
+  }
+  return null;
+}
+
+export function parseBubbleItemsParam(): string[] | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-items');
+  if (!value) return undefined;
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
@@ -1,0 +1,423 @@
+/**
+ * E2E coverage for the `icons` override on `DomternalBubbleMenu`.
+ *
+ * Fixtures: `src/bubble-icons-fixtures.ts`. Activated via URL params
+ * `?bubble-icons=full|partial|empty|malformed|html|default` and
+ * `?bubble-items=bold,italic,strike`. Runtime swap via
+ * `window.__DEMO_SET_BUBBLE_ICONS__('full' | null)`.
+ */
+
+import { test } from './fixtures.js';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const bubbleMenu = '.dm-bubble-menu';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function gotoDefault(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function gotoNotion(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as Record<string, { setContent: (h: string, e: boolean) => void; commands: { focus: () => void } }>).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(100);
+}
+
+async function selectInParagraph(page: Page, startOffset: number, endOffset: number, selector = `${editorSelector} p`): Promise<void> {
+  await page.evaluate(
+    ({ sel, edSel, startOffset, endOffset }) => {
+      const el = document.querySelector(sel);
+      if (!el || !el.firstChild) return;
+      const range = document.createRange();
+      range.setStart(el.firstChild, startOffset);
+      range.setEnd(el.firstChild, endOffset);
+      const s = window.getSelection();
+      s?.removeAllRanges();
+      s?.addRange(range);
+      const editor = document.querySelector(edSel);
+      if (editor instanceof HTMLElement) editor.focus();
+    },
+    { sel: selector, edSel: editorSelector, startOffset, endOffset },
+  );
+  await page.waitForTimeout(150);
+}
+
+function bubbleButton(page: Page, ariaLabel: string): Locator {
+  return page.locator(`${bubbleMenu} button[aria-label="${ariaLabel}"]`).first();
+}
+
+async function expectCustomIcon(page: Page, ariaLabel: string, expectedKey: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator(`svg[data-test-icon="custom-${expectedKey}"]`)).toHaveCount(1);
+}
+
+async function expectDefaultIcon(page: Page, ariaLabel: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator('svg[data-test-icon]')).toHaveCount(0);
+  await expect(button.locator('svg')).not.toHaveCount(0);
+}
+
+async function openBubble(page: Page, html = '<p>Hello custom icons</p>'): Promise<void> {
+  await setContentAndFocus(page, html);
+  await selectInParagraph(page, 0, 'Hello'.length);
+  await expect(page.locator(bubbleMenu)).toBeVisible();
+}
+
+test.describe('BubbleMenu icons - Group A: basic override', () => {
+  test('A1: format buttons use custom icons when ?bubble-icons=full', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Underline', 'underline');
+  });
+
+  test('A2: partial override, unmapped keys fall back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Underline');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+
+  test('A3: empty IconSet falls back to defaults for every button', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=empty');
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    const buttonCount = await page.locator(`${bubbleMenu} button`).count();
+    expect(buttonCount).toBeGreaterThan(0);
+  });
+
+  test('A4: no icons prop preserves default Phosphor rendering', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    await expectDefaultIcon(page, 'Bold');
+    await expectDefaultIcon(page, 'Italic');
+  });
+
+  test('A5: custom SVG attributes are preserved verbatim', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    const svg = bold.locator('svg[data-test-icon="custom-bold"]');
+    await expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    await expect(svg).toHaveAttribute('width', '16');
+    await expect(svg).toHaveAttribute('height', '16');
+    await expect(svg.locator('circle')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group B: sub-components', () => {
+  test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
+  });
+
+  test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignLeft"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignRight"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignJustify"]')).toHaveCount(1);
+  });
+
+  test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();
+    // Click typically closes the bubble: reopen via re-select.
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(dropdownTrigger.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+  });
+
+  test('B4: Notion mode "..." block-menu trigger uses custom icon', async ({ page }) => {
+    await gotoNotion(page, 'bubble-icons=full');
+    await openBubble(page);
+    const moreOptions = bubbleButton(page, 'More options');
+    await expect(moreOptions).toBeVisible();
+    await expect(moreOptions.locator('svg[data-test-icon="custom-dotsThree"]')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group C: reactivity', () => {
+  test('C1: setting icons at runtime swaps default to custom', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expectDefaultIcon(page, 'Bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('C2: unsetting icons at runtime restores defaults', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectDefaultIcon(page, 'Bold');
+  });
+
+  test('C3: rapid toggling does not detach duplicates and final state is correct', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      for (let i = 0; i < 5; i++) {
+        setter('full');
+        setter(null);
+      }
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group D: contexts', () => {
+  test('D1: text context (paragraph selection) uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page, '<p>Some text content for selection</p>');
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+  });
+
+  test('D2: heading context uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<h1>Heading title</h1>');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('D3: code block context hides bubble or shows custom-icon subset', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
+    await selectInParagraph(page, 0, 5, `${editorSelector} code`);
+    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
+    // if it IS visible, no default-icon SVGs should leak through.
+    const isVisible = await page.locator(bubbleMenu).isVisible();
+    if (isVisible) {
+      const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
+      expect(defaultIcons).toBe(0);
+    }
+  });
+
+  test('D4: context switch mid-session keeps custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p>Paragraph text</p><h1>Heading text</h1>');
+    await selectInParagraph(page, 0, 'Paragraph'.length, `${editorSelector} p`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group E: item filtering', () => {
+  test('E1: every item in a custom items list uses its custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Strikethrough', 'strike');
+  });
+
+  test('E2: item in custom list without override falls back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+});
+
+test.describe('BubbleMenu icons - Group F: active state', () => {
+  test('F1: bold-active button keeps custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p><strong>Bold text here</strong></p>');
+    await selectInParagraph(page, 0, 'Bold'.length, `${editorSelector} strong`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F2: activating bold via click does not revert icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.click();
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F3: aria attributes are preserved despite custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expect(page.locator(bubbleMenu)).toHaveAttribute('role', 'toolbar');
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-label', 'Bold');
+    await expect(bold).toHaveAttribute('title', /Bold/);
+    // Roving tabindex is optional per wrapper; cap at one focused button.
+    const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
+    expect(zeros).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group G: edge cases', () => {
+  test('G1: empty SVG string renders empty content, button still works', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=malformed');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toBeVisible();
+    await expect(bold.locator('svg')).toHaveCount(0);
+    await bold.click();
+    await page.waitForTimeout(50);
+    const ed = await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { isActive: (k: string) => boolean }>).__DEMO_EDITOR__;
+      return editor.isActive('bold');
+    });
+    expect(ed).toBe(true);
+  });
+
+  test('G2: arbitrary HTML in IconSet renders as HTML', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=html');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold.locator('.my-bold-icon')).toHaveText('B');
+  });
+
+  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
+      editor.destroy();
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
+    const leaks = await page.locator(`[data-test-icon]`).count();
+    expect(leaks).toBe(0);
+  });
+
+  test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {
+    await page.goto('/?bubble-icons=full');
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.click(modeToggleNotion);
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('G5: same IconSet content set twice does not detach buttons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await page.evaluate(() => {
+      const btn = document.querySelector('.dm-bubble-menu button[aria-label="Bold"]');
+      if (btn instanceof HTMLElement) btn.dataset.persistMarker = 'yes';
+    });
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await expect(bubbleButton(page, 'Bold')).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group H: keyboard a11y', () => {
+  test('H1: keyboard nav across buttons preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.focus();
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(50);
+    const focused = page.locator(`${bubbleMenu} button:focus`).first();
+    const focusedExists = await focused.count();
+    if (focusedExists > 0) {
+      await expect(focused.locator('svg[data-test-icon]')).toHaveCount(1);
+    }
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('H2: Escape closes bubble; reopen preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group I: theme smoke', () => {
+  test('I1: dark mode toggle does not affect custom icon rendering', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    const themeBtn = page.locator('.theme-toggle');
+    if (await themeBtn.count() > 0) await themeBtn.click();
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});

--- a/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
@@ -12,7 +12,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 const editorSelector = '.dm-editor .ProseMirror';
 const bubbleMenu = '.dm-bubble-menu';
-const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const modeToggleNotion = 'button:has-text("Notion style")';
 
 async function gotoDefault(page: Page, search = ''): Promise<void> {
   await page.goto('/' + (search ? `?${search}` : ''));
@@ -245,8 +245,7 @@ test.describe('BubbleMenu icons - Group D: contexts', () => {
     await gotoDefault(page, 'bubble-icons=full');
     await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
     await selectInParagraph(page, 0, 5, `${editorSelector} code`);
-    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
-    // if it IS visible, no default-icon SVGs should leak through.
+    // Bubble may hide inside codeBlock; if visible, no default icon should leak through.
     const isVisible = await page.locator(bubbleMenu).isVisible();
     if (isVisible) {
       const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
@@ -300,7 +299,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     await openBubble(page);
     const bold = bubbleButton(page, 'Bold');
     await bold.click();
-    await selectInParagraph(page, 0, 'Hello'.length);
+    await page.waitForTimeout(100);
     await expect(page.locator(bubbleMenu)).toBeVisible();
     await expect(bold).toHaveAttribute('aria-pressed', 'true');
     await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
@@ -313,7 +312,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     const bold = bubbleButton(page, 'Bold');
     await expect(bold).toHaveAttribute('aria-label', 'Bold');
     await expect(bold).toHaveAttribute('title', /Bold/);
-    // Roving tabindex is optional per wrapper; cap at one focused button.
+    // Roving tabindex is optional; assert at most one button has tabindex=0.
     const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
     expect(zeros).toBeLessThanOrEqual(1);
   });
@@ -342,18 +341,18 @@ test.describe('BubbleMenu icons - Group G: edge cases', () => {
     await expect(bold.locator('.my-bold-icon')).toHaveText('B');
   });
 
-  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+  test('G3: swapping icons removes the old custom SVG from the DOM', async ({ page }) => {
     await gotoDefault(page, 'bubble-icons=full');
     await openBubble(page);
     await expectCustomIcon(page, 'Bold', 'bold');
     await page.evaluate(() => {
-      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
-      editor.destroy();
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
     });
     await page.waitForTimeout(100);
-    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
-    const leaks = await page.locator(`[data-test-icon]`).count();
-    expect(leaks).toBe(0);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
   });
 
   test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {

--- a/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vanilla/e2e/bubble-menu-icons.spec.ts
@@ -129,20 +129,16 @@ test.describe('BubbleMenu icons - Group A: basic override', () => {
 
 test.describe('BubbleMenu icons - Group B: sub-components', () => {
   test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
   });
 
   test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await expect(panel).toBeVisible();
@@ -153,11 +149,9 @@ test.describe('BubbleMenu icons - Group B: sub-components', () => {
   });
 
   test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();

--- a/apps/demo-vanilla/src/EditorDemo.ts
+++ b/apps/demo-vanilla/src/EditorDemo.ts
@@ -45,6 +45,12 @@ import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-m
 import type { MentionItem } from '@domternal/extension-mention';
 import { createLowlight, common } from 'lowlight';
 import { DEMO_CONTENT } from './demo-content.js';
+import {
+  parseBubbleIconsParam,
+  parseBubbleItemsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -172,12 +178,22 @@ export class EditorDemo {
       ...(options.useLayout && { layout: TOOLBAR_LAYOUT }),
     });
 
+    // E2E fixture: ?bubble-icons= URL param + window.__DEMO_SET_BUBBLE_ICONS__ runtime hook.
+    const initialIcons = resolveBubbleIcons(parseBubbleIconsParam());
+    const initialItems = parseBubbleItemsParam();
     this.#bubbleMenu = new DomternalBubbleMenu(bubbleHost, {
       editor,
-      ...(bubbleAuto
+      ...(bubbleAuto || initialItems
         ? {}
         : { contexts: { text: ['bold', 'italic', 'underline', 'strike', 'code'] } }),
+      ...(initialItems ? { items: initialItems } : {}),
+      ...(initialIcons ? { icons: initialIcons } : {}),
     });
+
+    (window as unknown as Record<string, unknown>).__DEMO_SET_BUBBLE_ICONS__ =
+      (key: BubbleIconsParam | null): void => {
+        this.#bubbleMenu.setIcons(resolveBubbleIcons(key));
+      };
 
     this.#floatingMenu = new DomternalFloatingMenu(floatingHost, { editor });
 
@@ -255,6 +271,7 @@ export class EditorDemo {
     this.#editorWrapper.destroy();
 
     (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ = undefined;
+    (window as unknown as Record<string, unknown>).__DEMO_SET_BUBBLE_ICONS__ = undefined;
 
     this.#container.replaceChildren();
   }

--- a/apps/demo-vanilla/src/NotionDemo.ts
+++ b/apps/demo-vanilla/src/NotionDemo.ts
@@ -56,6 +56,11 @@ import type { BlockMatcher, BlockCandidate } from '@domternal/extension-block-me
 import { TableOfContents, FloatingTocOutline, TableOfContentsBlock } from '@domternal/extension-toc';
 import { createLowlight, common } from 'lowlight';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
+import {
+  parseBubbleIconsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -206,7 +211,15 @@ export class NotionDemo {
     });
     const editor = this.#editorWrapper.editor;
 
-    this.#bubbleMenu = new DomternalBubbleMenu(bubbleHost, { editor });
+    const initialIcons = resolveBubbleIcons(parseBubbleIconsParam());
+    this.#bubbleMenu = new DomternalBubbleMenu(bubbleHost, {
+      editor,
+      ...(initialIcons ? { icons: initialIcons } : {}),
+    });
+    (window as unknown as Record<string, unknown>).__DEMO_SET_BUBBLE_ICONS__ =
+      (key: BubbleIconsParam | null): void => {
+        this.#bubbleMenu.setIcons(resolveBubbleIcons(key));
+      };
     this.#floatingMenu = new DomternalFloatingMenu(floatingHost, {
       editor,
       requireExplicitTrigger: true,
@@ -284,6 +297,7 @@ export class NotionDemo {
       w.__DEMO_EDITOR__ = undefined;
       w.__DOMTERNAL_LIST_CTX__ = undefined;
     }
+    w.__DEMO_SET_BUBBLE_ICONS__ = undefined;
 
     this.#container.replaceChildren();
   }

--- a/apps/demo-vanilla/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vanilla/src/bubble-icons-fixtures.ts
@@ -1,0 +1,78 @@
+/**
+ * Fixtures for the bubble menu `icons` override e2e suite.
+ *
+ * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Playwright can assert which icon was rendered for each button.
+ */
+
+import type { IconSet } from '@domternal/core';
+
+export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
+
+function customSvgFor(name: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+}
+
+export const FULL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+  underline: customSvgFor('underline'),
+  strike: customSvgFor('strike'),
+  code: customSvgFor('code'),
+  link: customSvgFor('link'),
+  highlight: customSvgFor('highlight'),
+  subscript: customSvgFor('subscript'),
+  superscript: customSvgFor('superscript'),
+  textAlignLeft: customSvgFor('textAlignLeft'),
+  textAlignCenter: customSvgFor('textAlignCenter'),
+  textAlignRight: customSvgFor('textAlignRight'),
+  textAlignJustify: customSvgFor('textAlignJustify'),
+  dotsThree: customSvgFor('dotsThree'),
+};
+
+export const PARTIAL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+};
+
+export const EMPTY_OVERRIDE: IconSet = {};
+
+export const MALFORMED_OVERRIDE: IconSet = {
+  bold: '',
+};
+
+export const HTML_OVERRIDE: IconSet = {
+  bold: '<span class="my-bold-icon">B</span>',
+};
+
+export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {
+  switch (param) {
+    case 'full': return FULL_OVERRIDE;
+    case 'partial': return PARTIAL_OVERRIDE;
+    case 'empty': return EMPTY_OVERRIDE;
+    case 'malformed': return MALFORMED_OVERRIDE;
+    case 'html': return HTML_OVERRIDE;
+    case 'default':
+    case null:
+    default:
+      return undefined;
+  }
+}
+
+export function parseBubbleIconsParam(): BubbleIconsParam | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-icons');
+  if (value === 'full' || value === 'partial' || value === 'empty' || value === 'malformed' || value === 'html' || value === 'default') {
+    return value;
+  }
+  return null;
+}
+
+export function parseBubbleItemsParam(): string[] | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-items');
+  if (!value) return undefined;
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/apps/demo-vanilla/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vanilla/src/bubble-icons-fixtures.ts
@@ -1,28 +1,32 @@
 /**
  * Fixtures for the bubble menu `icons` override e2e suite.
  *
- * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Each fixture SVG carries a `data-test-icon="custom-<label>"` attribute so
  * Playwright can assert which icon was rendered for each button.
+ *
+ * IconSet keys must match core's actual icon names (e.g. Bold uses `textB`).
+ * The marker label stays user-readable (e.g. `custom-bold`) so tests stay
+ * readable.
  */
 
 import type { IconSet } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
-function customSvgFor(name: string): string {
-  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+function customSvgFor(label: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${label}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
 }
 
 export const FULL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
-  underline: customSvgFor('underline'),
-  strike: customSvgFor('strike'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
+  textUnderline: customSvgFor('underline'),
+  textStrikethrough: customSvgFor('strike'),
   code: customSvgFor('code'),
   link: customSvgFor('link'),
-  highlight: customSvgFor('highlight'),
-  subscript: customSvgFor('subscript'),
-  superscript: customSvgFor('superscript'),
+  highlighterCircle: customSvgFor('highlight'),
+  textSubscript: customSvgFor('subscript'),
+  textSuperscript: customSvgFor('superscript'),
   textAlignLeft: customSvgFor('textAlignLeft'),
   textAlignCenter: customSvgFor('textAlignCenter'),
   textAlignRight: customSvgFor('textAlignRight'),
@@ -31,18 +35,18 @@ export const FULL_OVERRIDE: IconSet = {
 };
 
 export const PARTIAL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
 };
 
 export const EMPTY_OVERRIDE: IconSet = {};
 
 export const MALFORMED_OVERRIDE: IconSet = {
-  bold: '',
+  textB: '',
 };
 
 export const HTML_OVERRIDE: IconSet = {
-  bold: '<span class="my-bold-icon">B</span>',
+  textB: '<span class="my-bold-icon">B</span>',
 };
 
 export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {

--- a/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
@@ -1,0 +1,423 @@
+/**
+ * E2E coverage for the `icons` override on `DomternalBubbleMenu`.
+ *
+ * Fixtures: `src/bubble-icons-fixtures.ts`. Activated via URL params
+ * `?bubble-icons=full|partial|empty|malformed|html|default` and
+ * `?bubble-items=bold,italic,strike`. Runtime swap via
+ * `window.__DEMO_SET_BUBBLE_ICONS__('full' | null)`.
+ */
+
+import { test } from './fixtures.js';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const bubbleMenu = '.dm-bubble-menu';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function gotoDefault(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function gotoNotion(page: Page, search = ''): Promise<void> {
+  await page.goto('/' + (search ? `?${search}` : ''));
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+  await page.waitForFunction(() => Boolean((window as unknown as Record<string, unknown>).__DEMO_EDITOR__));
+}
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as Record<string, { setContent: (h: string, e: boolean) => void; commands: { focus: () => void } }>).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(100);
+}
+
+async function selectInParagraph(page: Page, startOffset: number, endOffset: number, selector = `${editorSelector} p`): Promise<void> {
+  await page.evaluate(
+    ({ sel, edSel, startOffset, endOffset }) => {
+      const el = document.querySelector(sel);
+      if (!el || !el.firstChild) return;
+      const range = document.createRange();
+      range.setStart(el.firstChild, startOffset);
+      range.setEnd(el.firstChild, endOffset);
+      const s = window.getSelection();
+      s?.removeAllRanges();
+      s?.addRange(range);
+      const editor = document.querySelector(edSel);
+      if (editor instanceof HTMLElement) editor.focus();
+    },
+    { sel: selector, edSel: editorSelector, startOffset, endOffset },
+  );
+  await page.waitForTimeout(150);
+}
+
+function bubbleButton(page: Page, ariaLabel: string): Locator {
+  return page.locator(`${bubbleMenu} button[aria-label="${ariaLabel}"]`).first();
+}
+
+async function expectCustomIcon(page: Page, ariaLabel: string, expectedKey: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator(`svg[data-test-icon="custom-${expectedKey}"]`)).toHaveCount(1);
+}
+
+async function expectDefaultIcon(page: Page, ariaLabel: string): Promise<void> {
+  const button = bubbleButton(page, ariaLabel);
+  await expect(button).toBeVisible();
+  await expect(button.locator('svg[data-test-icon]')).toHaveCount(0);
+  await expect(button.locator('svg')).not.toHaveCount(0);
+}
+
+async function openBubble(page: Page, html = '<p>Hello custom icons</p>'): Promise<void> {
+  await setContentAndFocus(page, html);
+  await selectInParagraph(page, 0, 'Hello'.length);
+  await expect(page.locator(bubbleMenu)).toBeVisible();
+}
+
+test.describe('BubbleMenu icons - Group A: basic override', () => {
+  test('A1: format buttons use custom icons when ?bubble-icons=full', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Underline', 'underline');
+  });
+
+  test('A2: partial override, unmapped keys fall back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Underline');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+
+  test('A3: empty IconSet falls back to defaults for every button', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=empty');
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    const buttonCount = await page.locator(`${bubbleMenu} button`).count();
+    expect(buttonCount).toBeGreaterThan(0);
+  });
+
+  test('A4: no icons prop preserves default Phosphor rendering', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
+    await expectDefaultIcon(page, 'Bold');
+    await expectDefaultIcon(page, 'Italic');
+  });
+
+  test('A5: custom SVG attributes are preserved verbatim', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    const svg = bold.locator('svg[data-test-icon="custom-bold"]');
+    await expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    await expect(svg).toHaveAttribute('width', '16');
+    await expect(svg).toHaveAttribute('height', '16');
+    await expect(svg.locator('circle')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group B: sub-components', () => {
+  test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
+  });
+
+  test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignLeft"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignRight"]')).toHaveCount(1);
+    await expect(panel.locator('svg[data-test-icon="custom-textAlignJustify"]')).toHaveCount(1);
+  });
+
+  test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
+    const exists = await dropdownTrigger.count();
+    test.skip(exists === 0, 'no dropdown in this demo layout');
+    await dropdownTrigger.click();
+    const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
+    await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();
+    // Click typically closes the bubble: reopen via re-select.
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(dropdownTrigger.locator('svg[data-test-icon="custom-textAlignCenter"]')).toHaveCount(1);
+  });
+
+  test('B4: Notion mode "..." block-menu trigger uses custom icon', async ({ page }) => {
+    await gotoNotion(page, 'bubble-icons=full');
+    await openBubble(page);
+    const moreOptions = bubbleButton(page, 'More options');
+    await expect(moreOptions).toBeVisible();
+    await expect(moreOptions.locator('svg[data-test-icon="custom-dotsThree"]')).toHaveCount(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group C: reactivity', () => {
+  test('C1: setting icons at runtime swaps default to custom', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await expectDefaultIcon(page, 'Bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('C2: unsetting icons at runtime restores defaults', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
+    });
+    await page.waitForTimeout(50);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectDefaultIcon(page, 'Bold');
+  });
+
+  test('C3: rapid toggling does not detach duplicates and final state is correct', async ({ page }) => {
+    await gotoDefault(page);
+    await openBubble(page);
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      for (let i = 0; i < 5; i++) {
+        setter('full');
+        setter(null);
+      }
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group D: contexts', () => {
+  test('D1: text context (paragraph selection) uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page, '<p>Some text content for selection</p>');
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+  });
+
+  test('D2: heading context uses custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<h1>Heading title</h1>');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('D3: code block context hides bubble or shows custom-icon subset', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
+    await selectInParagraph(page, 0, 5, `${editorSelector} code`);
+    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
+    // if it IS visible, no default-icon SVGs should leak through.
+    const isVisible = await page.locator(bubbleMenu).isVisible();
+    if (isVisible) {
+      const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
+      expect(defaultIcons).toBe(0);
+    }
+  });
+
+  test('D4: context switch mid-session keeps custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p>Paragraph text</p><h1>Heading text</h1>');
+    await selectInParagraph(page, 0, 'Paragraph'.length, `${editorSelector} p`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await selectInParagraph(page, 0, 'Heading'.length, `${editorSelector} h1`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group E: item filtering', () => {
+  test('E1: every item in a custom items list uses its custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectCustomIcon(page, 'Strikethrough', 'strike');
+  });
+
+  test('E2: item in custom list without override falls back to default', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=partial&bubble-items=bold,italic,strike');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await expectCustomIcon(page, 'Italic', 'italic');
+    await expectDefaultIcon(page, 'Strikethrough');
+  });
+});
+
+test.describe('BubbleMenu icons - Group F: active state', () => {
+  test('F1: bold-active button keeps custom icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await setContentAndFocus(page, '<p><strong>Bold text here</strong></p>');
+    await selectInParagraph(page, 0, 'Bold'.length, `${editorSelector} strong`);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F2: activating bold via click does not revert icon', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.click();
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(bold).toHaveAttribute('aria-pressed', 'true');
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('F3: aria attributes are preserved despite custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expect(page.locator(bubbleMenu)).toHaveAttribute('role', 'toolbar');
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toHaveAttribute('aria-label', 'Bold');
+    await expect(bold).toHaveAttribute('title', /Bold/);
+    // Roving tabindex is optional per wrapper; cap at one focused button.
+    const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
+    expect(zeros).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('BubbleMenu icons - Group G: edge cases', () => {
+  test('G1: empty SVG string renders empty content, button still works', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=malformed');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold).toBeVisible();
+    await expect(bold.locator('svg')).toHaveCount(0);
+    await bold.click();
+    await page.waitForTimeout(50);
+    const ed = await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { isActive: (k: string) => boolean }>).__DEMO_EDITOR__;
+      return editor.isActive('bold');
+    });
+    expect(ed).toBe(true);
+  });
+
+  test('G2: arbitrary HTML in IconSet renders as HTML', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=html');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await expect(bold.locator('.my-bold-icon')).toHaveText('B');
+  });
+
+  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.evaluate(() => {
+      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
+      editor.destroy();
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
+    const leaks = await page.locator(`[data-test-icon]`).count();
+    expect(leaks).toBe(0);
+  });
+
+  test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {
+    await page.goto('/?bubble-icons=full');
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.click(modeToggleNotion);
+    await page.waitForSelector(editorSelector);
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+
+  test('G5: same IconSet content set twice does not detach buttons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await page.evaluate(() => {
+      const btn = document.querySelector('.dm-bubble-menu button[aria-label="Bold"]');
+      if (btn instanceof HTMLElement) btn.dataset.persistMarker = 'yes';
+    });
+    await page.evaluate(() => {
+      const setter = (window as unknown as Record<string, (k: string) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter('full');
+    });
+    await page.waitForTimeout(100);
+    await expect(bubbleButton(page, 'Bold')).toHaveCount(1);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group H: keyboard a11y', () => {
+  test('H1: keyboard nav across buttons preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    const bold = bubbleButton(page, 'Bold');
+    await bold.focus();
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(50);
+    const focused = page.locator(`${bubbleMenu} button:focus`).first();
+    const focusedExists = await focused.count();
+    if (focusedExists > 0) {
+      await expect(focused.locator('svg[data-test-icon]')).toHaveCount(1);
+    }
+    await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
+  });
+
+  test('H2: Escape closes bubble; reopen preserves custom icons', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});
+
+test.describe('BubbleMenu icons - Group I: theme smoke', () => {
+  test('I1: dark mode toggle does not affect custom icon rendering', async ({ page }) => {
+    await gotoDefault(page, 'bubble-icons=full');
+    const themeBtn = page.locator('.theme-toggle');
+    if (await themeBtn.count() > 0) await themeBtn.click();
+    await openBubble(page);
+    await expectCustomIcon(page, 'Bold', 'bold');
+  });
+});

--- a/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
@@ -12,7 +12,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 const editorSelector = '.dm-editor .ProseMirror';
 const bubbleMenu = '.dm-bubble-menu';
-const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const modeToggleNotion = 'button:has-text("Notion style")';
 
 async function gotoDefault(page: Page, search = ''): Promise<void> {
   await page.goto('/' + (search ? `?${search}` : ''));
@@ -245,8 +245,7 @@ test.describe('BubbleMenu icons - Group D: contexts', () => {
     await gotoDefault(page, 'bubble-icons=full');
     await setContentAndFocus(page, '<pre><code>const x = 1;</code></pre>');
     await selectInParagraph(page, 0, 5, `${editorSelector} code`);
-    // Hidden bubble menu inside codeBlock is an acceptable framework choice;
-    // if it IS visible, no default-icon SVGs should leak through.
+    // Bubble may hide inside codeBlock; if visible, no default icon should leak through.
     const isVisible = await page.locator(bubbleMenu).isVisible();
     if (isVisible) {
       const defaultIcons = await page.locator(`${bubbleMenu} svg:not([data-test-icon])`).count();
@@ -300,7 +299,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     await openBubble(page);
     const bold = bubbleButton(page, 'Bold');
     await bold.click();
-    await selectInParagraph(page, 0, 'Hello'.length);
+    await page.waitForTimeout(100);
     await expect(page.locator(bubbleMenu)).toBeVisible();
     await expect(bold).toHaveAttribute('aria-pressed', 'true');
     await expect(bold.locator('svg[data-test-icon="custom-bold"]')).toHaveCount(1);
@@ -313,7 +312,7 @@ test.describe('BubbleMenu icons - Group F: active state', () => {
     const bold = bubbleButton(page, 'Bold');
     await expect(bold).toHaveAttribute('aria-label', 'Bold');
     await expect(bold).toHaveAttribute('title', /Bold/);
-    // Roving tabindex is optional per wrapper; cap at one focused button.
+    // Roving tabindex is optional; assert at most one button has tabindex=0.
     const zeros = await page.locator(`${bubbleMenu} button[tabindex="0"]`).count();
     expect(zeros).toBeLessThanOrEqual(1);
   });
@@ -342,18 +341,18 @@ test.describe('BubbleMenu icons - Group G: edge cases', () => {
     await expect(bold.locator('.my-bold-icon')).toHaveText('B');
   });
 
-  test('G3: destroying editor with custom icons does not leak', async ({ page }) => {
+  test('G3: swapping icons removes the old custom SVG from the DOM', async ({ page }) => {
     await gotoDefault(page, 'bubble-icons=full');
     await openBubble(page);
     await expectCustomIcon(page, 'Bold', 'bold');
     await page.evaluate(() => {
-      const editor = (window as unknown as Record<string, { destroy: () => void }>).__DEMO_EDITOR__;
-      editor.destroy();
+      const setter = (window as unknown as Record<string, (k: string | null) => void>).__DEMO_SET_BUBBLE_ICONS__;
+      setter(null);
     });
     await page.waitForTimeout(100);
-    await expect(page.locator(`${bubbleMenu}.dm-bubble-menu`)).toHaveCount(0);
-    const leaks = await page.locator(`[data-test-icon]`).count();
-    expect(leaks).toBe(0);
+    await selectInParagraph(page, 0, 'Hello'.length);
+    await expect(page.locator(bubbleMenu)).toBeVisible();
+    await expect(page.locator(`${bubbleMenu} [data-test-icon]`)).toHaveCount(0);
   });
 
   test('G4: switching to notion mode reads icons param at mount', async ({ page }) => {

--- a/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
+++ b/apps/demo-vue/e2e/bubble-menu-icons.spec.ts
@@ -129,20 +129,16 @@ test.describe('BubbleMenu icons - Group A: basic override', () => {
 
 test.describe('BubbleMenu icons - Group B: sub-components', () => {
   test('B1: text-align dropdown trigger renders custom icon', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await expect(dropdownTrigger.locator('svg[data-test-icon^="custom-textAlign"]')).toHaveCount(1);
   });
 
   test('B2: text-align dropdown sub-items use custom icons', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await expect(panel).toBeVisible();
@@ -153,11 +149,9 @@ test.describe('BubbleMenu icons - Group B: sub-components', () => {
   });
 
   test('B3: dropdown trigger reflects active sub-item icon after alignment change', async ({ page }) => {
-    await gotoDefault(page, 'bubble-icons=full');
+    await gotoNotion(page, 'bubble-icons=full');
     await openBubble(page);
     const dropdownTrigger = page.locator(`${bubbleMenu} button.dm-toolbar-dropdown-trigger`).first();
-    const exists = await dropdownTrigger.count();
-    test.skip(exists === 0, 'no dropdown in this demo layout');
     await dropdownTrigger.click();
     const panel = page.locator(`${bubbleMenu} .dm-toolbar-dropdown-panel`).first();
     await panel.locator('svg[data-test-icon="custom-textAlignCenter"]').first().click();

--- a/apps/demo-vue/src/EditorDemo.vue
+++ b/apps/demo-vue/src/EditorDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import {
   useEditor,
   useEditorState,
@@ -45,9 +45,16 @@ import { Table } from '@domternal/extension-table';
 import { Emoji, emojis, createEmojiSuggestionRenderer } from '@domternal/extension-emoji';
 import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
 import type { MentionItem } from '@domternal/extension-mention';
+import type { IconSet } from '@domternal/core';
 import { createLowlight, common } from 'lowlight';
 import { DEMO_CONTENT } from './demo-content.js';
 import { useExposeEditorForE2E } from './useExposeEditorForE2E.js';
+import {
+  parseBubbleIconsParam,
+  parseBubbleItemsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const { useLayout } = defineProps<{ useLayout: boolean }>();
 
@@ -119,6 +126,21 @@ const isEmpty = useEditorState(editor, (ed) => ed.isEmpty);
 
 useExposeEditorForE2E(editor);
 
+// E2E fixture: ?bubble-icons= URL param + window.__DEMO_SET_BUBBLE_ICONS__ runtime hook.
+const bubbleIcons = ref<IconSet | undefined>(resolveBubbleIcons(parseBubbleIconsParam()));
+const bubbleItems = ref<string[] | undefined>(parseBubbleItemsParam());
+
+onMounted(() => {
+  const w = window as unknown as Record<string, unknown>;
+  w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+    bubbleIcons.value = resolveBubbleIcons(key);
+  };
+});
+onUnmounted(() => {
+  const w = window as unknown as Record<string, unknown>;
+  w['__DEMO_SET_BUBBLE_ICONS__'] = undefined;
+});
+
 const styledHtml = computed(() =>
   htmlContent.value ? inlineStyles(htmlContent.value, { codeHighlighter, tableColumnWidths: 'pixel' }) : '',
 );
@@ -142,11 +164,15 @@ defineExpose({ editor, editorRef });
     <DomternalBubbleMenu
       v-if="bubbleAuto"
       :editor="editor"
+      :icons="bubbleIcons"
+      :items="bubbleItems"
     />
     <DomternalBubbleMenu
       v-else
       :editor="editor"
-      :contexts="{ text: ['bold', 'italic', 'underline', 'strike', 'code'] }"
+      :contexts="bubbleItems ? undefined : { text: ['bold', 'italic', 'underline', 'strike', 'code'] }"
+      :items="bubbleItems"
+      :icons="bubbleIcons"
     />
     <DomternalFloatingMenu :editor="editor" />
     <DomternalEmojiPicker :editor="editor" :emojis="emojis" />

--- a/apps/demo-vue/src/NotionDemo.vue
+++ b/apps/demo-vue/src/NotionDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import {
   useEditor,
   useEditorState,
@@ -40,6 +40,7 @@ import {
   inlineStyles,
   getListItemCursorContext,
 } from '@domternal/core';
+import type { IconSet } from '@domternal/core';
 import { CodeBlockLowlight, createCodeHighlighter } from '@domternal/extension-code-block-lowlight';
 import { Image } from '@domternal/extension-image';
 import { Details } from '@domternal/extension-details';
@@ -58,6 +59,11 @@ import type { BlockMatcher, BlockCandidate } from '@domternal/extension-block-me
 import { TableOfContents, FloatingTocOutline, TableOfContentsBlock } from '@domternal/extension-toc';
 import { createLowlight, common } from 'lowlight';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
+import {
+  parseBubbleIconsParam,
+  resolveBubbleIcons,
+  type BubbleIconsParam,
+} from './bubble-icons-fixtures.js';
 
 const lowlight = createLowlight(common);
 const codeHighlighter = createCodeHighlighter(lowlight);
@@ -173,6 +179,19 @@ const styledHtml = computed(() =>
 );
 
 const toasts = ref<Toast[]>([]);
+
+// E2E fixture for bubble menu icons override.
+const bubbleIcons = ref<IconSet | undefined>(resolveBubbleIcons(parseBubbleIconsParam()));
+onMounted(() => {
+  const w = window as unknown as Record<string, unknown>;
+  w['__DEMO_SET_BUBBLE_ICONS__'] = (key: BubbleIconsParam | null): void => {
+    bubbleIcons.value = resolveBubbleIcons(key);
+  };
+});
+onUnmounted(() => {
+  const w = window as unknown as Record<string, unknown>;
+  w['__DEMO_SET_BUBBLE_ICONS__'] = undefined;
+});
 let toastCounter = 0;
 const pushToast = (message: string, kind: Toast['kind']): void => {
   const id = ++toastCounter;
@@ -222,7 +241,7 @@ watch(editor, (ed, _old, onCleanup) => {
       </div>
 
       <template v-if="editor">
-        <DomternalBubbleMenu :editor="editor" />
+        <DomternalBubbleMenu :editor="editor" :icons="bubbleIcons" />
         <DomternalFloatingMenu :editor="editor" :require-explicit-trigger="true" />
         <DomternalNotionColorPicker :editor="editor" />
       </template>

--- a/apps/demo-vue/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vue/src/bubble-icons-fixtures.ts
@@ -1,0 +1,78 @@
+/**
+ * Fixtures for the bubble menu `icons` override e2e suite.
+ *
+ * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Playwright can assert which icon was rendered for each button.
+ */
+
+import type { IconSet } from '@domternal/core';
+
+export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
+
+function customSvgFor(name: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+}
+
+export const FULL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+  underline: customSvgFor('underline'),
+  strike: customSvgFor('strike'),
+  code: customSvgFor('code'),
+  link: customSvgFor('link'),
+  highlight: customSvgFor('highlight'),
+  subscript: customSvgFor('subscript'),
+  superscript: customSvgFor('superscript'),
+  textAlignLeft: customSvgFor('textAlignLeft'),
+  textAlignCenter: customSvgFor('textAlignCenter'),
+  textAlignRight: customSvgFor('textAlignRight'),
+  textAlignJustify: customSvgFor('textAlignJustify'),
+  dotsThree: customSvgFor('dotsThree'),
+};
+
+export const PARTIAL_OVERRIDE: IconSet = {
+  bold: customSvgFor('bold'),
+  italic: customSvgFor('italic'),
+};
+
+export const EMPTY_OVERRIDE: IconSet = {};
+
+export const MALFORMED_OVERRIDE: IconSet = {
+  bold: '',
+};
+
+export const HTML_OVERRIDE: IconSet = {
+  bold: '<span class="my-bold-icon">B</span>',
+};
+
+export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {
+  switch (param) {
+    case 'full': return FULL_OVERRIDE;
+    case 'partial': return PARTIAL_OVERRIDE;
+    case 'empty': return EMPTY_OVERRIDE;
+    case 'malformed': return MALFORMED_OVERRIDE;
+    case 'html': return HTML_OVERRIDE;
+    case 'default':
+    case null:
+    default:
+      return undefined;
+  }
+}
+
+export function parseBubbleIconsParam(): BubbleIconsParam | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-icons');
+  if (value === 'full' || value === 'partial' || value === 'empty' || value === 'malformed' || value === 'html' || value === 'default') {
+    return value;
+  }
+  return null;
+}
+
+export function parseBubbleItemsParam(): string[] | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get('bubble-items');
+  if (!value) return undefined;
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}

--- a/apps/demo-vue/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vue/src/bubble-icons-fixtures.ts
@@ -1,28 +1,32 @@
 /**
  * Fixtures for the bubble menu `icons` override e2e suite.
  *
- * Each fixture SVG carries a `data-test-icon="custom-<key>"` attribute so
+ * Each fixture SVG carries a `data-test-icon="custom-<label>"` attribute so
  * Playwright can assert which icon was rendered for each button.
+ *
+ * IconSet keys must match core's actual icon names (e.g. Bold uses `textB`).
+ * The marker label stays user-readable (e.g. `custom-bold`) so tests stay
+ * readable.
  */
 
 import type { IconSet } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
-function customSvgFor(name: string): string {
-  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${name}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
+function customSvgFor(label: string): string {
+  return `<svg viewBox="0 0 24 24" data-test-icon="custom-${label}" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>`;
 }
 
 export const FULL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
-  underline: customSvgFor('underline'),
-  strike: customSvgFor('strike'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
+  textUnderline: customSvgFor('underline'),
+  textStrikethrough: customSvgFor('strike'),
   code: customSvgFor('code'),
   link: customSvgFor('link'),
-  highlight: customSvgFor('highlight'),
-  subscript: customSvgFor('subscript'),
-  superscript: customSvgFor('superscript'),
+  highlighterCircle: customSvgFor('highlight'),
+  textSubscript: customSvgFor('subscript'),
+  textSuperscript: customSvgFor('superscript'),
   textAlignLeft: customSvgFor('textAlignLeft'),
   textAlignCenter: customSvgFor('textAlignCenter'),
   textAlignRight: customSvgFor('textAlignRight'),
@@ -31,18 +35,18 @@ export const FULL_OVERRIDE: IconSet = {
 };
 
 export const PARTIAL_OVERRIDE: IconSet = {
-  bold: customSvgFor('bold'),
-  italic: customSvgFor('italic'),
+  textB: customSvgFor('bold'),
+  textItalic: customSvgFor('italic'),
 };
 
 export const EMPTY_OVERRIDE: IconSet = {};
 
 export const MALFORMED_OVERRIDE: IconSet = {
-  bold: '',
+  textB: '',
 };
 
 export const HTML_OVERRIDE: IconSet = {
-  bold: '<span class="my-bold-icon">B</span>',
+  textB: '<span class="my-bold-icon">B</span>',
 };
 
 export function resolveBubbleIcons(param: BubbleIconsParam | null): IconSet | undefined {

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -151,7 +151,10 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
   /** Context-aware: map context names to item arrays, `true` for all valid items, or `null` to disable */
   readonly contexts = input<Record<string, string[] | true | null> | undefined>(undefined);
 
-  /** Custom icon overrides. Falls back to default Phosphor icons for unmapped keys. */
+  /**
+   * Custom icon overrides. Falls back to default Phosphor icons for unmapped keys.
+   * For nullable bindings, use `iconsSignal() ?? {}` to satisfy strict template checks.
+   */
   readonly icons = input<IconSet | undefined>(undefined);
 
   /**

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -20,7 +20,7 @@ import {
   defaultIcons,
   positionFloatingOnce,
 } from '@domternal/core';
-import type { BubbleMenuOptions, ToolbarButton, ToolbarDropdown ,
+import type { BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown ,
   Editor} from '@domternal/core';
 
 interface BubbleMenuSeparator { type: 'separator'; name: string }
@@ -145,10 +145,13 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
   readonly updateDelay = input(0);
 
   /** Fixed item names (e.g. ['bold', 'italic', 'code']). Omit for auto mode (all format items). */
-  readonly items = input<string[]>();
+  readonly items = input<string[] | undefined>(undefined);
 
   /** Context-aware: map context names to item arrays, `true` for all valid items, or `null` to disable */
-  readonly contexts = input<Record<string, string[] | true | null>>();
+  readonly contexts = input<Record<string, string[] | true | null> | undefined>(undefined);
+
+  /** Custom icon overrides. Falls back to default Phosphor icons for unmapped keys. */
+  readonly icons = input<IconSet | undefined>(undefined);
 
   /**
    * Returns the effective contexts map: the explicit `contexts` input

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -5,6 +5,7 @@ import {
   ViewEncapsulation,
   input,
   signal,
+  effect,
   inject,
   NgZone,
   viewChild,
@@ -228,6 +229,12 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
       crypto?.randomUUID?.().slice(0, 8) ?? Math.random().toString(36).slice(2, 8);
     this.pluginKey = new PluginKey('angularBubbleMenu-' + suffix);
 
+    // Cache keys do not include icon-set identity, so flush on swap.
+    effect(() => {
+      this.icons();
+      this.htmlCache.clear();
+    });
+
     afterNextRender(() => {
       const editor = this.editor();
       const ctxs = this.resolveContexts(editor);
@@ -296,7 +303,8 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
   getCachedIcon(name: string): SafeHtml {
     let cached = this.htmlCache.get(name);
     if (!cached) {
-      cached = this.sanitizer.bypassSecurityTrustHtml(defaultIcons[name] ?? '');
+      const custom = this.icons();
+      cached = this.sanitizer.bypassSecurityTrustHtml(custom?.[name] ?? defaultIcons[name] ?? '');
       this.htmlCache.set(name, cached);
     }
     return cached;
@@ -644,7 +652,8 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
     const key = `t:${iconName}`;
     let cached = this.htmlCache.get(key);
     if (!cached) {
-      const svg = defaultIcons[iconName] ?? '';
+      const custom = this.icons();
+      const svg = custom?.[iconName] ?? defaultIcons[iconName] ?? '';
       cached = this.sanitizer.bypassSecurityTrustHtml(svg + this.dropdownCaret);
       this.htmlCache.set(key, cached);
     }
@@ -655,7 +664,8 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
     const key = `dc:${iconName}:${label}`;
     let cached = this.htmlCache.get(key);
     if (!cached) {
-      const svg = defaultIcons[iconName] ?? '';
+      const custom = this.icons();
+      const svg = custom?.[iconName] ?? defaultIcons[iconName] ?? '';
       cached = this.sanitizer.bypassSecurityTrustHtml(`${svg} ${label}`);
       this.htmlCache.set(key, cached);
     }

--- a/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
+++ b/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
@@ -1,12 +1,13 @@
 import {
   useCallback,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
 } from 'react';
 import type { Editor, BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown } from '@domternal/core';
-import { defaultIcons, positionFloatingOnce } from '@domternal/core';
+import { positionFloatingOnce } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useBubbleMenu } from './useBubbleMenu.js';
 
@@ -43,12 +44,11 @@ export function DomternalBubbleMenu({
   updateDelay,
   items,
   contexts,
+  icons,
   children,
 }: DomternalBubbleMenuProps): ReactNode {
   const { editor: contextEditor } = useCurrentEditor();
   const editor = editorProp ?? contextEditor;
-
-  const htmlCacheRef = useRef(new Map<string, string>());
 
   const {
     menuRef,
@@ -69,18 +69,22 @@ export function DomternalBubbleMenu({
     updateDelay,
     items,
     contexts,
+    icons,
   });
 
   // Force re-read of activeVersion in render to subscribe to state changes.
   void activeVersion;
 
-  const getCachedHtml = useCallback((name: string): string => {
-    const cache = htmlCacheRef.current;
-    const cached = cache.get(name);
-    if (cached) return cached;
-    const html = getCachedIcon(name);
-    cache.set(name, html);
-    return html;
+  // Fresh cache on getCachedIcon identity change, so an icons prop swap evicts old SVGs.
+  const getCachedHtml = useMemo(() => {
+    const cache = new Map<string, string>();
+    return (name: string): string => {
+      const cached = cache.get(name);
+      if (cached !== undefined) return cached;
+      const html = getCachedIcon(name);
+      cache.set(name, html);
+      return html;
+    };
   }, [getCachedIcon]);
 
   // Only one dropdown is open at a time across the entire bubble menu - the
@@ -220,7 +224,7 @@ function BubbleDropdown({
     ? dropdown.items.find((sub) => isItemActive(sub))
     : undefined;
   const triggerIcon = activeChild?.icon ?? dropdown.icon;
-  const triggerHtml = (defaultIcons[triggerIcon] ?? getCachedHtml(triggerIcon)) + DROPDOWN_CARET;
+  const triggerHtml = getCachedHtml(triggerIcon) + DROPDOWN_CARET;
 
   // Position dropdown + outside-close / Escape / cooperative dismissal via
   // a single AbortController.
@@ -291,7 +295,7 @@ function BubbleDropdown({
         >
           {dropdown.items.map((sub) => {
             const subActive = isItemActive(sub);
-            const subHtml = `${defaultIcons[sub.icon] ?? getCachedHtml(sub.icon)} ${sub.label}`;
+            const subHtml = `${getCachedHtml(sub.icon)} ${sub.label}`;
             return (
               <button
                 key={sub.name}

--- a/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
+++ b/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import type { Editor, BubbleMenuOptions, ToolbarButton, ToolbarDropdown } from '@domternal/core';
+import type { Editor, BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown } from '@domternal/core';
 import { defaultIcons, positionFloatingOnce } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useBubbleMenu } from './useBubbleMenu.js';
@@ -25,6 +25,8 @@ export interface DomternalBubbleMenuProps {
   items?: string[];
   /** Context-aware: map context names to item arrays, true for all, or null to disable. */
   contexts?: Record<string, string[] | true | null>;
+  /** Custom icon overrides. Falls back to default Phosphor icons for unmapped keys. */
+  icons?: IconSet;
   /** Additional content rendered after buttons. */
   children?: React.ReactNode;
 }

--- a/packages/react/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/react/src/bubble-menu/useBubbleMenu.ts
@@ -6,7 +6,7 @@ import {
   defaultBubbleContexts,
   defaultIcons,
 } from '@domternal/core';
-import type { Editor, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
+import type { Editor, IconSet, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
 
 // --- Duck-typed ProseMirror shapes (avoids instanceof across bundles) ---
 
@@ -90,6 +90,7 @@ export interface UseBubbleMenuOptions {
   updateDelay?: number | undefined;
   items?: string[] | undefined;
   contexts?: Record<string, string[] | true | null> | undefined;
+  icons?: IconSet | undefined;
 }
 
 export interface UseBubbleMenuResult {
@@ -109,7 +110,7 @@ export interface UseBubbleMenuResult {
 }
 
 export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResult {
-  const { editor, shouldShow, placement = 'top', offset = 8, updateDelay = 0, items, contexts: explicitContexts } = options;
+  const { editor, shouldShow, placement = 'top', offset = 8, updateDelay = 0, items, contexts: explicitContexts, icons } = options;
   // Synthesise default contexts when the consumer hasn't supplied either
   // `contexts` or `items`. The default depends on the `.dm-notion-mode`
   // ancestor class so Notion-style hosts get a richer toolbar without
@@ -519,7 +520,7 @@ export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResul
     isItemDisabled,
     executeCommand,
     activeVersion,
-    getCachedIcon: (name: string) => defaultIcons[name] ?? '',
+    getCachedIcon: (name: string) => icons?.[name] ?? defaultIcons[name] ?? '',
     trailing,
     openColorPicker,
     openBlockContextMenu,

--- a/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
@@ -2,9 +2,9 @@ import {
   ToolbarController,
   createBubbleMenuPlugin,
   defaultBubbleContexts,
-  defaultIcons,
   positionFloatingOnce,
 } from '@domternal/core';
+import { resolveIcon } from '../shared/iconRenderer.js';
 import type {
   Editor,
   BubbleMenuOptions,
@@ -138,6 +138,7 @@ export class DomternalBubbleMenu extends EventTarget {
   #updateDelay: number;
   #explicitItems: string[] | undefined;
   #explicitContexts: Record<string, string[] | true | null> | undefined;
+  #icons: IconSet | undefined;
 
   // Editor-derived caches (set once in #init)
   #maps: ItemMaps | null = null;
@@ -185,7 +186,7 @@ export class DomternalBubbleMenu extends EventTarget {
     this.#updateDelay = options.updateDelay ?? 0;
     this.#explicitItems = options.items;
     this.#explicitContexts = options.contexts;
-    void options.icons;
+    this.#icons = options.icons;
     this.#customContent = options.customContent;
     this.#pluginKey = createPluginKey('vanillaBubbleMenu');
 
@@ -280,7 +281,7 @@ export class DomternalBubbleMenu extends EventTarget {
   /** Replace the icon set. `undefined` restores default Phosphor icons. */
   setIcons(icons: IconSet | undefined): void {
     if (this.#destroyed) return;
-    void icons;
+    this.#icons = icons;
     this.#scheduleRender();
   }
 
@@ -581,7 +582,7 @@ export class DomternalBubbleMenu extends EventTarget {
     btn.setAttribute('aria-label', item.label);
     btn.setAttribute('aria-pressed', String(isActive));
     btn.title = item.label;
-    btn.innerHTML = defaultIcons[item.icon] ?? '';
+    btn.innerHTML = resolveIcon(item.icon, this.#icons);
 
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', (e) => { this.#onButtonClick(item, e); });
@@ -598,7 +599,7 @@ export class DomternalBubbleMenu extends EventTarget {
       ? dd.items.find((sub) => this.#activeMap.get(sub.name) ?? false)
       : undefined;
     const triggerIcon = activeChild?.icon ?? dd.icon;
-    const triggerHtml = (defaultIcons[triggerIcon] ?? '') + DROPDOWN_CARET;
+    const triggerHtml = resolveIcon(triggerIcon, this.#icons) + DROPDOWN_CARET;
 
     const trigger = document.createElement('button');
     trigger.type = 'button';
@@ -636,7 +637,7 @@ export class DomternalBubbleMenu extends EventTarget {
 
     for (const sub of dd.items) {
       const subActive = this.#activeMap.get(sub.name) ?? false;
-      const subHtml = `${defaultIcons[sub.icon] ?? ''} ${sub.label}`;
+      const subHtml = `${resolveIcon(sub.icon, this.#icons)} ${sub.label}`;
       const subBtn = document.createElement('button');
       subBtn.type = 'button';
       subBtn.className = 'dm-toolbar-dropdown-item';
@@ -688,7 +689,7 @@ export class DomternalBubbleMenu extends EventTarget {
       : 'More options';
     btn.setAttribute('aria-label', 'More options');
     btn.setAttribute('aria-haspopup', 'menu');
-    btn.innerHTML = defaultIcons['dotsThree'] ?? '';
+    btn.innerHTML = resolveIcon('dotsThree', this.#icons);
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', () => { this.openBlockContextMenu(btn); });
     return btn;

--- a/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
@@ -8,6 +8,7 @@ import {
 import type {
   Editor,
   BubbleMenuOptions,
+  IconSet,
   ToolbarButton,
   ToolbarDropdown,
   PluginKey,
@@ -55,6 +56,8 @@ export interface DomternalBubbleMenuOptions extends CustomContentOption {
    * this context). Defaults to `defaultBubbleContexts(editor)`.
    */
   contexts?: Record<string, string[] | true | null>;
+  /** Custom icon overrides. Falls back to default Phosphor icons for unmapped keys. */
+  icons?: IconSet;
 }
 
 export type { BubbleMenuItem, BubbleMenuTrailingState };
@@ -182,6 +185,7 @@ export class DomternalBubbleMenu extends EventTarget {
     this.#updateDelay = options.updateDelay ?? 0;
     this.#explicitItems = options.items;
     this.#explicitContexts = options.contexts;
+    void options.icons;
     this.#customContent = options.customContent;
     this.#pluginKey = createPluginKey('vanillaBubbleMenu');
 
@@ -270,6 +274,13 @@ export class DomternalBubbleMenu extends EventTarget {
       contexts ?? (this.#explicitItems ? undefined : defaultBubbleContexts(this.#editor));
     this.#updateResolvedItems();
     this.#updateStates();
+    this.#scheduleRender();
+  }
+
+  /** Replace the icon set. `undefined` restores default Phosphor icons. */
+  setIcons(icons: IconSet | undefined): void {
+    if (this.#destroyed) return;
+    void icons;
     this.#scheduleRender();
   }
 

--- a/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
@@ -2,7 +2,6 @@ import { computed, defineComponent, h, ref, watch } from 'vue';
 import type { PropType, ShallowRef, VNode } from 'vue';
 import {
   ToolbarController,
-  defaultIcons,
   positionFloatingOnce,
 } from '@domternal/core';
 import type { Editor, IconSet, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
@@ -43,6 +42,7 @@ export const DomternalBubbleMenu = defineComponent({
     // is safe (both share the same .value interface and watch subscribes to either)
     // and matches the wrapper convention (see useEmojiPicker).
     const editorRef = computed(() => props.editor ?? contextEditor.value) as ShallowRef<Editor | null>;
+    const iconsRef = computed(() => props.icons) as ShallowRef<IconSet | undefined>;
 
     const {
       menuRef,
@@ -63,6 +63,7 @@ export const DomternalBubbleMenu = defineComponent({
       updateDelay: props.updateDelay,
       items: props.items,
       contexts: props.contexts,
+      icons: iconsRef,
     });
 
     // Only one dropdown is open at a time across the entire bubble menu - the
@@ -267,7 +268,7 @@ const BubbleDropdown = defineComponent({
         ? dropdown.items.find((sub) => props.isItemActive(sub))
         : undefined;
       const triggerIcon = activeChild?.icon ?? dropdown.icon;
-      const triggerHtml = (defaultIcons[triggerIcon] ?? props.getCachedIcon(triggerIcon)) + DROPDOWN_CARET;
+      const triggerHtml = props.getCachedIcon(triggerIcon) + DROPDOWN_CARET;
 
       return h('div', {
         class: 'dm-toolbar-dropdown-wrapper',
@@ -295,7 +296,7 @@ const BubbleDropdown = defineComponent({
             'data-dropdown-panel': dropdown.name,
           }, dropdown.items.map((sub) => {
             const subActive = props.isItemActive(sub);
-            const subHtml = `${defaultIcons[sub.icon] ?? props.getCachedIcon(sub.icon)} ${sub.label}`;
+            const subHtml = `${props.getCachedIcon(sub.icon)} ${sub.label}`;
             return h('button', {
               key: sub.name,
               type: 'button',

--- a/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
@@ -5,7 +5,7 @@ import {
   defaultIcons,
   positionFloatingOnce,
 } from '@domternal/core';
-import type { Editor, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
+import type { Editor, IconSet, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useBubbleMenu } from './useBubbleMenu.js';
 
@@ -21,6 +21,8 @@ export interface DomternalBubbleMenuProps {
   updateDelay?: number;
   items?: string[];
   contexts?: Record<string, string[] | true | null>;
+  /** Custom icon overrides. Falls back to default Phosphor icons for unmapped keys. */
+  icons?: IconSet;
 }
 
 export const DomternalBubbleMenu = defineComponent({
@@ -33,6 +35,7 @@ export const DomternalBubbleMenu = defineComponent({
     updateDelay: { type: Number, default: 0 },
     items: { type: Array as PropType<string[]>, default: undefined },
     contexts: { type: Object as PropType<Record<string, string[] | true | null>>, default: undefined },
+    icons: { type: Object as PropType<IconSet>, default: undefined },
   },
   setup(props, { slots }) {
     const { editor: contextEditor } = useCurrentEditor();

--- a/packages/vue/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/useBubbleMenu.ts
@@ -7,7 +7,7 @@ import {
   defaultBubbleContexts,
   defaultIcons,
 } from '@domternal/core';
-import type { Editor, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
+import type { Editor, IconSet, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
 import { useDebouncedRef } from '../utils.js';
 
 // --- Duck-typed ProseMirror shapes (avoids instanceof across bundles) ---
@@ -92,6 +92,7 @@ export interface UseBubbleMenuOptions {
   updateDelay?: number | undefined;
   items?: string[] | undefined;
   contexts?: Record<string, string[] | true | null> | undefined;
+  icons?: ShallowRef<IconSet | undefined> | undefined;
 }
 
 export interface UseBubbleMenuResult {
@@ -111,7 +112,7 @@ export interface UseBubbleMenuResult {
 }
 
 export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResult {
-  const { editor, shouldShow, placement = 'top', offset = 8, updateDelay = 0, items, contexts: explicitContexts } = options;
+  const { editor, shouldShow, placement = 'top', offset = 8, updateDelay = 0, items, contexts: explicitContexts, icons: iconsRef } = options;
 
   const menuRef = ref<HTMLDivElement>();
   // Prefer crypto.randomUUID for collision-free uniqueness when two
@@ -507,7 +508,7 @@ export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResul
   };
 
   const getCachedIcon = (name: string): string => {
-    return defaultIcons[name] ?? '';
+    return iconsRef?.value?.[name] ?? defaultIcons[name] ?? '';
   };
 
   /**


### PR DESCRIPTION
## Summary

Adds the `icons` prop on `DomternalBubbleMenu` in all four wrappers, matching the existing `DomternalToolbar` API. Related to #79  (issue stays open until the next package release).

```html
<domternal-bubble-menu [editor]="ed" [icons]="icons" />
```

## Changes

- Routed every `defaultIcons[name]` lookup through `icons?.[name] ?? defaultIcons[name]` in Angular/React/Vue/Vanilla bubble menus.
- Per-wrapper cache invalidation on icon swap (Angular `effect`, React `useMemo`, Vue `computed`, Vanilla full rebuild).
- Notion `dotsThree` trailing + text-align dropdown trigger + sub-items honour the override.
