### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.7.1 (2026-05-23)
+
+### Features
+
+- feat(ci): layered safety nets to prevent silent surface regressions. Consumer type-surface test exercises every `RawCommands` augmentation through the dist; per-package API surface snapshots; CSS variable references validated against theme definitions; gzipped bundle size budgets per package; grep guard forbidding relative-path module augmentations; `publint --strict`. (#84)
+- feat(theme): tables render as a "data view" globally - 15px font, 1.5 line-height, tight cell padding. Easier to scan than body-scale tables. Override on `.dm-editor .ProseMirror table` for body-scale. (#84)
+- feat(theme): Notion mode suppresses the slash-command placeholder inside narrow `<td>` / `<th>` cells so long hints like `Press '/' for commands` don't wrap onto two lines. (#84)
+- feat(core): new `copyThemeClass(view, target)` utility - copies the editor's `dm-theme-*` class onto a floating element portaled to `document.body` so the dark/light cascade reaches it. (#84)
+
+### Fixes
+
+- fix(core): `RawCommands` module augmentations now reach external consumers. 30+ source files switched from `declare module '../types/Commands.js'` to `declare module '@domternal/core'`; tsup + rollup-plugin-dts dropped relative-path augmentations during bundling, silently breaking `editor.commands.focus()` and the rest of the command surface in any consumer of `@domternal/core@0.7.0`. (#84)
+- fix(theme): table dropdown text rendered dark-on-dark in dark mode because portaled popovers couldn't read `--dm-button-color`. Added fallback to `--dm-text`. (#84)
+- fix(core,extension-image,theme): `LinkPopover` and image popover rewritten to read theme tokens instead of hardcoded hex values; removed their dark-theme override blocks. Both popovers now adapt automatically to light/dark via the standard cascade. (#84)
+- fix(extension-block-menu,theme): native `prosemirror-dropcursor` no longer doubles up with BlockHandle's own `.dm-block-drop-indicator` during a handle drag. BlockHandle adds a `dm-block-handle-dragging` class for the drag's duration; the theme hides the native cursor only while that class is present. Non-handle drags (text selection, external file drops) keep the native cursor. (#84)
+- fix(extension-toc): `Table of contents` slash menu item moved from `Basic` group (priority 600, first slot) to `Advanced` (priority 90, last slot). Sits next to `Toggle block` at the end of the menu instead of dominating the first position. (#84)
+- fix(theme): Notion mode body and h1 / h2 / h3 `font-size` overrides removed. Both modes now share the base text scale, so toggling between classic and Notion shifts layout (narrow column, gutter, tight rhythm) without a text-size jump. (#84)
+- fix(theme): Notion mode table cells match classic-mode cell height. Higher-specificity rule keeps `td > p` / `th > p` margin at 0 against the Notion paragraph-margin rule that was puffing cells. (#84)
+
 ## 0.7.0 (2026-05-19)
 
 ### Breaking changes

--- a/apps/demo-angular/e2e/notion-demo.spec.ts
+++ b/apps/demo-angular/e2e/notion-demo.spec.ts
@@ -634,7 +634,8 @@ test.describe('Notion-mode library class', () => {
     expect(styles.blockHandleGutter).toBe('0');
     expect(styles.blockHandleLeft).toBe('-3.5rem');
     expect(styles.editorLineHeight).toBe('1.7');
-    expect(styles.editorFontSize).toBe('1.0625rem');
+    // Notion mode inherits classic body size; toggle shifts layout, not scale.
+    expect(styles.editorFontSize).toBe('1rem');
   });
 
   test('class composes with .dm-theme-dark: chrome stripped + dark surface tokens active', async ({ page }) => {

--- a/apps/demo-react/e2e/notion-demo.spec.ts
+++ b/apps/demo-react/e2e/notion-demo.spec.ts
@@ -634,7 +634,8 @@ test.describe('Notion-mode library class', () => {
     expect(styles.blockHandleGutter).toBe('0');
     expect(styles.blockHandleLeft).toBe('-3.5rem');
     expect(styles.editorLineHeight).toBe('1.7');
-    expect(styles.editorFontSize).toBe('1.0625rem');
+    // Notion mode inherits classic body size; toggle shifts layout, not scale.
+    expect(styles.editorFontSize).toBe('1rem');
   });
 
   test('class composes with .dm-theme-dark: chrome stripped + dark surface tokens active', async ({ page }) => {

--- a/apps/demo-vanilla/e2e/notion-demo.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-demo.spec.ts
@@ -634,7 +634,8 @@ test.describe('Notion-mode library class', () => {
     expect(styles.blockHandleGutter).toBe('0');
     expect(styles.blockHandleLeft).toBe('-3.5rem');
     expect(styles.editorLineHeight).toBe('1.7');
-    expect(styles.editorFontSize).toBe('1.0625rem');
+    // Notion mode inherits classic body size; toggle shifts layout, not scale.
+    expect(styles.editorFontSize).toBe('1rem');
   });
 
   test('class composes with .dm-theme-dark: chrome stripped + dark surface tokens active', async ({ page }) => {

--- a/apps/demo-vue/e2e/notion-demo.spec.ts
+++ b/apps/demo-vue/e2e/notion-demo.spec.ts
@@ -637,7 +637,8 @@ test.describe('Notion-mode library class', () => {
     expect(styles.blockHandleGutter).toBe('0');
     expect(styles.blockHandleLeft).toBe('-3.5rem');
     expect(styles.editorLineHeight).toBe('1.7');
-    expect(styles.editorFontSize).toBe('1.0625rem');
+    // Notion mode inherits classic body size; toggle shifts layout, not scale.
+    expect(styles.editorFontSize).toBe('1rem');
   });
 
   test('class composes with .dm-theme-dark: chrome stripped + dark surface tokens active', async ({ page }) => {

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-menu/README.md
+++ b/packages/extension-block-menu/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Block-menu UX extensions for Domternal editor - FloatingMenu, BlockHandle (hover gutter + drag), SlashCommand, ContextMenu, and keyboard reorder",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/README.md
+++ b/packages/extension-toc/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/src/helpers/activeStateTracker.test.ts
+++ b/packages/extension-toc/src/helpers/activeStateTracker.test.ts
@@ -101,6 +101,19 @@ describe('activeStateTracker', () => {
     tracker.destroy();
   });
 
+  it('treats a small positive subpixel top as "passed"', () => {
+    // `scrollTo(rect.top + scrollY)` can leave rect.top at ~0.25 due to
+    // CSS-pixel/device-pixel rounding; strict `<= 0` would miss it.
+    const onChange = vi.fn();
+    const tracker = createActiveStateTracker({ onChange });
+    const passed = mountHeading('passed', -300);
+    const justArrived = mountHeading('justArrived', 0.25);
+    const upcoming = mountHeading('upcoming', 200);
+    tracker.observe([passed, justArrived, upcoming]);
+    expect(onChange).toHaveBeenLastCalledWith('justArrived');
+    tracker.destroy();
+  });
+
   it('does NOT switch active to the next heading until its top reaches the viewport top', () => {
     // Active switches exactly when the viewport top line touches the
     // next heading - top <= 0. While the next heading is still below

--- a/packages/extension-toc/src/helpers/activeStateTracker.ts
+++ b/packages/extension-toc/src/helpers/activeStateTracker.ts
@@ -84,6 +84,10 @@ function makeReadId(attrName: string): (el: HTMLElement) => string | null {
  * driven recompute (rAF-throttled, see below), the switch tracks the
  * scroll position frame-by-frame instead of waiting on IO callbacks.
  */
+// `scrollTo(rect.top + scrollY)` leaves rect.top at a subpixel like 0.25.
+// 1px tolerance absorbs the rounding without catching far-below headings.
+const SUBPIXEL_TOLERANCE = 1;
+
 function pickActive(
   elements: readonly HTMLElement[],
   _intersecting: ReadonlySet<HTMLElement>,
@@ -97,7 +101,7 @@ function pickActive(
     // Skip elements with no visual extent (display:none ancestor,
     // detached, zero-sized).
     if (rect.width === 0 && rect.height === 0) continue;
-    if (rect.top <= 0 && rect.top > lastPassedTop) {
+    if (rect.top <= SUBPIXEL_TOLERANCE && rect.top > lastPassedTop) {
       lastPassedTop = rect.top;
       lastPassed = el;
     }

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -8,7 +8,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 <u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
 
 ## Features

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release. Rolls up the editor polish, augmentation regression fix, and CI safety nets shipped in #84.

**Highlights**:
- `RawCommands` augmentations now reach external consumers (silent `editor.commands.*` type loss in `@domternal/core@0.7.0` is fixed).
- New layered CI safety nets: consumer type-surface test, API surface snapshots, CSS variable validation, bundle size budgets, grep guard against relative-path augmentations, `publint --strict`.
- Theme polish: dark-mode table dropdown text readable, drop indicator no longer doubles up during handle drag, Notion-mode tables match classic-mode cell height.
- Global table styling switched to "data view" (15px font, tight padding) and Notion-mode body/headings inherit classic sizes for consistent text scale across modes.
- TOC slash menu item moved from `Basic` (first slot) to `Advanced` (last slot).

See [CHANGELOG.md](./CHANGELOG.md#071-2026-05-23) for the full entry.

## Changes

- Bumped 15 `packages/*/package.json` + `domternal.dev/package.json` to `0.7.1`.
- `peerDependencies` and `prepublishOnly` hooks stay at `>=0.7.0` (patch release rule).
- `0.7.1` entry added to `CHANGELOG.md` and `domternal.dev/src/content/docs/v1/changelog.mdx`.
- Cosmetic: missing bullet between `Documentation` and `StackBlitz (Angular)` links added in 15 package READMEs.

## Verified

- `pnpm test && pnpm build && pnpm typecheck && pnpm lint`
- `pnpm test:types-consumer && pnpm test:api-surface && pnpm test:css-vars && pnpm test:bundle-size`
- E2E suite (`pnpm test:e2e`) - to run before merge