### PR TITLE
feat(extension-toc,demos,theme): Notion scrollable mode, container scroll-spy TOC, drop indicator fix

### DIFF
--- a/apps/demo-angular/e2e/notion-demo.spec.ts
+++ b/apps/demo-angular/e2e/notion-demo.spec.ts
@@ -4058,9 +4058,10 @@ test.describe('Table of Contents - hover expansion', () => {
   test('hovering the outline transitions through to "expanded" state', async ({ page }) => {
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    // The default hoverInDelay is 120ms; allow up to 600ms before
-    // failing so any CI-induced jitter does not flake the test.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    // The default hoverInDelay is 120ms; allow up to 1500ms before
+    // failing so CI / saturated-CPU jitter does not flake the test
+    // (setTimeout is clamped under load, can drift well past 120ms).
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity is now 1 and rows are pointer-events:auto.
     const card = page.locator('.dm-toc-outline-card');
@@ -4080,7 +4081,7 @@ test.describe('Table of Contents - hover expansion', () => {
     // measurements are real (computed style still reads correctly
     // when collapsed, but text-overflow / wrapping needs visibility).
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const paddings = await rows.evaluateAll(
       (nodes) => nodes.map((n) => parseFloat(window.getComputedStyle(n).paddingInlineStart)),
@@ -4093,7 +4094,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const rows = page.locator('.dm-toc-outline-row');
     const lastIndex = (await rows.count()) - 1;
@@ -4133,7 +4134,7 @@ test.describe('Table of Contents - hover expansion', () => {
       const editor = document.querySelector<HTMLElement>('.ProseMirror');
       editor?.focus();
     });
-    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 1500 });
   });
 
   test('active row mirrors active tick (font-weight + aria-current)', async ({ page }) => {
@@ -4144,7 +4145,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Reveal card so getComputedStyle gives a meaningful weight value.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const matchedRow = page.locator(`.dm-toc-outline-row[data-toc-anchor="${targetId}"]`);
     await expect(matchedRow).toHaveAttribute('aria-current', 'location');
@@ -4182,7 +4183,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Expand via hover (waits up to 600ms past the 120ms in-delay).
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Move the mouse away. Use page.mouse.move() to a safe location
     // far from the outline; locator.hover('body') would re-enter the
@@ -4246,7 +4247,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Open expanded card and click the row pointing at the hidden heading.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
     await page.locator('.dm-toc-outline-row[data-toc-anchor="hidden"]').click();
 
     // The heading is now visible (details forced open by the
@@ -4268,7 +4269,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await outline.hover();
     // State still flips - reduced-motion only zeroes the CSS
     // transition, the JS state machine itself is unaffected.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity should be 1 (not transitioning).
     const card = page.locator('.dm-toc-outline-card');
@@ -5020,7 +5021,7 @@ test.describe('Table of Contents - robustness', () => {
     await outline.dispatchEvent('mouseenter');
 
     // Wait past hoverInDelay (120ms) + a generous grace window.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Now bounce in the OTHER direction. Final gesture is leave,
     // expect "collapsed" after hoverOutDelay (350ms).

--- a/apps/demo-angular/e2e/notion-demo.spec.ts
+++ b/apps/demo-angular/e2e/notion-demo.spec.ts
@@ -3431,12 +3431,11 @@ test.describe('Table of Contents - floating outline ticks', () => {
     expect(scrollYAfter).toBeGreaterThan(scrollYBefore);
   });
 
-  test('outline hides itself when fewer headings than minHeadings (default 2)', async ({ page }) => {
+  test('outline shows itself with a single heading at the default minHeadings (1)', async ({ page }) => {
     await setContent(page, '<h1>Only one heading</h1><p>body</p>');
     const outline = page.locator('.dm-toc-outline');
-    await expect(outline).toHaveAttribute('data-state', 'hidden');
-    // CSS rule turns data-state="hidden" into display: none.
-    await expect(outline).not.toBeVisible();
+    await expect(outline).toHaveAttribute('data-state', 'collapsed');
+    await expect(outline).toBeVisible();
   });
 
   test('outline hides itself on viewports at or below the mobile breakpoint', async ({ page }) => {

--- a/apps/demo-angular/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-angular/e2e/notion-drop-indicator.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E regression: during a BlockHandle drag, only the custom
+ * `.dm-block-drop-indicator` is visible; the native
+ * `prosemirror-dropcursor-block` / `-inline` element is hidden by the
+ * theme's `.dm-block-handle-dragging` rule.
+ *
+ * Without the hide rule (or with a typo in the selector, which is how
+ * this bug originally shipped), both indicators render and the user
+ * sees a doubled drop line. The unit test in BlockHandle only checks
+ * the class toggle, so this CSS visibility assertion has to live in a
+ * real browser.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page, type JSHandle } from '@playwright/test';
+
+const editorSelector = 'app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const blockHandleSelector = '.dm-block-handle';
+const dragBtnSelector = '.dm-block-handle-drag';
+const editorWrapperSelector = 'app-notion-demo .dm-editor';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+/**
+ * Read the relevant indicator state from the page. Captures both
+ * BlockHandle's custom indicator and the native PM dropcursor (both
+ * possible classes) so a single call answers "is the bug visible?".
+ */
+async function readIndicatorState(page: Page): Promise<{
+  hasDraggingClass: boolean;
+  customVisible: boolean;
+  nativeBlockVisible: boolean;
+  nativeInlineVisible: boolean;
+}> {
+  return page.evaluate(() => {
+    const isVisible = (el: HTMLElement | null): boolean => {
+      if (!el) return false;
+      const cs = window.getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      // PM dropcursor sets inline `position: absolute; ...`; treat zero
+      // bounding rect as not visible (e.g. before any dragover fires).
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 || rect.height > 0;
+    };
+    const dmEditor = document.querySelector<HTMLElement>('.dm-editor');
+    return {
+      hasDraggingClass: !!dmEditor?.classList.contains('dm-block-handle-dragging'),
+      customVisible: isVisible(document.querySelector<HTMLElement>('.dm-block-drop-indicator')),
+      nativeBlockVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-block')),
+      nativeInlineVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-inline')),
+    };
+  });
+}
+
+/**
+ * Start a synthetic HTML5 drag from the first block's handle and fire a
+ * single dragover at a position inside the editor. Returns the shared
+ * DataTransfer handle so the caller can run dragend later.
+ */
+async function startDragOverFirstBlock(page: Page): Promise<JSHandle<DataTransfer>> {
+  // Surface the handle by hovering the first block.
+  const firstBlock = page.locator(`${editorSelector} > *`).first();
+  await firstBlock.hover();
+  await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+  const dt = await page.evaluateHandle(() => new DataTransfer());
+  const handle = page.locator(dragBtnSelector);
+
+  // Target the second block to ensure the drop position is meaningful
+  // (PM's dropcursor needs a resolved position to render).
+  const target = page.locator(`${editorSelector} > *`).nth(1);
+  const targetBox = await target.boundingBox();
+  expect(targetBox).not.toBeNull();
+  if (!targetBox) throw new Error('target rect missing');
+  const clientX = targetBox.x + targetBox.width / 2;
+  const clientY = targetBox.y + targetBox.height * 0.8;
+
+  await handle.dispatchEvent('dragstart', { dataTransfer: dt });
+  // dragover wakes both indicators: BlockHandle's `dragover` listener
+  // positions `.dm-block-drop-indicator`, and PM's dropcursor plugin
+  // creates its DOM element (then the CSS rule hides it).
+  await page.locator(editorSelector).dispatchEvent('dragover', {
+    dataTransfer: dt,
+    clientX,
+    clientY,
+  });
+
+  // Two RAFs give layout time to flush so getBoundingClientRect reads
+  // the latest values for both indicator elements.
+  await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+
+  return dt;
+}
+
+async function endDrag(page: Page, dt: JSHandle<DataTransfer>): Promise<void> {
+  await page.locator(dragBtnSelector).dispatchEvent('dragend', { dataTransfer: dt });
+  await dt.dispose();
+  // PM dropcursor schedules its element removal ~20ms after dragend
+  // (`scheduleRemoval(20)`); wait past that so the post-drag assertions
+  // see the cleared state.
+  await page.waitForTimeout(80);
+}
+
+test.describe('BlockHandle drag - single drop indicator only', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('editor gets `dm-block-handle-dragging` class while a handle drag is in flight', async ({ page }) => {
+    const before = await readIndicatorState(page);
+    expect(before.hasDraggingClass).toBe(false);
+
+    const dt = await startDragOverFirstBlock(page);
+
+    const during = await readIndicatorState(page);
+    expect(during.hasDraggingClass).toBe(true);
+
+    await endDrag(page, dt);
+
+    const after = await readIndicatorState(page);
+    expect(after.hasDraggingClass).toBe(false);
+  });
+
+  test('custom `.dm-block-drop-indicator` is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('native PM dropcursor is hidden during a handle drag (no double line)', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    // Whichever of the two PM cursor flavours got mounted MUST be invisible.
+    // The bug this guards against: both visible at the same time.
+    expect(state.nativeBlockVisible).toBe(false);
+    expect(state.nativeInlineVisible).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('only one drop indicator is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    const visibleCount = [state.customVisible, state.nativeBlockVisible, state.nativeInlineVisible]
+      .filter(Boolean).length;
+    expect(visibleCount).toBe(1);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('PM dropcursor element carries a `prosemirror-dropcursor-*` class (not the legacy `ProseMirror-dropcursor`)', async ({ page }) => {
+    // Sanity check that pins down the class name PM actually emits. If
+    // the underlying library renames these, this test fires first and
+    // the hide rule needs the same rename.
+    const dt = await startDragOverFirstBlock(page);
+    const data = await page.evaluate(() => {
+      const block = document.querySelector('.prosemirror-dropcursor-block');
+      const inline = document.querySelector('.prosemirror-dropcursor-inline');
+      const legacy = document.querySelector('.ProseMirror-dropcursor');
+      return {
+        hasBlockOrInline: !!(block || inline),
+        hasLegacy: !!legacy,
+      };
+    });
+    expect(data.hasBlockOrInline).toBe(true);
+    expect(data.hasLegacy).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('custom indicator and dragging class clear after dragend', async ({ page }) => {
+    // PM dropcursor's own cleanup runs on its `dragend` listener attached
+    // to `view.dom`. Our synthetic dragend fires on the handle button (a
+    // sibling of `.ProseMirror`, not a descendant), so PM never sees it
+    // and its element lingers until the 5s scheduled removal. We assert
+    // only what BlockHandle owns: its custom indicator is hidden and the
+    // `.dm-block-handle-dragging` class is cleared.
+    const dt = await startDragOverFirstBlock(page);
+    await endDrag(page, dt);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(false);
+    expect(state.hasDraggingClass).toBe(false);
+  });
+});

--- a/apps/demo-angular/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-angular/e2e/notion-drop-indicator.spec.ts
@@ -17,7 +17,6 @@ const editorSelector = 'app-notion-demo .ProseMirror';
 const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
 const blockHandleSelector = '.dm-block-handle';
 const dragBtnSelector = '.dm-block-handle-drag';
-const editorWrapperSelector = 'app-notion-demo .dm-editor';
 
 async function goNotion(page: Page): Promise<void> {
   await page.goto('/');

--- a/apps/demo-angular/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-angular/e2e/notion-scrollable.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E for "Notion scrollable" mode: editor inside a fixed-height
+ * `.notion-page--scrollable` wrapper. Plugin runs `data-scroll-mode='container'`
+ * (skips 50vh sticky + bottom-visible IO + middle/center/frozen modes).
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'app-notion-demo .ProseMirror';
+const modeToggleScrollable = '.toolbar-mode-toggle button:has-text("Notion scrollable")';
+const containerSelector = '.notion-page--scrollable';
+
+async function goScrollable(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleScrollable);
+  await page.click(modeToggleScrollable);
+  await page.waitForSelector(editorSelector);
+  // Outline mounts as soon as TableOfContents storage has >= minHeadings.
+  await page.waitForSelector('.dm-toc-outline');
+  // Sticky positioning needs `--dm-toc-mid-half-height` resolved before
+  // the layout settles - wait for the plugin to publish it.
+  await page.waitForFunction(() => {
+    const o = document.querySelector('.dm-toc-outline') as HTMLElement | null;
+    return o !== null && o.style.getPropertyValue('--dm-toc-mid-half-height') !== '';
+  });
+}
+
+test.describe('Notion scrollable - container layout', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('page wrapper has max-height + overflow-y: auto', async ({ page }) => {
+    const styles = await page.locator(containerSelector).evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { maxHeight: cs.maxHeight, overflowY: cs.overflowY };
+    });
+    expect(styles.maxHeight).toBe('700px');
+    expect(styles.overflowY).toBe('auto');
+  });
+
+  test('outline carries data-scroll-mode="container"', async ({ page }) => {
+    const outline = page.locator('.dm-toc-outline');
+    await expect(outline).toHaveAttribute('data-scroll-mode', 'container');
+    const shell = page.locator('.dm-toc-outline-shell');
+    await expect(shell).toHaveAttribute('data-scroll-mode', 'container');
+  });
+
+  test('mounting the outline does not introduce a horizontal scrollbar', async ({ page }) => {
+    // Regression: absolute nav without `right` pokes past the host's right
+    // edge and triggers the host's overflow-x scrollbar.
+    const dims = await page.locator(containerSelector).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(dims.scrollWidth).toBeLessThanOrEqual(dims.clientWidth + 1);
+  });
+
+  test('outline uses sticky positioning (no 50vh page-scroll model)', async ({ page }) => {
+    const data = await page.locator('.dm-toc-outline').evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        position: cs.position,
+        midTopVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-top'),
+        halfHeightVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-half-height'),
+        bottomVisible: (el as HTMLElement).dataset['bottomVisible'] ?? null,
+        mode: (el as HTMLElement).dataset['mode'] ?? null,
+      };
+    });
+    expect(data.position).toBe('sticky');
+    expect(data.halfHeightVar).not.toBe('');
+    // Page-scroll model is fully skipped in container mode.
+    expect(data.midTopVar).toBe('');
+    expect(data.bottomVisible).toBeNull();
+    expect(data.mode).toBeNull();
+  });
+});
+
+test.describe('Notion scrollable - outline stays centered on container scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('outline.y stays the same regardless of host scrollTop', async ({ page }) => {
+    const initial = await page.locator('.dm-toc-outline').boundingBox();
+    expect(initial).not.toBeNull();
+
+    // Drive host scroll directly; the outline must not move with content.
+    for (const scrollTop of [50, 200, 500, 800]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const after = await page.locator('.dm-toc-outline').boundingBox();
+      expect(after).not.toBeNull();
+      expect(Math.abs(after!.y - initial!.y)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test('outline sits at the vertical middle of the visible container viewport', async ({ page }) => {
+    const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+    const hostBox = await page.locator(containerSelector).boundingBox();
+    if (!outlineBox || !hostBox) throw new Error('missing rect');
+    const hostMid = hostBox.y + hostBox.height / 2;
+    const outlineMid = outlineBox.y + outlineBox.height / 2;
+    expect(Math.abs(outlineMid - hostMid)).toBeLessThanOrEqual(4);
+  });
+
+  test('outline never escapes the container bounds at any scroll position', async ({ page }) => {
+    for (const scrollTop of [0, 100, 300, 600, 900]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+      const hostBox = await page.locator(containerSelector).boundingBox();
+      if (!outlineBox || !hostBox) continue;
+      expect(outlineBox.y).toBeGreaterThanOrEqual(hostBox.y - 2);
+      expect(outlineBox.y + outlineBox.height)
+        .toBeLessThanOrEqual(hostBox.y + hostBox.height + 2);
+    }
+  });
+});
+
+test.describe('Notion scrollable - clicking a tick scrolls the host only', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('clicking a tick moves the host scrollTop, not window.scrollY', async ({ page }) => {
+    // Push the page so window.scrollY > 0; the click must NOT reset it.
+    await page.evaluate(() => { window.scrollTo(0, 200); });
+    await page.waitForTimeout(50);
+
+    const before = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    // DOM click bypasses Playwright actionability so the tick column's
+    // pointer-events gating doesn't get in the way.
+    await page.evaluate(() => {
+      const ticks = document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+      ticks[ticks.length - 1]?.click();
+    });
+    await page.waitForTimeout(600);
+
+    const after = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    expect(after.hostTop).toBeGreaterThan(before.hostTop);
+    expect(Math.abs(after.windowY - before.windowY)).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('Notion scrollable - scroll-spy follows host scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('scrolling host past first H2 makes that H2 the active tick', async ({ page }) => {
+    const ticks = page.locator('.dm-toc-outline-tick');
+    expect(await ticks.count()).toBeGreaterThanOrEqual(2);
+
+    // scrollIntoView scrolls the nearest overflow:auto ancestor (= host).
+    await page.evaluate(() => {
+      const h2 = document.querySelector('app-notion-demo .ProseMirror h2');
+      if (h2) h2.scrollIntoView({ behavior: 'auto', block: 'start' });
+    });
+    await page.waitForTimeout(300);
+
+    const data = await page.evaluate(() => {
+      const active = document.querySelector('.dm-toc-outline-tick.dm-toc--active') as HTMLElement | null;
+      const h2 = document.querySelector('app-notion-demo .ProseMirror h2') as HTMLElement | null;
+      return { activeAnchor: active?.dataset['tocAnchor'] ?? null, firstH2Id: h2?.id ?? null };
+    });
+    expect(data.firstH2Id).toBeTruthy();
+    expect(data.activeAnchor).toBe(data.firstH2Id);
+  });
+});

--- a/apps/demo-angular/e2e/notion-toc-dynamic.spec.ts
+++ b/apps/demo-angular/e2e/notion-toc-dynamic.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * E2E: FloatingTocOutline picks up dynamically inserted headings AND the
+ * outline becomes visible as soon as the first heading exists.
+ *
+ * Default `minHeadings: 1` (matches Notion). The "delete-all then add 1
+ * H1" regression specifically guards against the prior 2-heading
+ * threshold that left the outline `display: none` after typing a single
+ * heading into an empty doc.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline');
+  await page.waitForTimeout(200);
+}
+
+async function placeCursorAtEnd(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(pm);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+async function selectAllAndDelete(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.querySelector<HTMLElement>('.ProseMirror')?.focus();
+  });
+  await page.keyboard.press('Control+A');
+  await page.keyboard.press('Meta+A');
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(150);
+}
+
+async function readOutlineState(page: Page): Promise<{
+  tickCount: number;
+  state: string | null;
+  display: string | null;
+  anchors: string[];
+}> {
+  return await page.evaluate(() => {
+    const outline = document.querySelector<HTMLElement>('.dm-toc-outline');
+    const ticks = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick'));
+    return {
+      tickCount: ticks.length,
+      state: outline?.dataset['state'] ?? null,
+      display: outline ? getComputedStyle(outline).display : null,
+      anchors: ticks.map((t) => t.dataset['tocAnchor'] ?? ''),
+    };
+  });
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - TOC tracks new headings`, () => {
+    test('appending H1 via # shortcut adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('# Appended H1');
+      await page.waitForTimeout(300);
+
+      const after = await readOutlineState(page);
+      expect(after.tickCount).toBe(before.tickCount + 1);
+      expect(after.anchors[after.anchors.length - 1]).toBeTruthy();
+    });
+
+    test('appending H1 via slash command adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/');
+      await page.waitForSelector('.dm-slash-command-menu');
+      await page.keyboard.type('Heading 1');
+      await page.waitForTimeout(150);
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Slash H1');
+      await page.waitForTimeout(300);
+
+      expect((await readOutlineState(page)).tickCount).toBe(before.tickCount + 1);
+    });
+
+    test('clearing the doc then typing one H1 shows the outline (minHeadings:1)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.keyboard.type('# Lone H1');
+      await page.waitForTimeout(400);
+
+      const observed = await readOutlineState(page);
+      expect(observed.tickCount).toBe(1);
+      expect(observed.state).toBe('collapsed');
+      expect(observed.display).not.toBe('none');
+    });
+
+    test('empty doc keeps the outline hidden until a heading exists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.waitForTimeout(200);
+
+      const empty = await readOutlineState(page);
+      expect(empty.tickCount).toBe(0);
+      expect(empty.state).toBe('hidden');
+      expect(empty.display).toBe('none');
+
+      await page.keyboard.type('# First');
+      await page.waitForTimeout(400);
+
+      const withOne = await readOutlineState(page);
+      expect(withOne.tickCount).toBe(1);
+      expect(withOne.state).toBe('collapsed');
+      expect(withOne.display).not.toBe('none');
+    });
+  });
+}

--- a/apps/demo-angular/e2e/notion-toc-overflow.spec.ts
+++ b/apps/demo-angular/e2e/notion-toc-overflow.spec.ts
@@ -1,0 +1,397 @@
+/**
+ * E2E: tick column caps at 50% of the container and clips extras
+ * (Notion behavior - no compression, no scroll on the column). The
+ * hover card opens at the top and is fully scrollable.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline-ticks');
+  await page.waitForTimeout(200);
+}
+
+async function pasteManyH2s(page: Page, count: number): Promise<void> {
+  const html = Array.from({ length: count }, (_, i) => `<h2>S${String(i)}</h2>`).join('');
+  await page.evaluate((h) => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const data = new DataTransfer();
+    data.setData('text/html', h);
+    pm.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true }));
+  }, html);
+  await page.waitForTimeout(700);
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - tick column caps at 50% + card scrolls`, () => {
+    test('DOM structure: ticks live in `.dm-toc-outline-ticks`, sibling of `.dm-toc-outline-card`', async ({ page }) => {
+      await gotoMode(page, mode);
+      const data = await page.evaluate(() => {
+        const nav = document.querySelector<HTMLElement>('.dm-toc-outline');
+        const wrapper = nav?.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = nav?.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return {
+          wrapperExists: !!wrapper,
+          cardExists: !!card,
+          wrapperHasTicks: (wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0) > 0,
+          cardIsSiblingOfWrapper: card?.parentElement === nav && wrapper?.parentElement === nav,
+        };
+      });
+      expect(data.wrapperExists).toBe(true);
+      expect(data.cardExists).toBe(true);
+      expect(data.wrapperHasTicks).toBe(true);
+      expect(data.cardIsSiblingOfWrapper).toBe(true);
+    });
+
+    test('inter-tick gap stays at the CSS default with many headings (no compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const gap = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w ? parseFloat(getComputedStyle(w).gap) : -1;
+      });
+      // Default is 10px - must stay constant regardless of heading count.
+      expect(gap).toBeCloseTo(10, 0);
+    });
+
+    test('ticks wrapper caps at ~50% and clips overflow (hidden, not scroll)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const data = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return null;
+        const cs = getComputedStyle(w);
+        const maxH = parseFloat(cs.maxHeight);
+        return {
+          overflow: cs.overflow,
+          overflowX: cs.overflowX,
+          overflowY: cs.overflowY,
+          maxHeight: maxH,
+          scrollHeight: w.scrollHeight,
+          clientHeight: w.clientHeight,
+          tickCount: w.querySelectorAll('.dm-toc-outline-tick').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      // Overflow MUST be hidden, never auto/scroll - the column doesn't scroll.
+      expect(data!.overflowY).not.toBe('auto');
+      expect(data!.overflowY).not.toBe('scroll');
+      expect(['hidden', 'clip']).toContain(data!.overflowY);
+      // Natural content far exceeds the visible wrapper.
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight + 100);
+      // ~50% of the container; page-mode 50vh ≈ 360, container ≈ 382.
+      expect(data!.maxHeight).toBeGreaterThan(300);
+      expect(data!.maxHeight).toBeLessThan(450);
+    });
+
+    test('hover opens the card with scrollTop = 0 (starts at the first row)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+
+      // Pre-scroll the (collapsed) card so we can prove the reset on open.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 200;
+      });
+
+      // Hover the nav to trigger the in-delay (120ms default) + expand.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          opacity: parseFloat(getComputedStyle(card).opacity),
+          scrollTop: card.scrollTop,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.opacity).toBeGreaterThan(0.5);
+      // Plugin reset scrollTop to 0 on the collapsed→expanded transition.
+      expect(data!.scrollTop).toBe(0);
+    });
+
+    test('card itself is scrollable for long heading lists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          overflowY: getComputedStyle(card).overflowY,
+          scrollHeight: card.scrollHeight,
+          clientHeight: card.clientHeight,
+          rowCount: card.querySelectorAll('.dm-toc-outline-row').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.overflowY).toBe('auto');
+      expect(data!.rowCount).toBeGreaterThan(100);
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight);
+    });
+
+    test('card rows keep a uniform height regardless of count (no flex compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const heights = await page.evaluate(() => {
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-row'));
+        return rows.slice(0, 20).map((r) => r.getBoundingClientRect().height);
+      });
+      expect(heights.length).toBeGreaterThanOrEqual(10);
+      // All rows match the first - no flex-shrink compression.
+      const first = heights[0];
+      expect(first).toBeGreaterThan(10);
+      for (const h of heights) {
+        expect(Math.abs(h - first)).toBeLessThan(0.5);
+      }
+    });
+
+    test('card max-height matches the ticks wrapper (= 50% of the container)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!wrapper || !card) return null;
+        return {
+          wrapperMaxH: parseFloat(getComputedStyle(wrapper).maxHeight),
+          cardMaxH: parseFloat(getComputedStyle(card).maxHeight),
+        };
+      });
+      expect(data).not.toBeNull();
+      // Card uses the same CSS var so the values match exactly.
+      expect(data!.cardMaxH).toBeCloseTo(data!.wrapperMaxH, 1);
+    });
+
+    test('removing headings shifts the visible window (no orphan ticks)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const beforeCount = await page.evaluate(
+        () => document.querySelectorAll('.dm-toc-outline-tick').length,
+      );
+
+      // Clear the doc; the outline should re-render with just the seeded heading(s).
+      await page.evaluate(() => {
+        const pm = document.querySelector<HTMLElement>('.ProseMirror');
+        pm?.focus();
+      });
+      await page.keyboard.press('Control+A');
+      await page.keyboard.press('Meta+A');
+      await page.keyboard.press('Delete');
+      await page.waitForTimeout(300);
+      await page.keyboard.type('# Only one');
+      await page.waitForTimeout(300);
+
+      const after = await page.evaluate(() => ({
+        count: document.querySelectorAll('.dm-toc-outline-tick').length,
+        wrapperChildrenCount:
+          document.querySelector('.dm-toc-outline-ticks')?.children.length ?? 0,
+      }));
+      expect(beforeCount).toBeGreaterThan(100);
+      expect(after.count).toBe(1);
+      expect(after.wrapperChildrenCount).toBe(1);
+    });
+
+    test('every heading produces a tick in the DOM (clipped, not truncated)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const headings = document.querySelectorAll('.ProseMirror h1, .ProseMirror h2, .ProseMirror h3');
+        return {
+          tickCount: wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0,
+          headingCount: headings.length,
+        };
+      });
+      // Plugin renders ALL; CSS clip hides the ones past the 50% mark.
+      expect(data.tickCount).toBe(data.headingCount);
+      expect(data.tickCount).toBeGreaterThan(80);
+    });
+
+    test('a clipped tick exists in DOM with valid anchor (just not visible)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 100);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = Array.from(wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick') ?? []);
+        const wrapperRect = wrapper?.getBoundingClientRect();
+        // Find a tick that sits below the wrapper's visible bottom edge.
+        const clipped = ticks.find((t) => {
+          const r = t.getBoundingClientRect();
+          return wrapperRect && r.top > wrapperRect.bottom;
+        });
+        return {
+          clippedExists: !!clipped,
+          clippedAnchor: clipped?.dataset['tocAnchor'] ?? '',
+          totalTicks: ticks.length,
+        };
+      });
+      expect(data.totalTicks).toBeGreaterThan(80);
+      expect(data.clippedExists).toBe(true);
+      // UniqueID stamped it - the anchor is non-empty even for clipped ticks.
+      expect(data.clippedAnchor).toBeTruthy();
+    });
+
+    test('tick column does not scroll on wheel - scrollTop stays 0', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      // Synthesize a wheel event on the wrapper - overflow:hidden ignores it.
+      await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return;
+        w.dispatchEvent(new WheelEvent('wheel', { deltaY: 500, bubbles: true }));
+      });
+      await page.waitForTimeout(100);
+      const scrollTop = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w?.scrollTop ?? -1;
+      });
+      expect(scrollTop).toBe(0);
+    });
+
+    test('clicking a visible tick scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 60);
+      const before = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // Click a tick deep enough that the scroll has to move appreciably.
+      const anchor = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+        const target = ticks?.[ticks.length - 5];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const after = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // EITHER the window OR the container scrolled - depends on mode.
+      const movedWindow = after.winY - before.winY;
+      const movedHost = after.hostTop - before.hostTop;
+      expect(Math.max(movedWindow, movedHost)).toBeGreaterThan(50);
+    });
+
+    test('clicking a row in the expanded card scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Click the 5th row deep in the card (likely below the fold for tick column).
+      const anchor = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        const rows = card?.querySelectorAll<HTMLElement>('.dm-toc-outline-row');
+        const target = rows?.[4];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const found = await page.evaluate((id) => {
+        const h = document.querySelector<HTMLElement>(`[id="${id}"]`);
+        return !!h;
+      }, anchor);
+      expect(found).toBe(true);
+    });
+
+    test('card stays expanded while the mouse is over the card itself', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 40);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Move pointer into the card center; avoids the brief gap-leave
+      // that Playwright's `.hover()` can hit between elements.
+      const cardBox = await page.locator('.dm-toc-outline-card').boundingBox();
+      if (cardBox) {
+        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2, { steps: 8 });
+      }
+      await page.waitForTimeout(150);
+      const state = await page.evaluate(
+        () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+      );
+      expect(state).toBe('expanded');
+    });
+
+    test('card collapses after the hover-out delay when leaving the outline', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 20);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('expanded');
+      // Move the pointer somewhere harmless.
+      await page.mouse.move(10, 10);
+      // Default hover-out delay is 350ms; allow a buffer.
+      await page.waitForTimeout(500);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('collapsed');
+    });
+
+    test('reopening the card resets scrollTop to 0 even after the user scrolled it', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // User scrolls the card mid-list.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 600;
+      });
+      // Collapse.
+      await page.mouse.move(10, 10);
+      await page.waitForTimeout(500);
+      // Reopen.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const top = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return card?.scrollTop ?? -1;
+      });
+      expect(top).toBe(0);
+    });
+
+    if (mode === 'Notion style') {
+      // Page-scroll only: `50vh` tracks viewport. Container mode's host
+      // is pinned at `max-height: 700px`, so resize is a no-op there.
+      test('viewport resize updates the ticks wrapper max-height (page-scroll)', async ({ page }) => {
+        await gotoMode(page, mode);
+        await pasteManyH2s(page, 100);
+        const before = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        await page.setViewportSize({ width: 1280, height: 1000 });
+        await page.waitForTimeout(200);
+        const after = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        expect(after).toBeGreaterThan(before + 50);
+      });
+    }
+  });
+}

--- a/apps/demo-angular/src/app/app.html
+++ b/apps/demo-angular/src/app/app.html
@@ -10,10 +10,21 @@
     <button [class.active]="mode() === 'default'" (click)="mode.set('default')">Default toolbar</button>
     <button [class.active]="mode() === 'custom'" (click)="mode.set('custom')">Custom layout</button>
     <button [class.active]="mode() === 'notion'" (click)="mode.set('notion')">Notion style</button>
+    <button [class.active]="mode() === 'notion-scrollable'" (click)="mode.set('notion-scrollable')">Notion scrollable</button>
   </div>
 
-  @if (mode() === 'notion') {
-    <app-notion-demo />
+  @if (isNotion()) {
+    <!-- @switch with mode as discriminator forces a fresh component instance
+         when switching between the two Notion variants - matches the vanilla
+         demo's destroy + recreate behaviour on mode change. -->
+    @switch (mode()) {
+      @case ('notion') {
+        <app-notion-demo />
+      }
+      @case ('notion-scrollable') {
+        <app-notion-demo [scrollable]="true" />
+      }
+    }
   } @else {
     <app-editor-demo [useLayout]="useLayout()" />
   }

--- a/apps/demo-angular/src/app/app.ts
+++ b/apps/demo-angular/src/app/app.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, computed, signal } from '@angular/c
 import { EditorDemoComponent } from './editor-demo/editor-demo.component.js';
 import { NotionDemoComponent } from './notion-demo/notion-demo.component.js';
 
-export type DemoMode = 'default' | 'custom' | 'notion';
+export type DemoMode = 'default' | 'custom' | 'notion' | 'notion-scrollable';
 
 @Component({
   selector: 'app-root',
@@ -16,6 +16,8 @@ export class App {
   // The editor-demo takes a boolean `useLayout` input; derive it from mode
   // so the existing component stays unchanged.
   useLayout = computed(() => this.mode() === 'custom');
+  isNotion = computed(() => this.mode() === 'notion' || this.mode() === 'notion-scrollable');
+  isScrollable = computed(() => this.mode() === 'notion-scrollable');
 
   toggleTheme(): void {
     this.isDark.update(v => !v);

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.html
@@ -1,8 +1,12 @@
-<div class="notion-page">
+<div
+  #pageEl
+  class="notion-page"
+  [class.notion-page--scrollable]="scrollable()"
+>
   <domternal-editor
     #ec
     class="dm-notion-mode"
-    [extensions]="extensions"
+    [extensions]="extensions()"
     [content]="editorContent"
     (editorCreated)="onEditorCreated($event)"
   />

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
@@ -10,6 +10,10 @@
 }
 
 .notion-page {
+  // Position context for the FloatingTocOutline extension which absolutely
+  // positions itself against the nearest positioned ancestor when anchored
+  // in editor mode.
+  position: relative;
   // Wide enough that the centered content column has clear left/right
   // whitespace AND the BlockHandle has room to live in that left margin.
   max-width: 56rem;
@@ -28,6 +32,34 @@
   border: 1px solid var(--dm-border-color, rgba(0, 0, 0, 0.08));
   border-radius: 0.375rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+// Scrollable variant: caps height and scrolls content internally instead
+// of growing. Pair with `FloatingTocOutline.activeScrollParent` so the
+// outline's scroll-spy follows the host scroll.
+.notion-page--scrollable {
+  max-height: 700px;
+  overflow-y: auto;
+
+  // Tokenised slim scrollbar; dark theme overrides keep contrast.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
 }
 
 // Toast surfaced by the Notion demo when a block link is copied (or fails

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -218,13 +218,10 @@ export class NotionDemoComponent implements OnDestroy {
     };
   }
 
-  // Tracked so `ngOnDestroy` and subsequent `onEditorCreated` calls can
-  // remove listeners before adding new ones. Without this, repeatedly
-  // mounting the component (HMR / route re-entry) would accumulate
-  // listeners on the same `.dm-editor` DOM node.
-  private copyLinkHost: HTMLElement | null = null;
-  private copyLinkSuccessListener: ((event: Event) => void) | null = null;
-  private copyLinkErrorListener: ((event: Event) => void) | null = null;
+  // AbortController scoped to one editor lifetime: `abort()` removes all
+  // listeners attached with its signal. Recreated per `onEditorCreated`
+  // so HMR / route re-entry can't leak listeners onto a stale host.
+  private toastsAbortCtl = new AbortController();
 
   onEditorCreated(editor: Editor): void {
     this.editor.set(editor);
@@ -238,23 +235,17 @@ export class NotionDemoComponent implements OnDestroy {
     // Tear down any previously-attached listeners before wiring new ones -
     // protects against leaking listeners when the editor is recreated
     // (HMR, re-entering the route, etc.).
-    this.removeCopyLinkListeners();
+    this.toastsAbortCtl.abort();
+    this.toastsAbortCtl = new AbortController();
+    const { signal } = this.toastsAbortCtl;
 
     // Surface toasts when "Copy link to block" succeeds or fails. Host apps
     // own this UX: BlockContextMenu only emits `dm:copy-link-success` (on
     // actual success) and `dm:copy-link-error` (on clipboard failure).
     const host = editor.view.dom.closest<HTMLElement>('.dm-editor');
     if (!host) return;
-    this.copyLinkHost = host;
-
-    this.copyLinkSuccessListener = (): void => {
-      this.showToast('Link copied', 'status', 'notion-demo-toast', NotionDemoComponent.TOAST_MS.success);
-    };
-    this.copyLinkErrorListener = (): void => {
-      this.showToast('Failed to copy link', 'alert', 'notion-demo-toast notion-demo-toast--error', NotionDemoComponent.TOAST_MS.error);
-    };
-    host.addEventListener('dm:copy-link-success', this.copyLinkSuccessListener);
-    host.addEventListener('dm:copy-link-error', this.copyLinkErrorListener);
+    host.addEventListener('dm:copy-link-success', () => this.pushToast('Link copied', 'success'), { signal });
+    host.addEventListener('dm:copy-link-error', () => this.pushToast('Failed to copy link', 'error'), { signal });
   }
 
   /** Inline-style the live HTML output for the "Styled HTML" pane. */
@@ -263,30 +254,19 @@ export class NotionDemoComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.removeCopyLinkListeners();
-    this.copyLinkHost = null;
+    this.toastsAbortCtl.abort();
     const w = window as unknown as Record<string, unknown>;
     w['__DEMO_SET_BUBBLE_ICONS__'] = undefined;
   }
 
-  private removeCopyLinkListeners(): void {
-    if (!this.copyLinkHost) return;
-    if (this.copyLinkSuccessListener) {
-      this.copyLinkHost.removeEventListener('dm:copy-link-success', this.copyLinkSuccessListener);
-      this.copyLinkSuccessListener = null;
-    }
-    if (this.copyLinkErrorListener) {
-      this.copyLinkHost.removeEventListener('dm:copy-link-error', this.copyLinkErrorListener);
-      this.copyLinkErrorListener = null;
-    }
-  }
-
-  private showToast(message: string, role: 'status' | 'alert', className: string, durationMs: number): void {
+  private pushToast(message: string, kind: 'success' | 'error'): void {
     const toast = document.createElement('div');
-    toast.className = className;
+    toast.className = kind === 'success'
+      ? 'notion-demo-toast'
+      : 'notion-demo-toast notion-demo-toast--error';
     toast.textContent = message;
-    toast.setAttribute('role', role);
+    toast.setAttribute('role', kind === 'success' ? 'status' : 'alert');
     document.body.appendChild(toast);
-    setTimeout(() => toast.remove(), durationMs);
+    setTimeout(() => toast.remove(), NotionDemoComponent.TOAST_MS[kind]);
   }
 }

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, OnDestroy, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, OnDestroy, computed, input, signal, viewChild } from '@angular/core';
 import {
   DomternalEditorComponent,
   DomternalBubbleMenuComponent,
@@ -38,6 +38,7 @@ import {
   Editor,
   inlineStyles,
   getListItemCursorContext,
+  type AnyExtension,
 } from '@domternal/core';
 import { CodeBlockLowlight, createCodeHighlighter } from '@domternal/extension-code-block-lowlight';
 import { Image } from '@domternal/extension-image';
@@ -109,74 +110,95 @@ export class NotionDemoComponent implements OnDestroy {
    */
   private static readonly TOAST_MS = { success: 1800, error: 2600 };
 
-  extensions = [
-    Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
-    Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
-    BulletList, OrderedList, TaskList,
-    TextAlign, TextColor, FontSize, FontFamily, LineHeight,
-    NotionColorPicker,
-    Table,
-    Details,
-    Image,
-    Emoji.configure({
-      emojis,
-      enableEmoticons: true,
-      toolbar: false,
-      suggestion: { render: createEmojiSuggestionRenderer() },
-    }),
-    Mention.configure({
-      suggestion: {
-        char: '@',
-        name: 'user',
-        items: ({ query }: { query: string }) =>
-          mockUsers.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
-        render: createMentionSuggestionRenderer(),
-        minQueryLength: 0,
-        invalidNodes: ['codeBlock'],
-      },
-    }),
-    LinkPopover, SelectionDecoration, ClearFormatting,
-    // Registered after the list extensions so their in-item Tab/Shift-Tab
-    // keymaps keep priority inside list items.
-    ListIndent,
-    UniqueID,
-    BlockColor,
-    // `paragraphInsideContainer` keeps containers (blockquote / tableCell /
-    // details) as one drag unit. Paragraphs nested in listItem are NOT
-    // covered because they were Tab-indented as separate logical blocks.
-    BlockHandle.configure({
-      nested: {
-        allowedNodes: [
-          'listItem', 'taskItem',
-          'heading', 'paragraph', 'codeBlock', 'blockquote', 'horizontalRule',
-        ],
-        matchers: [
-          {
-            name: 'paragraphInsideContainer',
-            test: ({ block, container }: BlockCandidate) =>
-              block.type.name === 'paragraph'
-                && container !== null
-                && PARAGRAPH_EXCLUSION_PARENTS.has(container.type.name)
-                ? 'reject'
-                : 'allow',
-          } satisfies BlockMatcher,
-        ],
-      },
-    }),
-    BlockContextMenu,
-    KeyboardReorder,
-    SlashCommand,
-    SmartPaste,
-    TableOfContents,
-    FloatingTocOutline,
-    TableOfContentsBlock,
-    // Empty paragraphs get the slash hint; other empty blocks stay quiet so
-    // the hint isn't repeated on every block.
-    Placeholder.configure({
-      placeholder: ({ node }) =>
-        node.type.name === 'paragraph' ? "Press '/' for commands" : '',
-    }),
-  ];
+  /**
+   * Cap the page wrapper height and scroll its content internally. Adds
+   * `notion-page--scrollable` and wires `activeScrollParent` so the TOC
+   * scroll-spy follows the host scroll instead of the window.
+   */
+  readonly scrollable = input(false);
+
+  /**
+   * Reference to the `.notion-page` wrapper. Resolved after first render;
+   * the `extensions` computed below picks it up so the editor recreates
+   * with the wired `activeScrollParent` when this signal resolves.
+   */
+  readonly pageElRef = viewChild<ElementRef<HTMLDivElement>>('pageEl');
+
+  readonly extensions = computed<AnyExtension[]>(() => {
+    const sp = this.scrollable() ? this.pageElRef()?.nativeElement ?? null : null;
+    return NotionDemoComponent.buildExtensions(sp);
+  });
+
+  private static buildExtensions(scrollParent: Element | null): AnyExtension[] {
+    return [
+      Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
+      Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
+      BulletList, OrderedList, TaskList,
+      TextAlign, TextColor, FontSize, FontFamily, LineHeight,
+      NotionColorPicker,
+      Table,
+      Details,
+      Image,
+      Emoji.configure({
+        emojis,
+        enableEmoticons: true,
+        toolbar: false,
+        suggestion: { render: createEmojiSuggestionRenderer() },
+      }),
+      Mention.configure({
+        suggestion: {
+          char: '@',
+          name: 'user',
+          items: ({ query }: { query: string }) =>
+            mockUsers.filter((u) => u.label.toLowerCase().includes(query.toLowerCase())),
+          render: createMentionSuggestionRenderer(),
+          minQueryLength: 0,
+          invalidNodes: ['codeBlock'],
+        },
+      }),
+      LinkPopover, SelectionDecoration, ClearFormatting,
+      // Registered after the list extensions so their in-item Tab/Shift-Tab
+      // keymaps keep priority inside list items.
+      ListIndent,
+      UniqueID,
+      BlockColor,
+      // `paragraphInsideContainer` keeps containers (blockquote / tableCell /
+      // details) as one drag unit. Paragraphs nested in listItem are NOT
+      // covered because they were Tab-indented as separate logical blocks.
+      BlockHandle.configure({
+        nested: {
+          allowedNodes: [
+            'listItem', 'taskItem',
+            'heading', 'paragraph', 'codeBlock', 'blockquote', 'horizontalRule',
+          ],
+          matchers: [
+            {
+              name: 'paragraphInsideContainer',
+              test: ({ block, container }: BlockCandidate) =>
+                block.type.name === 'paragraph'
+                  && container !== null
+                  && PARAGRAPH_EXCLUSION_PARENTS.has(container.type.name)
+                  ? 'reject'
+                  : 'allow',
+            } satisfies BlockMatcher,
+          ],
+        },
+      }),
+      BlockContextMenu,
+      KeyboardReorder,
+      SlashCommand,
+      SmartPaste,
+      TableOfContents,
+      FloatingTocOutline.configure({ activeScrollParent: scrollParent }),
+      TableOfContentsBlock,
+      // Empty paragraphs get the slash hint; other empty blocks stay quiet so
+      // the hint isn't repeated on every block.
+      Placeholder.configure({
+        placeholder: ({ node }) =>
+          node.type.name === 'paragraph' ? "Press '/' for commands" : '',
+      }),
+    ];
+  }
 
   editorContent = NOTION_DEMO_CONTENT;
   editor = signal<Editor | null>(null);

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -32,6 +32,7 @@ import {
   LineHeight,
   SelectionDecoration,
   ClearFormatting,
+  Dropcursor,
   UniqueID,
   BlockColor,
   Placeholder,
@@ -157,6 +158,10 @@ export class NotionDemoComponent implements OnDestroy {
         },
       }),
       LinkPopover, SelectionDecoration, ClearFormatting,
+      // Native PM dropcursor; BlockHandle hides it during a handle drag so
+      // only the custom `.dm-block-drop-indicator` shows. Kept loaded for
+      // non-handle drops (text selection, external file drops).
+      Dropcursor,
       // Registered after the list extensions so their in-item Tab/Shift-Tab
       // keymaps keep priority inside list items.
       ListIndent,

--- a/apps/demo-react/e2e/notion-demo.spec.ts
+++ b/apps/demo-react/e2e/notion-demo.spec.ts
@@ -4058,9 +4058,10 @@ test.describe('Table of Contents - hover expansion', () => {
   test('hovering the outline transitions through to "expanded" state', async ({ page }) => {
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    // The default hoverInDelay is 120ms; allow up to 600ms before
-    // failing so any CI-induced jitter does not flake the test.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    // The default hoverInDelay is 120ms; allow up to 1500ms before
+    // failing so CI / saturated-CPU jitter does not flake the test
+    // (setTimeout is clamped under load, can drift well past 120ms).
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity is now 1 and rows are pointer-events:auto.
     const card = page.locator('.dm-toc-outline-card');
@@ -4080,7 +4081,7 @@ test.describe('Table of Contents - hover expansion', () => {
     // measurements are real (computed style still reads correctly
     // when collapsed, but text-overflow / wrapping needs visibility).
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const paddings = await rows.evaluateAll(
       (nodes) => nodes.map((n) => parseFloat(window.getComputedStyle(n).paddingInlineStart)),
@@ -4093,7 +4094,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const rows = page.locator('.dm-toc-outline-row');
     const lastIndex = (await rows.count()) - 1;
@@ -4133,7 +4134,7 @@ test.describe('Table of Contents - hover expansion', () => {
       const editor = document.querySelector<HTMLElement>('.ProseMirror');
       editor?.focus();
     });
-    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 1500 });
   });
 
   test('active row mirrors active tick (font-weight + aria-current)', async ({ page }) => {
@@ -4144,7 +4145,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Reveal card so getComputedStyle gives a meaningful weight value.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const matchedRow = page.locator(`.dm-toc-outline-row[data-toc-anchor="${targetId}"]`);
     await expect(matchedRow).toHaveAttribute('aria-current', 'location');
@@ -4182,7 +4183,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Expand via hover (waits up to 600ms past the 120ms in-delay).
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Move the mouse away. Use page.mouse.move() to a safe location
     // far from the outline; locator.hover('body') would re-enter the
@@ -4246,7 +4247,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Open expanded card and click the row pointing at the hidden heading.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
     await page.locator('.dm-toc-outline-row[data-toc-anchor="hidden"]').click();
 
     // The heading is now visible (details forced open by the
@@ -4268,7 +4269,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await outline.hover();
     // State still flips - reduced-motion only zeroes the CSS
     // transition, the JS state machine itself is unaffected.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity should be 1 (not transitioning).
     const card = page.locator('.dm-toc-outline-card');
@@ -5020,7 +5021,7 @@ test.describe('Table of Contents - robustness', () => {
     await outline.dispatchEvent('mouseenter');
 
     // Wait past hoverInDelay (120ms) + a generous grace window.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Now bounce in the OTHER direction. Final gesture is leave,
     // expect "collapsed" after hoverOutDelay (350ms).

--- a/apps/demo-react/e2e/notion-demo.spec.ts
+++ b/apps/demo-react/e2e/notion-demo.spec.ts
@@ -3431,12 +3431,11 @@ test.describe('Table of Contents - floating outline ticks', () => {
     expect(scrollYAfter).toBeGreaterThan(scrollYBefore);
   });
 
-  test('outline hides itself when fewer headings than minHeadings (default 2)', async ({ page }) => {
+  test('outline shows itself with a single heading at the default minHeadings (1)', async ({ page }) => {
     await setContent(page, '<h1>Only one heading</h1><p>body</p>');
     const outline = page.locator('.dm-toc-outline');
-    await expect(outline).toHaveAttribute('data-state', 'hidden');
-    // CSS rule turns data-state="hidden" into display: none.
-    await expect(outline).not.toBeVisible();
+    await expect(outline).toHaveAttribute('data-state', 'collapsed');
+    await expect(outline).toBeVisible();
   });
 
   test('outline hides itself on viewports at or below the mobile breakpoint', async ({ page }) => {

--- a/apps/demo-react/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-react/e2e/notion-drop-indicator.spec.ts
@@ -17,7 +17,6 @@ const editorSelector = '.app-notion-demo .ProseMirror';
 const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
 const blockHandleSelector = '.dm-block-handle';
 const dragBtnSelector = '.dm-block-handle-drag';
-const editorWrapperSelector = '.app-notion-demo .dm-editor';
 
 async function goNotion(page: Page): Promise<void> {
   await page.goto('/');

--- a/apps/demo-react/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-react/e2e/notion-drop-indicator.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E regression: during a BlockHandle drag, only the custom
+ * `.dm-block-drop-indicator` is visible; the native
+ * `prosemirror-dropcursor-block` / `-inline` element is hidden by the
+ * theme's `.dm-block-handle-dragging` rule.
+ *
+ * Without the hide rule (or with a typo in the selector, which is how
+ * this bug originally shipped), both indicators render and the user
+ * sees a doubled drop line. The unit test in BlockHandle only checks
+ * the class toggle, so this CSS visibility assertion has to live in a
+ * real browser.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page, type JSHandle } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const blockHandleSelector = '.dm-block-handle';
+const dragBtnSelector = '.dm-block-handle-drag';
+const editorWrapperSelector = '.app-notion-demo .dm-editor';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+/**
+ * Read the relevant indicator state from the page. Captures both
+ * BlockHandle's custom indicator and the native PM dropcursor (both
+ * possible classes) so a single call answers "is the bug visible?".
+ */
+async function readIndicatorState(page: Page): Promise<{
+  hasDraggingClass: boolean;
+  customVisible: boolean;
+  nativeBlockVisible: boolean;
+  nativeInlineVisible: boolean;
+}> {
+  return page.evaluate(() => {
+    const isVisible = (el: HTMLElement | null): boolean => {
+      if (!el) return false;
+      const cs = window.getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      // PM dropcursor sets inline `position: absolute; ...`; treat zero
+      // bounding rect as not visible (e.g. before any dragover fires).
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 || rect.height > 0;
+    };
+    const dmEditor = document.querySelector<HTMLElement>('.dm-editor');
+    return {
+      hasDraggingClass: !!dmEditor?.classList.contains('dm-block-handle-dragging'),
+      customVisible: isVisible(document.querySelector<HTMLElement>('.dm-block-drop-indicator')),
+      nativeBlockVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-block')),
+      nativeInlineVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-inline')),
+    };
+  });
+}
+
+/**
+ * Start a synthetic HTML5 drag from the first block's handle and fire a
+ * single dragover at a position inside the editor. Returns the shared
+ * DataTransfer handle so the caller can run dragend later.
+ */
+async function startDragOverFirstBlock(page: Page): Promise<JSHandle<DataTransfer>> {
+  // Surface the handle by hovering the first block.
+  const firstBlock = page.locator(`${editorSelector} > *`).first();
+  await firstBlock.hover();
+  await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+  const dt = await page.evaluateHandle(() => new DataTransfer());
+  const handle = page.locator(dragBtnSelector);
+
+  // Target the second block to ensure the drop position is meaningful
+  // (PM's dropcursor needs a resolved position to render).
+  const target = page.locator(`${editorSelector} > *`).nth(1);
+  const targetBox = await target.boundingBox();
+  expect(targetBox).not.toBeNull();
+  if (!targetBox) throw new Error('target rect missing');
+  const clientX = targetBox.x + targetBox.width / 2;
+  const clientY = targetBox.y + targetBox.height * 0.8;
+
+  await handle.dispatchEvent('dragstart', { dataTransfer: dt });
+  // dragover wakes both indicators: BlockHandle's `dragover` listener
+  // positions `.dm-block-drop-indicator`, and PM's dropcursor plugin
+  // creates its DOM element (then the CSS rule hides it).
+  await page.locator(editorSelector).dispatchEvent('dragover', {
+    dataTransfer: dt,
+    clientX,
+    clientY,
+  });
+
+  // Two RAFs give layout time to flush so getBoundingClientRect reads
+  // the latest values for both indicator elements.
+  await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+
+  return dt;
+}
+
+async function endDrag(page: Page, dt: JSHandle<DataTransfer>): Promise<void> {
+  await page.locator(dragBtnSelector).dispatchEvent('dragend', { dataTransfer: dt });
+  await dt.dispose();
+  // PM dropcursor schedules its element removal ~20ms after dragend
+  // (`scheduleRemoval(20)`); wait past that so the post-drag assertions
+  // see the cleared state.
+  await page.waitForTimeout(80);
+}
+
+test.describe('BlockHandle drag - single drop indicator only', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('editor gets `dm-block-handle-dragging` class while a handle drag is in flight', async ({ page }) => {
+    const before = await readIndicatorState(page);
+    expect(before.hasDraggingClass).toBe(false);
+
+    const dt = await startDragOverFirstBlock(page);
+
+    const during = await readIndicatorState(page);
+    expect(during.hasDraggingClass).toBe(true);
+
+    await endDrag(page, dt);
+
+    const after = await readIndicatorState(page);
+    expect(after.hasDraggingClass).toBe(false);
+  });
+
+  test('custom `.dm-block-drop-indicator` is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('native PM dropcursor is hidden during a handle drag (no double line)', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    // Whichever of the two PM cursor flavours got mounted MUST be invisible.
+    // The bug this guards against: both visible at the same time.
+    expect(state.nativeBlockVisible).toBe(false);
+    expect(state.nativeInlineVisible).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('only one drop indicator is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    const visibleCount = [state.customVisible, state.nativeBlockVisible, state.nativeInlineVisible]
+      .filter(Boolean).length;
+    expect(visibleCount).toBe(1);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('PM dropcursor element carries a `prosemirror-dropcursor-*` class (not the legacy `ProseMirror-dropcursor`)', async ({ page }) => {
+    // Sanity check that pins down the class name PM actually emits. If
+    // the underlying library renames these, this test fires first and
+    // the hide rule needs the same rename.
+    const dt = await startDragOverFirstBlock(page);
+    const data = await page.evaluate(() => {
+      const block = document.querySelector('.prosemirror-dropcursor-block');
+      const inline = document.querySelector('.prosemirror-dropcursor-inline');
+      const legacy = document.querySelector('.ProseMirror-dropcursor');
+      return {
+        hasBlockOrInline: !!(block || inline),
+        hasLegacy: !!legacy,
+      };
+    });
+    expect(data.hasBlockOrInline).toBe(true);
+    expect(data.hasLegacy).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('custom indicator and dragging class clear after dragend', async ({ page }) => {
+    // PM dropcursor's own cleanup runs on its `dragend` listener attached
+    // to `view.dom`. Our synthetic dragend fires on the handle button (a
+    // sibling of `.ProseMirror`, not a descendant), so PM never sees it
+    // and its element lingers until the 5s scheduled removal. We assert
+    // only what BlockHandle owns: its custom indicator is hidden and the
+    // `.dm-block-handle-dragging` class is cleared.
+    const dt = await startDragOverFirstBlock(page);
+    await endDrag(page, dt);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(false);
+    expect(state.hasDraggingClass).toBe(false);
+  });
+});

--- a/apps/demo-react/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-react/e2e/notion-scrollable.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E for "Notion scrollable" mode: editor inside a fixed-height
+ * `.notion-page--scrollable` wrapper. Plugin runs `data-scroll-mode='container'`
+ * (skips 50vh sticky + bottom-visible IO + middle/center/frozen modes).
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleScrollable = '.toolbar-mode-toggle button:has-text("Notion scrollable")';
+const containerSelector = '.notion-page--scrollable';
+
+async function goScrollable(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleScrollable);
+  await page.click(modeToggleScrollable);
+  await page.waitForSelector(editorSelector);
+  // Outline mounts as soon as TableOfContents storage has >= minHeadings.
+  await page.waitForSelector('.dm-toc-outline');
+  // Sticky positioning needs `--dm-toc-mid-half-height` resolved before
+  // the layout settles - wait for the plugin to publish it.
+  await page.waitForFunction(() => {
+    const o = document.querySelector('.dm-toc-outline') as HTMLElement | null;
+    return o !== null && o.style.getPropertyValue('--dm-toc-mid-half-height') !== '';
+  });
+}
+
+test.describe('Notion scrollable - container layout', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('page wrapper has max-height + overflow-y: auto', async ({ page }) => {
+    const styles = await page.locator(containerSelector).evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { maxHeight: cs.maxHeight, overflowY: cs.overflowY };
+    });
+    expect(styles.maxHeight).toBe('700px');
+    expect(styles.overflowY).toBe('auto');
+  });
+
+  test('outline carries data-scroll-mode="container"', async ({ page }) => {
+    const outline = page.locator('.dm-toc-outline');
+    await expect(outline).toHaveAttribute('data-scroll-mode', 'container');
+    const shell = page.locator('.dm-toc-outline-shell');
+    await expect(shell).toHaveAttribute('data-scroll-mode', 'container');
+  });
+
+  test('mounting the outline does not introduce a horizontal scrollbar', async ({ page }) => {
+    // Regression: absolute nav without `right` pokes past the host's right
+    // edge and triggers the host's overflow-x scrollbar.
+    const dims = await page.locator(containerSelector).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(dims.scrollWidth).toBeLessThanOrEqual(dims.clientWidth + 1);
+  });
+
+  test('outline uses sticky positioning (no 50vh page-scroll model)', async ({ page }) => {
+    const data = await page.locator('.dm-toc-outline').evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        position: cs.position,
+        midTopVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-top'),
+        halfHeightVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-half-height'),
+        bottomVisible: (el as HTMLElement).dataset['bottomVisible'] ?? null,
+        mode: (el as HTMLElement).dataset['mode'] ?? null,
+      };
+    });
+    expect(data.position).toBe('sticky');
+    expect(data.halfHeightVar).not.toBe('');
+    // Page-scroll model is fully skipped in container mode.
+    expect(data.midTopVar).toBe('');
+    expect(data.bottomVisible).toBeNull();
+    expect(data.mode).toBeNull();
+  });
+});
+
+test.describe('Notion scrollable - outline stays centered on container scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('outline.y stays the same regardless of host scrollTop', async ({ page }) => {
+    const initial = await page.locator('.dm-toc-outline').boundingBox();
+    expect(initial).not.toBeNull();
+
+    // Drive host scroll directly; the outline must not move with content.
+    for (const scrollTop of [50, 200, 500, 800]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const after = await page.locator('.dm-toc-outline').boundingBox();
+      expect(after).not.toBeNull();
+      expect(Math.abs(after!.y - initial!.y)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test('outline sits at the vertical middle of the visible container viewport', async ({ page }) => {
+    const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+    const hostBox = await page.locator(containerSelector).boundingBox();
+    if (!outlineBox || !hostBox) throw new Error('missing rect');
+    const hostMid = hostBox.y + hostBox.height / 2;
+    const outlineMid = outlineBox.y + outlineBox.height / 2;
+    expect(Math.abs(outlineMid - hostMid)).toBeLessThanOrEqual(4);
+  });
+
+  test('outline never escapes the container bounds at any scroll position', async ({ page }) => {
+    for (const scrollTop of [0, 100, 300, 600, 900]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+      const hostBox = await page.locator(containerSelector).boundingBox();
+      if (!outlineBox || !hostBox) continue;
+      expect(outlineBox.y).toBeGreaterThanOrEqual(hostBox.y - 2);
+      expect(outlineBox.y + outlineBox.height)
+        .toBeLessThanOrEqual(hostBox.y + hostBox.height + 2);
+    }
+  });
+});
+
+test.describe('Notion scrollable - clicking a tick scrolls the host only', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('clicking a tick moves the host scrollTop, not window.scrollY', async ({ page }) => {
+    // Push the page so window.scrollY > 0; the click must NOT reset it.
+    await page.evaluate(() => { window.scrollTo(0, 200); });
+    await page.waitForTimeout(50);
+
+    const before = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    // DOM click bypasses Playwright actionability so the tick column's
+    // pointer-events gating doesn't get in the way.
+    await page.evaluate(() => {
+      const ticks = document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+      ticks[ticks.length - 1]?.click();
+    });
+    await page.waitForTimeout(600);
+
+    const after = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    expect(after.hostTop).toBeGreaterThan(before.hostTop);
+    expect(Math.abs(after.windowY - before.windowY)).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('Notion scrollable - scroll-spy follows host scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('scrolling host past first H2 makes that H2 the active tick', async ({ page }) => {
+    const ticks = page.locator('.dm-toc-outline-tick');
+    expect(await ticks.count()).toBeGreaterThanOrEqual(2);
+
+    // scrollIntoView scrolls the nearest overflow:auto ancestor (= host).
+    await page.evaluate(() => {
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2');
+      if (h2) h2.scrollIntoView({ behavior: 'auto', block: 'start' });
+    });
+    await page.waitForTimeout(300);
+
+    const data = await page.evaluate(() => {
+      const active = document.querySelector('.dm-toc-outline-tick.dm-toc--active') as HTMLElement | null;
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2') as HTMLElement | null;
+      return { activeAnchor: active?.dataset['tocAnchor'] ?? null, firstH2Id: h2?.id ?? null };
+    });
+    expect(data.firstH2Id).toBeTruthy();
+    expect(data.activeAnchor).toBe(data.firstH2Id);
+  });
+});

--- a/apps/demo-react/e2e/notion-toc-dynamic.spec.ts
+++ b/apps/demo-react/e2e/notion-toc-dynamic.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * E2E: FloatingTocOutline picks up dynamically inserted headings AND the
+ * outline becomes visible as soon as the first heading exists.
+ *
+ * Default `minHeadings: 1` (matches Notion). The "delete-all then add 1
+ * H1" regression specifically guards against the prior 2-heading
+ * threshold that left the outline `display: none` after typing a single
+ * heading into an empty doc.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline');
+  await page.waitForTimeout(200);
+}
+
+async function placeCursorAtEnd(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(pm);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+async function selectAllAndDelete(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.querySelector<HTMLElement>('.ProseMirror')?.focus();
+  });
+  await page.keyboard.press('Control+A');
+  await page.keyboard.press('Meta+A');
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(150);
+}
+
+async function readOutlineState(page: Page): Promise<{
+  tickCount: number;
+  state: string | null;
+  display: string | null;
+  anchors: string[];
+}> {
+  return await page.evaluate(() => {
+    const outline = document.querySelector<HTMLElement>('.dm-toc-outline');
+    const ticks = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick'));
+    return {
+      tickCount: ticks.length,
+      state: outline?.dataset['state'] ?? null,
+      display: outline ? getComputedStyle(outline).display : null,
+      anchors: ticks.map((t) => t.dataset['tocAnchor'] ?? ''),
+    };
+  });
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - TOC tracks new headings`, () => {
+    test('appending H1 via # shortcut adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('# Appended H1');
+      await page.waitForTimeout(300);
+
+      const after = await readOutlineState(page);
+      expect(after.tickCount).toBe(before.tickCount + 1);
+      expect(after.anchors[after.anchors.length - 1]).toBeTruthy();
+    });
+
+    test('appending H1 via slash command adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/');
+      await page.waitForSelector('.dm-slash-command-menu');
+      await page.keyboard.type('Heading 1');
+      await page.waitForTimeout(150);
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Slash H1');
+      await page.waitForTimeout(300);
+
+      expect((await readOutlineState(page)).tickCount).toBe(before.tickCount + 1);
+    });
+
+    test('clearing the doc then typing one H1 shows the outline (minHeadings:1)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.keyboard.type('# Lone H1');
+      await page.waitForTimeout(400);
+
+      const observed = await readOutlineState(page);
+      expect(observed.tickCount).toBe(1);
+      expect(observed.state).toBe('collapsed');
+      expect(observed.display).not.toBe('none');
+    });
+
+    test('empty doc keeps the outline hidden until a heading exists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.waitForTimeout(200);
+
+      const empty = await readOutlineState(page);
+      expect(empty.tickCount).toBe(0);
+      expect(empty.state).toBe('hidden');
+      expect(empty.display).toBe('none');
+
+      await page.keyboard.type('# First');
+      await page.waitForTimeout(400);
+
+      const withOne = await readOutlineState(page);
+      expect(withOne.tickCount).toBe(1);
+      expect(withOne.state).toBe('collapsed');
+      expect(withOne.display).not.toBe('none');
+    });
+  });
+}

--- a/apps/demo-react/e2e/notion-toc-overflow.spec.ts
+++ b/apps/demo-react/e2e/notion-toc-overflow.spec.ts
@@ -1,0 +1,397 @@
+/**
+ * E2E: tick column caps at 50% of the container and clips extras
+ * (Notion behavior - no compression, no scroll on the column). The
+ * hover card opens at the top and is fully scrollable.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline-ticks');
+  await page.waitForTimeout(200);
+}
+
+async function pasteManyH2s(page: Page, count: number): Promise<void> {
+  const html = Array.from({ length: count }, (_, i) => `<h2>S${String(i)}</h2>`).join('');
+  await page.evaluate((h) => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const data = new DataTransfer();
+    data.setData('text/html', h);
+    pm.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true }));
+  }, html);
+  await page.waitForTimeout(700);
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - tick column caps at 50% + card scrolls`, () => {
+    test('DOM structure: ticks live in `.dm-toc-outline-ticks`, sibling of `.dm-toc-outline-card`', async ({ page }) => {
+      await gotoMode(page, mode);
+      const data = await page.evaluate(() => {
+        const nav = document.querySelector<HTMLElement>('.dm-toc-outline');
+        const wrapper = nav?.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = nav?.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return {
+          wrapperExists: !!wrapper,
+          cardExists: !!card,
+          wrapperHasTicks: (wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0) > 0,
+          cardIsSiblingOfWrapper: card?.parentElement === nav && wrapper?.parentElement === nav,
+        };
+      });
+      expect(data.wrapperExists).toBe(true);
+      expect(data.cardExists).toBe(true);
+      expect(data.wrapperHasTicks).toBe(true);
+      expect(data.cardIsSiblingOfWrapper).toBe(true);
+    });
+
+    test('inter-tick gap stays at the CSS default with many headings (no compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const gap = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w ? parseFloat(getComputedStyle(w).gap) : -1;
+      });
+      // Default is 10px - must stay constant regardless of heading count.
+      expect(gap).toBeCloseTo(10, 0);
+    });
+
+    test('ticks wrapper caps at ~50% and clips overflow (hidden, not scroll)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const data = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return null;
+        const cs = getComputedStyle(w);
+        const maxH = parseFloat(cs.maxHeight);
+        return {
+          overflow: cs.overflow,
+          overflowX: cs.overflowX,
+          overflowY: cs.overflowY,
+          maxHeight: maxH,
+          scrollHeight: w.scrollHeight,
+          clientHeight: w.clientHeight,
+          tickCount: w.querySelectorAll('.dm-toc-outline-tick').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      // Overflow MUST be hidden, never auto/scroll - the column doesn't scroll.
+      expect(data!.overflowY).not.toBe('auto');
+      expect(data!.overflowY).not.toBe('scroll');
+      expect(['hidden', 'clip']).toContain(data!.overflowY);
+      // Natural content far exceeds the visible wrapper.
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight + 100);
+      // ~50% of the container; page-mode 50vh ≈ 360, container ≈ 382.
+      expect(data!.maxHeight).toBeGreaterThan(300);
+      expect(data!.maxHeight).toBeLessThan(450);
+    });
+
+    test('hover opens the card with scrollTop = 0 (starts at the first row)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+
+      // Pre-scroll the (collapsed) card so we can prove the reset on open.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 200;
+      });
+
+      // Hover the nav to trigger the in-delay (120ms default) + expand.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          opacity: parseFloat(getComputedStyle(card).opacity),
+          scrollTop: card.scrollTop,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.opacity).toBeGreaterThan(0.5);
+      // Plugin reset scrollTop to 0 on the collapsed→expanded transition.
+      expect(data!.scrollTop).toBe(0);
+    });
+
+    test('card itself is scrollable for long heading lists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          overflowY: getComputedStyle(card).overflowY,
+          scrollHeight: card.scrollHeight,
+          clientHeight: card.clientHeight,
+          rowCount: card.querySelectorAll('.dm-toc-outline-row').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.overflowY).toBe('auto');
+      expect(data!.rowCount).toBeGreaterThan(100);
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight);
+    });
+
+    test('card rows keep a uniform height regardless of count (no flex compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const heights = await page.evaluate(() => {
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-row'));
+        return rows.slice(0, 20).map((r) => r.getBoundingClientRect().height);
+      });
+      expect(heights.length).toBeGreaterThanOrEqual(10);
+      // All rows match the first - no flex-shrink compression.
+      const first = heights[0];
+      expect(first).toBeGreaterThan(10);
+      for (const h of heights) {
+        expect(Math.abs(h - first)).toBeLessThan(0.5);
+      }
+    });
+
+    test('card max-height matches the ticks wrapper (= 50% of the container)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!wrapper || !card) return null;
+        return {
+          wrapperMaxH: parseFloat(getComputedStyle(wrapper).maxHeight),
+          cardMaxH: parseFloat(getComputedStyle(card).maxHeight),
+        };
+      });
+      expect(data).not.toBeNull();
+      // Card uses the same CSS var so the values match exactly.
+      expect(data!.cardMaxH).toBeCloseTo(data!.wrapperMaxH, 1);
+    });
+
+    test('removing headings shifts the visible window (no orphan ticks)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const beforeCount = await page.evaluate(
+        () => document.querySelectorAll('.dm-toc-outline-tick').length,
+      );
+
+      // Clear the doc; the outline should re-render with just the seeded heading(s).
+      await page.evaluate(() => {
+        const pm = document.querySelector<HTMLElement>('.ProseMirror');
+        pm?.focus();
+      });
+      await page.keyboard.press('Control+A');
+      await page.keyboard.press('Meta+A');
+      await page.keyboard.press('Delete');
+      await page.waitForTimeout(300);
+      await page.keyboard.type('# Only one');
+      await page.waitForTimeout(300);
+
+      const after = await page.evaluate(() => ({
+        count: document.querySelectorAll('.dm-toc-outline-tick').length,
+        wrapperChildrenCount:
+          document.querySelector('.dm-toc-outline-ticks')?.children.length ?? 0,
+      }));
+      expect(beforeCount).toBeGreaterThan(100);
+      expect(after.count).toBe(1);
+      expect(after.wrapperChildrenCount).toBe(1);
+    });
+
+    test('every heading produces a tick in the DOM (clipped, not truncated)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const headings = document.querySelectorAll('.ProseMirror h1, .ProseMirror h2, .ProseMirror h3');
+        return {
+          tickCount: wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0,
+          headingCount: headings.length,
+        };
+      });
+      // Plugin renders ALL; CSS clip hides the ones past the 50% mark.
+      expect(data.tickCount).toBe(data.headingCount);
+      expect(data.tickCount).toBeGreaterThan(80);
+    });
+
+    test('a clipped tick exists in DOM with valid anchor (just not visible)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 100);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = Array.from(wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick') ?? []);
+        const wrapperRect = wrapper?.getBoundingClientRect();
+        // Find a tick that sits below the wrapper's visible bottom edge.
+        const clipped = ticks.find((t) => {
+          const r = t.getBoundingClientRect();
+          return wrapperRect && r.top > wrapperRect.bottom;
+        });
+        return {
+          clippedExists: !!clipped,
+          clippedAnchor: clipped?.dataset['tocAnchor'] ?? '',
+          totalTicks: ticks.length,
+        };
+      });
+      expect(data.totalTicks).toBeGreaterThan(80);
+      expect(data.clippedExists).toBe(true);
+      // UniqueID stamped it - the anchor is non-empty even for clipped ticks.
+      expect(data.clippedAnchor).toBeTruthy();
+    });
+
+    test('tick column does not scroll on wheel - scrollTop stays 0', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      // Synthesize a wheel event on the wrapper - overflow:hidden ignores it.
+      await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return;
+        w.dispatchEvent(new WheelEvent('wheel', { deltaY: 500, bubbles: true }));
+      });
+      await page.waitForTimeout(100);
+      const scrollTop = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w?.scrollTop ?? -1;
+      });
+      expect(scrollTop).toBe(0);
+    });
+
+    test('clicking a visible tick scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 60);
+      const before = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // Click a tick deep enough that the scroll has to move appreciably.
+      const anchor = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+        const target = ticks?.[ticks.length - 5];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const after = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // EITHER the window OR the container scrolled - depends on mode.
+      const movedWindow = after.winY - before.winY;
+      const movedHost = after.hostTop - before.hostTop;
+      expect(Math.max(movedWindow, movedHost)).toBeGreaterThan(50);
+    });
+
+    test('clicking a row in the expanded card scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Click the 5th row deep in the card (likely below the fold for tick column).
+      const anchor = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        const rows = card?.querySelectorAll<HTMLElement>('.dm-toc-outline-row');
+        const target = rows?.[4];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const found = await page.evaluate((id) => {
+        const h = document.querySelector<HTMLElement>(`[id="${id}"]`);
+        return !!h;
+      }, anchor);
+      expect(found).toBe(true);
+    });
+
+    test('card stays expanded while the mouse is over the card itself', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 40);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Move pointer into the card center; avoids the brief gap-leave
+      // that Playwright's `.hover()` can hit between elements.
+      const cardBox = await page.locator('.dm-toc-outline-card').boundingBox();
+      if (cardBox) {
+        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2, { steps: 8 });
+      }
+      await page.waitForTimeout(150);
+      const state = await page.evaluate(
+        () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+      );
+      expect(state).toBe('expanded');
+    });
+
+    test('card collapses after the hover-out delay when leaving the outline', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 20);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('expanded');
+      // Move the pointer somewhere harmless.
+      await page.mouse.move(10, 10);
+      // Default hover-out delay is 350ms; allow a buffer.
+      await page.waitForTimeout(500);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('collapsed');
+    });
+
+    test('reopening the card resets scrollTop to 0 even after the user scrolled it', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // User scrolls the card mid-list.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 600;
+      });
+      // Collapse.
+      await page.mouse.move(10, 10);
+      await page.waitForTimeout(500);
+      // Reopen.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const top = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return card?.scrollTop ?? -1;
+      });
+      expect(top).toBe(0);
+    });
+
+    if (mode === 'Notion style') {
+      // Page-scroll only: `50vh` tracks viewport. Container mode's host
+      // is pinned at `max-height: 700px`, so resize is a no-op there.
+      test('viewport resize updates the ticks wrapper max-height (page-scroll)', async ({ page }) => {
+        await gotoMode(page, mode);
+        await pasteManyH2s(page, 100);
+        const before = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        await page.setViewportSize({ width: 1280, height: 1000 });
+        await page.waitForTimeout(200);
+        const after = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        expect(after).toBeGreaterThan(before + 50);
+      });
+    }
+  });
+}

--- a/apps/demo-react/src/App.tsx
+++ b/apps/demo-react/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { EditorDemo } from './EditorDemo.js';
 import { NotionDemo } from './NotionDemo.js';
 
-type Mode = 'default' | 'custom' | 'notion';
+type Mode = 'default' | 'custom' | 'notion' | 'notion-scrollable';
 
 export function App() {
   const [isDark, setIsDark] = useState(false);
@@ -12,6 +12,8 @@ export function App() {
     setIsDark((v) => !v);
     document.body.classList.toggle('dm-theme-dark');
   };
+
+  const isNotion = mode === 'notion' || mode === 'notion-scrollable';
 
   return (
     <div className="demo">
@@ -32,10 +34,16 @@ export function App() {
         <button className={mode === 'notion' ? 'active' : ''} onClick={() => setMode('notion')}>
           Notion style
         </button>
+        <button className={mode === 'notion-scrollable' ? 'active' : ''} onClick={() => setMode('notion-scrollable')}>
+          Notion scrollable
+        </button>
       </div>
 
-      {mode === 'notion' ? (
-        <NotionDemo />
+      {isNotion ? (
+        // Keying on the mode forces a fresh mount when switching between
+        // the two Notion variants - matches the vanilla demo which
+        // destroys + recreates the NotionDemo on mode change.
+        <NotionDemo key={mode} scrollable={mode === 'notion-scrollable'} />
       ) : (
         <div className="app-editor-demo">
           <EditorDemo useLayout={mode === 'custom'} />

--- a/apps/demo-react/src/NotionDemo.tsx
+++ b/apps/demo-react/src/NotionDemo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import {
   useEditor,
@@ -39,6 +39,7 @@ import {
   Placeholder,
   inlineStyles,
   getListItemCursorContext,
+  type AnyExtension,
 } from '@domternal/core';
 import { CodeBlockLowlight, createCodeHighlighter } from '@domternal/extension-code-block-lowlight';
 import { Image } from '@domternal/extension-image';
@@ -92,7 +93,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
  */
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
-const extensions = [
+const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,
@@ -151,7 +152,7 @@ const extensions = [
   SlashCommand,
   SmartPaste,
   TableOfContents,
-  FloatingTocOutline,
+  FloatingTocOutline.configure({ activeScrollParent: scrollParent }),
   TableOfContentsBlock,
   // Empty paragraphs get the slash hint; other empty blocks stay quiet so
   // the hint isn't repeated on every block.
@@ -171,12 +172,30 @@ const getStyledHtml = (html: string): string => {
   return inlineStyles(html, { codeHighlighter, tableColumnWidths: 'pixel' });
 };
 
+export interface NotionDemoProps {
+  /** Cap the page wrapper height and scroll its content internally. Adds
+   * `notion-page--scrollable` and wires `activeScrollParent` so the TOC
+   * scroll-spy follows the host scroll instead of the window. */
+  scrollable?: boolean;
+}
+
 /**
  * Notion-style demo: no toolbar, floating menu on empty lines is the primary
  * block-insert UI, bubble menu for text formatting on selection. Mirrors
  * `apps/demo-angular/src/app/notion-demo/notion-demo.component.ts`.
  */
-export function NotionDemo(): ReactNode {
+export function NotionDemo({ scrollable = false }: NotionDemoProps): ReactNode {
+  // Capture the page wrapper element via a state-based ref. In scrollable
+  // mode the TOC needs this element to wire `activeScrollParent`; React
+  // can only hand it to us after first paint, so the editor recreates
+  // once when the ref resolves. Non-scrollable mode never reads it.
+  const [pageEl, setPageEl] = useState<HTMLDivElement | null>(null);
+
+  const extensions = useMemo<AnyExtension[]>(
+    () => buildExtensions(scrollable ? pageEl : null),
+    [scrollable, pageEl],
+  );
+
   const { editor, editorRef } = useEditor({
     extensions,
     content: NOTION_DEMO_CONTENT,
@@ -245,7 +264,10 @@ export function NotionDemo(): ReactNode {
   return (
     <>
       <div className="app-notion-demo">
-        <div className="notion-page">
+        <div
+          ref={setPageEl}
+          className={scrollable ? 'notion-page notion-page--scrollable' : 'notion-page'}
+        >
           <div className="dm-editor dm-notion-mode">
             <div ref={editorRef} />
           </div>

--- a/apps/demo-react/src/NotionDemo.tsx
+++ b/apps/demo-react/src/NotionDemo.tsx
@@ -34,6 +34,7 @@ import {
   LineHeight,
   SelectionDecoration,
   ClearFormatting,
+  Dropcursor,
   UniqueID,
   BlockColor,
   Placeholder,
@@ -120,6 +121,10 @@ const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
     },
   }),
   LinkPopover, SelectionDecoration, ClearFormatting,
+  // Native PM dropcursor; BlockHandle hides it during a handle drag so
+  // only the custom `.dm-block-drop-indicator` shows. Kept loaded for
+  // non-handle drops (text selection, external file drops).
+  Dropcursor,
   // Registered after the list extensions so their in-item Tab/Shift-Tab
   // keymaps keep priority inside list items.
   ListIndent,

--- a/apps/demo-react/src/NotionDemo.tsx
+++ b/apps/demo-react/src/NotionDemo.tsx
@@ -240,10 +240,9 @@ export function NotionDemo({ scrollable = false }: NotionDemoProps): ReactNode {
     const pushToast = (message: string, kind: Toast['kind']): void => {
       const id = Date.now() + Math.random();
       setToasts((current) => [...current, { id, message, kind }]);
-      const ms = kind === 'success' ? TOAST_MS.success : TOAST_MS.error;
       setTimeout(() => {
         setToasts((current) => current.filter((t) => t.id !== id));
-      }, ms);
+      }, TOAST_MS[kind]);
     };
 
     host?.addEventListener('dm:copy-link-success', () => {

--- a/apps/demo-react/src/_notion-demo.scss
+++ b/apps/demo-react/src/_notion-demo.scss
@@ -29,6 +29,34 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
+// Scrollable variant: caps height and scrolls content internally instead
+// of growing. Pair with `FloatingTocOutline.activeScrollParent` so the
+// outline's scroll-spy follows the host scroll.
+.notion-page--scrollable {
+  max-height: 700px;
+  overflow-y: auto;
+
+  // Tokenised slim scrollbar; dark theme overrides keep contrast.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
+}
+
 // Toast surfaced by the Notion demo when a block link is copied (or fails
 // to copy). Positioned fixed above the viewport bottom. The success
 // variant is neutral dark; the `--error` modifier uses a warning red.

--- a/apps/demo-vanilla/e2e/notion-demo.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-demo.spec.ts
@@ -4058,9 +4058,10 @@ test.describe('Table of Contents - hover expansion', () => {
   test('hovering the outline transitions through to "expanded" state', async ({ page }) => {
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    // The default hoverInDelay is 120ms; allow up to 600ms before
-    // failing so any CI-induced jitter does not flake the test.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    // The default hoverInDelay is 120ms; allow up to 1500ms before
+    // failing so CI / saturated-CPU jitter does not flake the test
+    // (setTimeout is clamped under load, can drift well past 120ms).
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity is now 1 and rows are pointer-events:auto.
     const card = page.locator('.dm-toc-outline-card');
@@ -4080,7 +4081,7 @@ test.describe('Table of Contents - hover expansion', () => {
     // measurements are real (computed style still reads correctly
     // when collapsed, but text-overflow / wrapping needs visibility).
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const paddings = await rows.evaluateAll(
       (nodes) => nodes.map((n) => parseFloat(window.getComputedStyle(n).paddingInlineStart)),
@@ -4093,7 +4094,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const rows = page.locator('.dm-toc-outline-row');
     const lastIndex = (await rows.count()) - 1;
@@ -4133,7 +4134,7 @@ test.describe('Table of Contents - hover expansion', () => {
       const editor = document.querySelector<HTMLElement>('.ProseMirror');
       editor?.focus();
     });
-    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 1500 });
   });
 
   test('active row mirrors active tick (font-weight + aria-current)', async ({ page }) => {
@@ -4144,7 +4145,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Reveal card so getComputedStyle gives a meaningful weight value.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const matchedRow = page.locator(`.dm-toc-outline-row[data-toc-anchor="${targetId}"]`);
     await expect(matchedRow).toHaveAttribute('aria-current', 'location');
@@ -4182,7 +4183,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Expand via hover (waits up to 600ms past the 120ms in-delay).
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Move the mouse away. Use page.mouse.move() to a safe location
     // far from the outline; locator.hover('body') would re-enter the
@@ -4246,7 +4247,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Open expanded card and click the row pointing at the hidden heading.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
     await page.locator('.dm-toc-outline-row[data-toc-anchor="hidden"]').click();
 
     // The heading is now visible (details forced open by the
@@ -4268,7 +4269,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await outline.hover();
     // State still flips - reduced-motion only zeroes the CSS
     // transition, the JS state machine itself is unaffected.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity should be 1 (not transitioning).
     const card = page.locator('.dm-toc-outline-card');
@@ -5020,7 +5021,7 @@ test.describe('Table of Contents - robustness', () => {
     await outline.dispatchEvent('mouseenter');
 
     // Wait past hoverInDelay (120ms) + a generous grace window.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Now bounce in the OTHER direction. Final gesture is leave,
     // expect "collapsed" after hoverOutDelay (350ms).

--- a/apps/demo-vanilla/e2e/notion-demo.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-demo.spec.ts
@@ -3431,12 +3431,11 @@ test.describe('Table of Contents - floating outline ticks', () => {
     expect(scrollYAfter).toBeGreaterThan(scrollYBefore);
   });
 
-  test('outline hides itself when fewer headings than minHeadings (default 2)', async ({ page }) => {
+  test('outline shows itself with a single heading at the default minHeadings (1)', async ({ page }) => {
     await setContent(page, '<h1>Only one heading</h1><p>body</p>');
     const outline = page.locator('.dm-toc-outline');
-    await expect(outline).toHaveAttribute('data-state', 'hidden');
-    // CSS rule turns data-state="hidden" into display: none.
-    await expect(outline).not.toBeVisible();
+    await expect(outline).toHaveAttribute('data-state', 'collapsed');
+    await expect(outline).toBeVisible();
   });
 
   test('outline hides itself on viewports at or below the mobile breakpoint', async ({ page }) => {

--- a/apps/demo-vanilla/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drop-indicator.spec.ts
@@ -17,7 +17,6 @@ const editorSelector = '.app-notion-demo .ProseMirror';
 const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
 const blockHandleSelector = '.dm-block-handle';
 const dragBtnSelector = '.dm-block-handle-drag';
-const editorWrapperSelector = '.app-notion-demo .dm-editor';
 
 async function goNotion(page: Page): Promise<void> {
   await page.goto('/');

--- a/apps/demo-vanilla/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drop-indicator.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E regression: during a BlockHandle drag, only the custom
+ * `.dm-block-drop-indicator` is visible; the native
+ * `prosemirror-dropcursor-block` / `-inline` element is hidden by the
+ * theme's `.dm-block-handle-dragging` rule.
+ *
+ * Without the hide rule (or with a typo in the selector, which is how
+ * this bug originally shipped), both indicators render and the user
+ * sees a doubled drop line. The unit test in BlockHandle only checks
+ * the class toggle, so this CSS visibility assertion has to live in a
+ * real browser.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page, type JSHandle } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+const blockHandleSelector = '.dm-block-handle';
+const dragBtnSelector = '.dm-block-handle-drag';
+const editorWrapperSelector = '.app-notion-demo .dm-editor';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+/**
+ * Read the relevant indicator state from the page. Captures both
+ * BlockHandle's custom indicator and the native PM dropcursor (both
+ * possible classes) so a single call answers "is the bug visible?".
+ */
+async function readIndicatorState(page: Page): Promise<{
+  hasDraggingClass: boolean;
+  customVisible: boolean;
+  nativeBlockVisible: boolean;
+  nativeInlineVisible: boolean;
+}> {
+  return page.evaluate(() => {
+    const isVisible = (el: HTMLElement | null): boolean => {
+      if (!el) return false;
+      const cs = window.getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      // PM dropcursor sets inline `position: absolute; ...`; treat zero
+      // bounding rect as not visible (e.g. before any dragover fires).
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 || rect.height > 0;
+    };
+    const dmEditor = document.querySelector<HTMLElement>('.dm-editor');
+    return {
+      hasDraggingClass: !!dmEditor?.classList.contains('dm-block-handle-dragging'),
+      customVisible: isVisible(document.querySelector<HTMLElement>('.dm-block-drop-indicator')),
+      nativeBlockVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-block')),
+      nativeInlineVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-inline')),
+    };
+  });
+}
+
+/**
+ * Start a synthetic HTML5 drag from the first block's handle and fire a
+ * single dragover at a position inside the editor. Returns the shared
+ * DataTransfer handle so the caller can run dragend later.
+ */
+async function startDragOverFirstBlock(page: Page): Promise<JSHandle<DataTransfer>> {
+  // Surface the handle by hovering the first block.
+  const firstBlock = page.locator(`${editorSelector} > *`).first();
+  await firstBlock.hover();
+  await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+  const dt = await page.evaluateHandle(() => new DataTransfer());
+  const handle = page.locator(dragBtnSelector);
+
+  // Target the second block to ensure the drop position is meaningful
+  // (PM's dropcursor needs a resolved position to render).
+  const target = page.locator(`${editorSelector} > *`).nth(1);
+  const targetBox = await target.boundingBox();
+  expect(targetBox).not.toBeNull();
+  if (!targetBox) throw new Error('target rect missing');
+  const clientX = targetBox.x + targetBox.width / 2;
+  const clientY = targetBox.y + targetBox.height * 0.8;
+
+  await handle.dispatchEvent('dragstart', { dataTransfer: dt });
+  // dragover wakes both indicators: BlockHandle's `dragover` listener
+  // positions `.dm-block-drop-indicator`, and PM's dropcursor plugin
+  // creates its DOM element (then the CSS rule hides it).
+  await page.locator(editorSelector).dispatchEvent('dragover', {
+    dataTransfer: dt,
+    clientX,
+    clientY,
+  });
+
+  // Two RAFs give layout time to flush so getBoundingClientRect reads
+  // the latest values for both indicator elements.
+  await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+
+  return dt;
+}
+
+async function endDrag(page: Page, dt: JSHandle<DataTransfer>): Promise<void> {
+  await page.locator(dragBtnSelector).dispatchEvent('dragend', { dataTransfer: dt });
+  await dt.dispose();
+  // PM dropcursor schedules its element removal ~20ms after dragend
+  // (`scheduleRemoval(20)`); wait past that so the post-drag assertions
+  // see the cleared state.
+  await page.waitForTimeout(80);
+}
+
+test.describe('BlockHandle drag - single drop indicator only', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('editor gets `dm-block-handle-dragging` class while a handle drag is in flight', async ({ page }) => {
+    const before = await readIndicatorState(page);
+    expect(before.hasDraggingClass).toBe(false);
+
+    const dt = await startDragOverFirstBlock(page);
+
+    const during = await readIndicatorState(page);
+    expect(during.hasDraggingClass).toBe(true);
+
+    await endDrag(page, dt);
+
+    const after = await readIndicatorState(page);
+    expect(after.hasDraggingClass).toBe(false);
+  });
+
+  test('custom `.dm-block-drop-indicator` is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('native PM dropcursor is hidden during a handle drag (no double line)', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    // Whichever of the two PM cursor flavours got mounted MUST be invisible.
+    // The bug this guards against: both visible at the same time.
+    expect(state.nativeBlockVisible).toBe(false);
+    expect(state.nativeInlineVisible).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('only one drop indicator is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    const visibleCount = [state.customVisible, state.nativeBlockVisible, state.nativeInlineVisible]
+      .filter(Boolean).length;
+    expect(visibleCount).toBe(1);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('PM dropcursor element carries a `prosemirror-dropcursor-*` class (not the legacy `ProseMirror-dropcursor`)', async ({ page }) => {
+    // Sanity check that pins down the class name PM actually emits. If
+    // the underlying library renames these, this test fires first and
+    // the hide rule needs the same rename.
+    const dt = await startDragOverFirstBlock(page);
+    const data = await page.evaluate(() => {
+      const block = document.querySelector('.prosemirror-dropcursor-block');
+      const inline = document.querySelector('.prosemirror-dropcursor-inline');
+      const legacy = document.querySelector('.ProseMirror-dropcursor');
+      return {
+        hasBlockOrInline: !!(block || inline),
+        hasLegacy: !!legacy,
+      };
+    });
+    expect(data.hasBlockOrInline).toBe(true);
+    expect(data.hasLegacy).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('custom indicator and dragging class clear after dragend', async ({ page }) => {
+    // PM dropcursor's own cleanup runs on its `dragend` listener attached
+    // to `view.dom`. Our synthetic dragend fires on the handle button (a
+    // sibling of `.ProseMirror`, not a descendant), so PM never sees it
+    // and its element lingers until the 5s scheduled removal. We assert
+    // only what BlockHandle owns: its custom indicator is hidden and the
+    // `.dm-block-handle-dragging` class is cleared.
+    const dt = await startDragOverFirstBlock(page);
+    await endDrag(page, dt);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(false);
+    expect(state.hasDraggingClass).toBe(false);
+  });
+});

--- a/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
@@ -120,6 +120,37 @@ test.describe('Notion scrollable - outline stays centered on container scroll', 
   });
 });
 
+test.describe('Notion scrollable - clicking a tick scrolls the host only', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('clicking a tick moves the host scrollTop, not window.scrollY', async ({ page }) => {
+    // Push the page so window.scrollY > 0; the click must NOT reset it.
+    await page.evaluate(() => { window.scrollTo(0, 200); });
+    await page.waitForTimeout(50);
+
+    const before = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    // DOM click bypasses Playwright actionability so the tick column's
+    // pointer-events gating doesn't get in the way.
+    await page.evaluate(() => {
+      const ticks = document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+      ticks[ticks.length - 1]?.click();
+    });
+    await page.waitForTimeout(600);
+
+    const after = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    expect(after.hostTop).toBeGreaterThan(before.hostTop);
+    expect(Math.abs(after.windowY - before.windowY)).toBeLessThanOrEqual(2);
+  });
+});
+
 test.describe('Notion scrollable - scroll-spy follows host scroll', () => {
   test.beforeEach(async ({ page }) => { await goScrollable(page); });
 

--- a/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
@@ -17,12 +17,11 @@ async function goScrollable(page: Page): Promise<void> {
   await page.waitForSelector(editorSelector);
   // Outline mounts as soon as TableOfContents storage has >= minHeadings.
   await page.waitForSelector('.dm-toc-outline');
-  // Wait for the plugin's first `recomputeContainerCenter()` to set an
-  // inline top - otherwise the initial boundingBox() may snapshot the
-  // pre-positioned state.
+  // Sticky positioning needs `--dm-toc-mid-half-height` resolved before
+  // the layout settles - wait for the plugin to publish it.
   await page.waitForFunction(() => {
     const o = document.querySelector('.dm-toc-outline') as HTMLElement | null;
-    return o !== null && o.style.top !== '';
+    return o !== null && o.style.getPropertyValue('--dm-toc-mid-half-height') !== '';
   });
 }
 
@@ -55,17 +54,19 @@ test.describe('Notion scrollable - container layout', () => {
     expect(dims.scrollWidth).toBeLessThanOrEqual(dims.clientWidth + 1);
   });
 
-  test('outline uses absolute positioning (no sticky 50vh)', async ({ page }) => {
+  test('outline uses sticky positioning (no 50vh page-scroll model)', async ({ page }) => {
     const data = await page.locator('.dm-toc-outline').evaluate((el) => {
       const cs = window.getComputedStyle(el);
       return {
         position: cs.position,
         midTopVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-top'),
+        halfHeightVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-half-height'),
         bottomVisible: (el as HTMLElement).dataset['bottomVisible'] ?? null,
         mode: (el as HTMLElement).dataset['mode'] ?? null,
       };
     });
-    expect(data.position).toBe('absolute');
+    expect(data.position).toBe('sticky');
+    expect(data.halfHeightVar).not.toBe('');
     // Page-scroll model is fully skipped in container mode.
     expect(data.midTopVar).toBe('');
     expect(data.bottomVisible).toBeNull();

--- a/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-scrollable.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * E2E for "Notion scrollable" mode: editor inside a fixed-height
+ * `.notion-page--scrollable` wrapper. Plugin runs `data-scroll-mode='container'`
+ * (skips 50vh sticky + bottom-visible IO + middle/center/frozen modes).
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleScrollable = '.toolbar-mode-toggle button:has-text("Notion scrollable")';
+const containerSelector = '.notion-page--scrollable';
+
+async function goScrollable(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleScrollable);
+  await page.click(modeToggleScrollable);
+  await page.waitForSelector(editorSelector);
+  // Outline mounts as soon as TableOfContents storage has >= minHeadings.
+  await page.waitForSelector('.dm-toc-outline');
+  // Wait for the plugin's first `recomputeContainerCenter()` to set an
+  // inline top - otherwise the initial boundingBox() may snapshot the
+  // pre-positioned state.
+  await page.waitForFunction(() => {
+    const o = document.querySelector('.dm-toc-outline') as HTMLElement | null;
+    return o !== null && o.style.top !== '';
+  });
+}
+
+test.describe('Notion scrollable - container layout', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('page wrapper has max-height + overflow-y: auto', async ({ page }) => {
+    const styles = await page.locator(containerSelector).evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { maxHeight: cs.maxHeight, overflowY: cs.overflowY };
+    });
+    expect(styles.maxHeight).toBe('700px');
+    expect(styles.overflowY).toBe('auto');
+  });
+
+  test('outline carries data-scroll-mode="container"', async ({ page }) => {
+    const outline = page.locator('.dm-toc-outline');
+    await expect(outline).toHaveAttribute('data-scroll-mode', 'container');
+    const shell = page.locator('.dm-toc-outline-shell');
+    await expect(shell).toHaveAttribute('data-scroll-mode', 'container');
+  });
+
+  test('mounting the outline does not introduce a horizontal scrollbar', async ({ page }) => {
+    // Regression: absolute nav without `right` pokes past the host's right
+    // edge and triggers the host's overflow-x scrollbar.
+    const dims = await page.locator(containerSelector).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(dims.scrollWidth).toBeLessThanOrEqual(dims.clientWidth + 1);
+  });
+
+  test('outline uses absolute positioning (no sticky 50vh)', async ({ page }) => {
+    const data = await page.locator('.dm-toc-outline').evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        position: cs.position,
+        midTopVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-top'),
+        bottomVisible: (el as HTMLElement).dataset['bottomVisible'] ?? null,
+        mode: (el as HTMLElement).dataset['mode'] ?? null,
+      };
+    });
+    expect(data.position).toBe('absolute');
+    // Page-scroll model is fully skipped in container mode.
+    expect(data.midTopVar).toBe('');
+    expect(data.bottomVisible).toBeNull();
+    expect(data.mode).toBeNull();
+  });
+});
+
+test.describe('Notion scrollable - outline stays centered on container scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('outline.y stays the same regardless of host scrollTop', async ({ page }) => {
+    const initial = await page.locator('.dm-toc-outline').boundingBox();
+    expect(initial).not.toBeNull();
+
+    // Drive host scroll directly; the outline must not move with content.
+    for (const scrollTop of [50, 200, 500, 800]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const after = await page.locator('.dm-toc-outline').boundingBox();
+      expect(after).not.toBeNull();
+      expect(Math.abs(after!.y - initial!.y)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test('outline sits at the vertical middle of the visible container viewport', async ({ page }) => {
+    const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+    const hostBox = await page.locator(containerSelector).boundingBox();
+    if (!outlineBox || !hostBox) throw new Error('missing rect');
+    const hostMid = hostBox.y + hostBox.height / 2;
+    const outlineMid = outlineBox.y + outlineBox.height / 2;
+    expect(Math.abs(outlineMid - hostMid)).toBeLessThanOrEqual(4);
+  });
+
+  test('outline never escapes the container bounds at any scroll position', async ({ page }) => {
+    for (const scrollTop of [0, 100, 300, 600, 900]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+      const hostBox = await page.locator(containerSelector).boundingBox();
+      if (!outlineBox || !hostBox) continue;
+      expect(outlineBox.y).toBeGreaterThanOrEqual(hostBox.y - 2);
+      expect(outlineBox.y + outlineBox.height)
+        .toBeLessThanOrEqual(hostBox.y + hostBox.height + 2);
+    }
+  });
+});
+
+test.describe('Notion scrollable - scroll-spy follows host scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('scrolling host past first H2 makes that H2 the active tick', async ({ page }) => {
+    const ticks = page.locator('.dm-toc-outline-tick');
+    expect(await ticks.count()).toBeGreaterThanOrEqual(2);
+
+    // scrollIntoView scrolls the nearest overflow:auto ancestor (= host).
+    await page.evaluate(() => {
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2');
+      if (h2) h2.scrollIntoView({ behavior: 'auto', block: 'start' });
+    });
+    await page.waitForTimeout(300);
+
+    const data = await page.evaluate(() => {
+      const active = document.querySelector('.dm-toc-outline-tick.dm-toc--active') as HTMLElement | null;
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2') as HTMLElement | null;
+      return { activeAnchor: active?.dataset['tocAnchor'] ?? null, firstH2Id: h2?.id ?? null };
+    });
+    expect(data.firstH2Id).toBeTruthy();
+    expect(data.activeAnchor).toBe(data.firstH2Id);
+  });
+});

--- a/apps/demo-vanilla/e2e/notion-toc-dynamic.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-toc-dynamic.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * E2E: FloatingTocOutline picks up dynamically inserted headings AND the
+ * outline becomes visible as soon as the first heading exists.
+ *
+ * Default `minHeadings: 1` (matches Notion). The "delete-all then add 1
+ * H1" regression specifically guards against the prior 2-heading
+ * threshold that left the outline `display: none` after typing a single
+ * heading into an empty doc.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline');
+  await page.waitForTimeout(200);
+}
+
+async function placeCursorAtEnd(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(pm);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+async function selectAllAndDelete(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.querySelector<HTMLElement>('.ProseMirror')?.focus();
+  });
+  await page.keyboard.press('Control+A');
+  await page.keyboard.press('Meta+A');
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(150);
+}
+
+async function readOutlineState(page: Page): Promise<{
+  tickCount: number;
+  state: string | null;
+  display: string | null;
+  anchors: string[];
+}> {
+  return await page.evaluate(() => {
+    const outline = document.querySelector<HTMLElement>('.dm-toc-outline');
+    const ticks = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick'));
+    return {
+      tickCount: ticks.length,
+      state: outline?.dataset['state'] ?? null,
+      display: outline ? getComputedStyle(outline).display : null,
+      anchors: ticks.map((t) => t.dataset['tocAnchor'] ?? ''),
+    };
+  });
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - TOC tracks new headings`, () => {
+    test('appending H1 via # shortcut adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('# Appended H1');
+      await page.waitForTimeout(300);
+
+      const after = await readOutlineState(page);
+      expect(after.tickCount).toBe(before.tickCount + 1);
+      expect(after.anchors[after.anchors.length - 1]).toBeTruthy();
+    });
+
+    test('appending H1 via slash command adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/');
+      await page.waitForSelector('.dm-slash-command-menu');
+      await page.keyboard.type('Heading 1');
+      await page.waitForTimeout(150);
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Slash H1');
+      await page.waitForTimeout(300);
+
+      expect((await readOutlineState(page)).tickCount).toBe(before.tickCount + 1);
+    });
+
+    test('clearing the doc then typing one H1 shows the outline (minHeadings:1)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.keyboard.type('# Lone H1');
+      await page.waitForTimeout(400);
+
+      const observed = await readOutlineState(page);
+      expect(observed.tickCount).toBe(1);
+      expect(observed.state).toBe('collapsed');
+      expect(observed.display).not.toBe('none');
+    });
+
+    test('empty doc keeps the outline hidden until a heading exists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.waitForTimeout(200);
+
+      const empty = await readOutlineState(page);
+      expect(empty.tickCount).toBe(0);
+      expect(empty.state).toBe('hidden');
+      expect(empty.display).toBe('none');
+
+      await page.keyboard.type('# First');
+      await page.waitForTimeout(400);
+
+      const withOne = await readOutlineState(page);
+      expect(withOne.tickCount).toBe(1);
+      expect(withOne.state).toBe('collapsed');
+      expect(withOne.display).not.toBe('none');
+    });
+  });
+}

--- a/apps/demo-vanilla/e2e/notion-toc-overflow.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-toc-overflow.spec.ts
@@ -1,0 +1,397 @@
+/**
+ * E2E: tick column caps at 50% of the container and clips extras
+ * (Notion behavior - no compression, no scroll on the column). The
+ * hover card opens at the top and is fully scrollable.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = `.toolbar-mode-toggle button:has-text("${label}")`;
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline-ticks');
+  await page.waitForTimeout(200);
+}
+
+async function pasteManyH2s(page: Page, count: number): Promise<void> {
+  const html = Array.from({ length: count }, (_, i) => `<h2>S${String(i)}</h2>`).join('');
+  await page.evaluate((h) => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const data = new DataTransfer();
+    data.setData('text/html', h);
+    pm.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true }));
+  }, html);
+  await page.waitForTimeout(700);
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - tick column caps at 50% + card scrolls`, () => {
+    test('DOM structure: ticks live in `.dm-toc-outline-ticks`, sibling of `.dm-toc-outline-card`', async ({ page }) => {
+      await gotoMode(page, mode);
+      const data = await page.evaluate(() => {
+        const nav = document.querySelector<HTMLElement>('.dm-toc-outline');
+        const wrapper = nav?.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = nav?.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return {
+          wrapperExists: !!wrapper,
+          cardExists: !!card,
+          wrapperHasTicks: (wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0) > 0,
+          cardIsSiblingOfWrapper: card?.parentElement === nav && wrapper?.parentElement === nav,
+        };
+      });
+      expect(data.wrapperExists).toBe(true);
+      expect(data.cardExists).toBe(true);
+      expect(data.wrapperHasTicks).toBe(true);
+      expect(data.cardIsSiblingOfWrapper).toBe(true);
+    });
+
+    test('inter-tick gap stays at the CSS default with many headings (no compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const gap = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w ? parseFloat(getComputedStyle(w).gap) : -1;
+      });
+      // Default is 10px - must stay constant regardless of heading count.
+      expect(gap).toBeCloseTo(10, 0);
+    });
+
+    test('ticks wrapper caps at ~50% and clips overflow (hidden, not scroll)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const data = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return null;
+        const cs = getComputedStyle(w);
+        const maxH = parseFloat(cs.maxHeight);
+        return {
+          overflow: cs.overflow,
+          overflowX: cs.overflowX,
+          overflowY: cs.overflowY,
+          maxHeight: maxH,
+          scrollHeight: w.scrollHeight,
+          clientHeight: w.clientHeight,
+          tickCount: w.querySelectorAll('.dm-toc-outline-tick').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      // Overflow MUST be hidden, never auto/scroll - the column doesn't scroll.
+      expect(data!.overflowY).not.toBe('auto');
+      expect(data!.overflowY).not.toBe('scroll');
+      expect(['hidden', 'clip']).toContain(data!.overflowY);
+      // Natural content far exceeds the visible wrapper.
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight + 100);
+      // ~50% of the container; page-mode 50vh ≈ 360, container ≈ 382.
+      expect(data!.maxHeight).toBeGreaterThan(300);
+      expect(data!.maxHeight).toBeLessThan(450);
+    });
+
+    test('hover opens the card with scrollTop = 0 (starts at the first row)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+
+      // Pre-scroll the (collapsed) card so we can prove the reset on open.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 200;
+      });
+
+      // Hover the nav to trigger the in-delay (120ms default) + expand.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          opacity: parseFloat(getComputedStyle(card).opacity),
+          scrollTop: card.scrollTop,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.opacity).toBeGreaterThan(0.5);
+      // Plugin reset scrollTop to 0 on the collapsed→expanded transition.
+      expect(data!.scrollTop).toBe(0);
+    });
+
+    test('card itself is scrollable for long heading lists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          overflowY: getComputedStyle(card).overflowY,
+          scrollHeight: card.scrollHeight,
+          clientHeight: card.clientHeight,
+          rowCount: card.querySelectorAll('.dm-toc-outline-row').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.overflowY).toBe('auto');
+      expect(data!.rowCount).toBeGreaterThan(100);
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight);
+    });
+
+    test('card rows keep a uniform height regardless of count (no flex compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const heights = await page.evaluate(() => {
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-row'));
+        return rows.slice(0, 20).map((r) => r.getBoundingClientRect().height);
+      });
+      expect(heights.length).toBeGreaterThanOrEqual(10);
+      // All rows match the first - no flex-shrink compression.
+      const first = heights[0];
+      expect(first).toBeGreaterThan(10);
+      for (const h of heights) {
+        expect(Math.abs(h - first)).toBeLessThan(0.5);
+      }
+    });
+
+    test('card max-height matches the ticks wrapper (= 50% of the container)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!wrapper || !card) return null;
+        return {
+          wrapperMaxH: parseFloat(getComputedStyle(wrapper).maxHeight),
+          cardMaxH: parseFloat(getComputedStyle(card).maxHeight),
+        };
+      });
+      expect(data).not.toBeNull();
+      // Card uses the same CSS var so the values match exactly.
+      expect(data!.cardMaxH).toBeCloseTo(data!.wrapperMaxH, 1);
+    });
+
+    test('removing headings shifts the visible window (no orphan ticks)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const beforeCount = await page.evaluate(
+        () => document.querySelectorAll('.dm-toc-outline-tick').length,
+      );
+
+      // Clear the doc; the outline should re-render with just the seeded heading(s).
+      await page.evaluate(() => {
+        const pm = document.querySelector<HTMLElement>('.ProseMirror');
+        pm?.focus();
+      });
+      await page.keyboard.press('Control+A');
+      await page.keyboard.press('Meta+A');
+      await page.keyboard.press('Delete');
+      await page.waitForTimeout(300);
+      await page.keyboard.type('# Only one');
+      await page.waitForTimeout(300);
+
+      const after = await page.evaluate(() => ({
+        count: document.querySelectorAll('.dm-toc-outline-tick').length,
+        wrapperChildrenCount:
+          document.querySelector('.dm-toc-outline-ticks')?.children.length ?? 0,
+      }));
+      expect(beforeCount).toBeGreaterThan(100);
+      expect(after.count).toBe(1);
+      expect(after.wrapperChildrenCount).toBe(1);
+    });
+
+    test('every heading produces a tick in the DOM (clipped, not truncated)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const headings = document.querySelectorAll('.ProseMirror h1, .ProseMirror h2, .ProseMirror h3');
+        return {
+          tickCount: wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0,
+          headingCount: headings.length,
+        };
+      });
+      // Plugin renders ALL; CSS clip hides the ones past the 50% mark.
+      expect(data.tickCount).toBe(data.headingCount);
+      expect(data.tickCount).toBeGreaterThan(80);
+    });
+
+    test('a clipped tick exists in DOM with valid anchor (just not visible)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 100);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = Array.from(wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick') ?? []);
+        const wrapperRect = wrapper?.getBoundingClientRect();
+        // Find a tick that sits below the wrapper's visible bottom edge.
+        const clipped = ticks.find((t) => {
+          const r = t.getBoundingClientRect();
+          return wrapperRect && r.top > wrapperRect.bottom;
+        });
+        return {
+          clippedExists: !!clipped,
+          clippedAnchor: clipped?.dataset['tocAnchor'] ?? '',
+          totalTicks: ticks.length,
+        };
+      });
+      expect(data.totalTicks).toBeGreaterThan(80);
+      expect(data.clippedExists).toBe(true);
+      // UniqueID stamped it - the anchor is non-empty even for clipped ticks.
+      expect(data.clippedAnchor).toBeTruthy();
+    });
+
+    test('tick column does not scroll on wheel - scrollTop stays 0', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      // Synthesize a wheel event on the wrapper - overflow:hidden ignores it.
+      await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return;
+        w.dispatchEvent(new WheelEvent('wheel', { deltaY: 500, bubbles: true }));
+      });
+      await page.waitForTimeout(100);
+      const scrollTop = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w?.scrollTop ?? -1;
+      });
+      expect(scrollTop).toBe(0);
+    });
+
+    test('clicking a visible tick scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 60);
+      const before = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // Click a tick deep enough that the scroll has to move appreciably.
+      const anchor = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+        const target = ticks?.[ticks.length - 5];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const after = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // EITHER the window OR the container scrolled - depends on mode.
+      const movedWindow = after.winY - before.winY;
+      const movedHost = after.hostTop - before.hostTop;
+      expect(Math.max(movedWindow, movedHost)).toBeGreaterThan(50);
+    });
+
+    test('clicking a row in the expanded card scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Click the 5th row deep in the card (likely below the fold for tick column).
+      const anchor = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        const rows = card?.querySelectorAll<HTMLElement>('.dm-toc-outline-row');
+        const target = rows?.[4];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const found = await page.evaluate((id) => {
+        const h = document.querySelector<HTMLElement>(`[id="${id}"]`);
+        return !!h;
+      }, anchor);
+      expect(found).toBe(true);
+    });
+
+    test('card stays expanded while the mouse is over the card itself', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 40);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Move pointer into the card center; avoids the brief gap-leave
+      // that Playwright's `.hover()` can hit between elements.
+      const cardBox = await page.locator('.dm-toc-outline-card').boundingBox();
+      if (cardBox) {
+        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2, { steps: 8 });
+      }
+      await page.waitForTimeout(150);
+      const state = await page.evaluate(
+        () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+      );
+      expect(state).toBe('expanded');
+    });
+
+    test('card collapses after the hover-out delay when leaving the outline', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 20);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('expanded');
+      // Move the pointer somewhere harmless.
+      await page.mouse.move(10, 10);
+      // Default hover-out delay is 350ms; allow a buffer.
+      await page.waitForTimeout(500);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('collapsed');
+    });
+
+    test('reopening the card resets scrollTop to 0 even after the user scrolled it', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // User scrolls the card mid-list.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 600;
+      });
+      // Collapse.
+      await page.mouse.move(10, 10);
+      await page.waitForTimeout(500);
+      // Reopen.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const top = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return card?.scrollTop ?? -1;
+      });
+      expect(top).toBe(0);
+    });
+
+    if (mode === 'Notion style') {
+      // Page-scroll only: `50vh` tracks viewport. Container mode's host
+      // is pinned at `max-height: 700px`, so resize is a no-op there.
+      test('viewport resize updates the ticks wrapper max-height (page-scroll)', async ({ page }) => {
+        await gotoMode(page, mode);
+        await pasteManyH2s(page, 100);
+        const before = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        await page.setViewportSize({ width: 1280, height: 1000 });
+        await page.waitForTimeout(200);
+        const after = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        expect(after).toBeGreaterThan(before + 50);
+      });
+    }
+  });
+}

--- a/apps/demo-vanilla/src/App.ts
+++ b/apps/demo-vanilla/src/App.ts
@@ -1,7 +1,7 @@
 import { EditorDemo } from './EditorDemo.js';
 import { NotionDemo } from './NotionDemo.js';
 
-type Mode = 'default' | 'custom' | 'notion';
+type Mode = 'default' | 'custom' | 'notion' | 'notion-scrollable';
 
 /**
  * Top-level demo router. Manages mode state (default / custom / notion),
@@ -53,6 +53,7 @@ export class App {
       { id: 'default', label: 'Default toolbar' },
       { id: 'custom', label: 'Custom layout' },
       { id: 'notion', label: 'Notion style' },
+      { id: 'notion-scrollable', label: 'Notion scrollable' },
     ];
 
     for (const m of modes) {
@@ -77,8 +78,8 @@ export class App {
 
   #setMode(mode: Mode): void {
     if (mode === this.#mode) return;
-    const wasNotion = this.#mode === 'notion';
-    const goingNotion = mode === 'notion';
+    const wasNotion = this.#mode === 'notion' || this.#mode === 'notion-scrollable';
+    const goingNotion = mode === 'notion' || mode === 'notion-scrollable';
     this.#mode = mode;
 
     // Preserve editor state on default ↔ custom toggle: only swap the
@@ -100,8 +101,10 @@ export class App {
   #mountCurrentMode(): void {
     this.#demoMount.replaceChildren();
 
-    if (this.#mode === 'notion') {
-      this.#notionDemo = new NotionDemo(this.#demoMount);
+    if (this.#mode === 'notion' || this.#mode === 'notion-scrollable') {
+      this.#notionDemo = new NotionDemo(this.#demoMount, {
+        scrollable: this.#mode === 'notion-scrollable',
+      });
       return;
     }
 

--- a/apps/demo-vanilla/src/NotionDemo.ts
+++ b/apps/demo-vanilla/src/NotionDemo.ts
@@ -88,7 +88,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
  */
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
-const buildExtensions = (): AnyExtension[] => [
+const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,
@@ -144,7 +144,7 @@ const buildExtensions = (): AnyExtension[] => [
   SlashCommand,
   SmartPaste,
   TableOfContents,
-  FloatingTocOutline,
+  FloatingTocOutline.configure({ activeScrollParent: scrollParent }),
   TableOfContentsBlock,
   Placeholder.configure({
     placeholder: ({ node }: { node: { type: { name: string } } }) =>
@@ -165,6 +165,12 @@ const buildExtensions = (): AnyExtension[] => [
  *
  * E2E exposure: `window.__DEMO_EDITOR__` + `window.__DOMTERNAL_LIST_CTX__`.
  */
+export interface NotionDemoOptions {
+  /** Cap the page wrapper height and scroll its content internally. Adds
+   * `notion-page--scrollable` and wires `activeScrollParent`. */
+  scrollable?: boolean;
+}
+
 export class NotionDemo {
   #container: HTMLElement;
   #editorWrapper: DomternalEditor;
@@ -182,14 +188,15 @@ export class NotionDemo {
   #updateOff: () => void;
   #destroyed = false;
 
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, options: NotionDemoOptions = {}) {
     this.#container = container;
+    const scrollable = options.scrollable === true;
 
     // DOM chain: .app-notion-demo > .notion-page > .dm-editor.dm-notion-mode > [editorHost]
     const notionDemo = document.createElement('div');
     notionDemo.className = 'app-notion-demo';
     const notionPage = document.createElement('div');
-    notionPage.className = 'notion-page';
+    notionPage.className = scrollable ? 'notion-page notion-page--scrollable' : 'notion-page';
     const editorShell = document.createElement('div');
     editorShell.className = 'dm-editor dm-notion-mode';
     const editorHost = document.createElement('div');
@@ -206,7 +213,8 @@ export class NotionDemo {
     container.appendChild(notionDemo);
 
     this.#editorWrapper = new DomternalEditor(editorHost, {
-      extensions: buildExtensions(),
+      // Scrollable mode tracks the host; full-height mode tracks window.
+      extensions: buildExtensions(scrollable ? notionPage : null),
       content: NOTION_DEMO_CONTENT,
     });
     const editor = this.#editorWrapper.editor;

--- a/apps/demo-vanilla/src/NotionDemo.ts
+++ b/apps/demo-vanilla/src/NotionDemo.ts
@@ -31,6 +31,7 @@ import {
   LineHeight,
   SelectionDecoration,
   ClearFormatting,
+  Dropcursor,
   UniqueID,
   BlockColor,
   Placeholder,
@@ -115,6 +116,10 @@ const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
     },
   }),
   LinkPopover, SelectionDecoration, ClearFormatting,
+  // Native PM dropcursor; BlockHandle hides it during a handle drag so
+  // only the custom `.dm-block-drop-indicator` shows. Kept loaded for
+  // non-handle drops (text selection, external file drops).
+  Dropcursor,
   // Registered after the list extensions so their in-item Tab/Shift-Tab
   // keymaps keep priority inside list items.
   ListIndent,

--- a/apps/demo-vanilla/src/_notion-demo.scss
+++ b/apps/demo-vanilla/src/_notion-demo.scss
@@ -29,6 +29,14 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
+// Scrollable variant: caps height and scrolls content internally instead
+// of growing. Pair with `FloatingTocOutline.activeScrollParent` so the
+// outline's scroll-spy follows the host scroll.
+.notion-page--scrollable {
+  max-height: 700px;
+  overflow-y: auto;
+}
+
 // Toast surfaced by the Notion demo when a block link is copied (or fails
 // to copy). Positioned fixed above the viewport bottom. The success
 // variant is neutral dark; the `--error` modifier uses a warning red.

--- a/apps/demo-vanilla/src/_notion-demo.scss
+++ b/apps/demo-vanilla/src/_notion-demo.scss
@@ -35,6 +35,26 @@
 .notion-page--scrollable {
   max-height: 700px;
   overflow-y: auto;
+
+  // Tokenised slim scrollbar; dark theme overrides keep contrast.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
 }
 
 // Toast surfaced by the Notion demo when a block link is copied (or fails

--- a/apps/demo-vue/e2e/notion-demo.spec.ts
+++ b/apps/demo-vue/e2e/notion-demo.spec.ts
@@ -4063,9 +4063,10 @@ test.describe('Table of Contents - hover expansion', () => {
   test('hovering the outline transitions through to "expanded" state', async ({ page }) => {
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    // The default hoverInDelay is 120ms; allow up to 600ms before
-    // failing so any CI-induced jitter does not flake the test.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    // The default hoverInDelay is 120ms; allow up to 1500ms before
+    // failing so CI / saturated-CPU jitter does not flake the test
+    // (setTimeout is clamped under load, can drift well past 120ms).
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity is now 1 and rows are pointer-events:auto.
     const card = page.locator('.dm-toc-outline-card');
@@ -4085,7 +4086,7 @@ test.describe('Table of Contents - hover expansion', () => {
     // measurements are real (computed style still reads correctly
     // when collapsed, but text-overflow / wrapping needs visibility).
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const paddings = await rows.evaluateAll(
       (nodes) => nodes.map((n) => parseFloat(window.getComputedStyle(n).paddingInlineStart)),
@@ -4098,7 +4099,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     const outline = page.locator('.dm-toc-outline');
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const rows = page.locator('.dm-toc-outline-row');
     const lastIndex = (await rows.count()) - 1;
@@ -4138,7 +4139,7 @@ test.describe('Table of Contents - hover expansion', () => {
       const editor = document.querySelector<HTMLElement>('.ProseMirror');
       editor?.focus();
     });
-    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'collapsed', { timeout: 1500 });
   });
 
   test('active row mirrors active tick (font-weight + aria-current)', async ({ page }) => {
@@ -4149,7 +4150,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Reveal card so getComputedStyle gives a meaningful weight value.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     const matchedRow = page.locator(`.dm-toc-outline-row[data-toc-anchor="${targetId}"]`);
     await expect(matchedRow).toHaveAttribute('aria-current', 'location');
@@ -4187,7 +4188,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Expand via hover (waits up to 600ms past the 120ms in-delay).
     await outline.hover();
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Move the mouse away. Use page.mouse.move() to a safe location
     // far from the outline; locator.hover('body') would re-enter the
@@ -4251,7 +4252,7 @@ test.describe('Table of Contents - hover expansion', () => {
 
     // Open expanded card and click the row pointing at the hidden heading.
     await page.locator('.dm-toc-outline').hover();
-    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(page.locator('.dm-toc-outline')).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
     await page.locator('.dm-toc-outline-row[data-toc-anchor="hidden"]').click();
 
     // The heading is now visible (details forced open by the
@@ -4273,7 +4274,7 @@ test.describe('Table of Contents - hover expansion', () => {
     await outline.hover();
     // State still flips - reduced-motion only zeroes the CSS
     // transition, the JS state machine itself is unaffected.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Card opacity should be 1 (not transitioning).
     const card = page.locator('.dm-toc-outline-card');
@@ -5025,7 +5026,7 @@ test.describe('Table of Contents - robustness', () => {
     await outline.dispatchEvent('mouseenter');
 
     // Wait past hoverInDelay (120ms) + a generous grace window.
-    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 600 });
+    await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 1500 });
 
     // Now bounce in the OTHER direction. Final gesture is leave,
     // expect "collapsed" after hoverOutDelay (350ms).

--- a/apps/demo-vue/e2e/notion-demo.spec.ts
+++ b/apps/demo-vue/e2e/notion-demo.spec.ts
@@ -3436,12 +3436,11 @@ test.describe('Table of Contents - floating outline ticks', () => {
     expect(scrollYAfter).toBeGreaterThan(scrollYBefore);
   });
 
-  test('outline hides itself when fewer headings than minHeadings (default 2)', async ({ page }) => {
+  test('outline shows itself with a single heading at the default minHeadings (1)', async ({ page }) => {
     await setContent(page, '<h1>Only one heading</h1><p>body</p>');
     const outline = page.locator('.dm-toc-outline');
-    await expect(outline).toHaveAttribute('data-state', 'hidden');
-    // CSS rule turns data-state="hidden" into display: none.
-    await expect(outline).not.toBeVisible();
+    await expect(outline).toHaveAttribute('data-state', 'collapsed');
+    await expect(outline).toBeVisible();
   });
 
   test('outline hides itself on viewports at or below the mobile breakpoint', async ({ page }) => {

--- a/apps/demo-vue/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-vue/e2e/notion-drop-indicator.spec.ts
@@ -17,7 +17,6 @@ const editorSelector = '.app-notion-demo .ProseMirror';
 const modeToggleNotion = '[data-testid="mode-notion"]';
 const blockHandleSelector = '.dm-block-handle';
 const dragBtnSelector = '.dm-block-handle-drag';
-const editorWrapperSelector = '.app-notion-demo .dm-editor';
 
 async function goNotion(page: Page): Promise<void> {
   await page.goto('/');

--- a/apps/demo-vue/e2e/notion-drop-indicator.spec.ts
+++ b/apps/demo-vue/e2e/notion-drop-indicator.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E regression: during a BlockHandle drag, only the custom
+ * `.dm-block-drop-indicator` is visible; the native
+ * `prosemirror-dropcursor-block` / `-inline` element is hidden by the
+ * theme's `.dm-block-handle-dragging` rule.
+ *
+ * Without the hide rule (or with a typo in the selector, which is how
+ * this bug originally shipped), both indicators render and the user
+ * sees a doubled drop line. The unit test in BlockHandle only checks
+ * the class toggle, so this CSS visibility assertion has to live in a
+ * real browser.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page, type JSHandle } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '[data-testid="mode-notion"]';
+const blockHandleSelector = '.dm-block-handle';
+const dragBtnSelector = '.dm-block-handle-drag';
+const editorWrapperSelector = '.app-notion-demo .dm-editor';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+/**
+ * Read the relevant indicator state from the page. Captures both
+ * BlockHandle's custom indicator and the native PM dropcursor (both
+ * possible classes) so a single call answers "is the bug visible?".
+ */
+async function readIndicatorState(page: Page): Promise<{
+  hasDraggingClass: boolean;
+  customVisible: boolean;
+  nativeBlockVisible: boolean;
+  nativeInlineVisible: boolean;
+}> {
+  return page.evaluate(() => {
+    const isVisible = (el: HTMLElement | null): boolean => {
+      if (!el) return false;
+      const cs = window.getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      // PM dropcursor sets inline `position: absolute; ...`; treat zero
+      // bounding rect as not visible (e.g. before any dragover fires).
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 || rect.height > 0;
+    };
+    const dmEditor = document.querySelector<HTMLElement>('.dm-editor');
+    return {
+      hasDraggingClass: !!dmEditor?.classList.contains('dm-block-handle-dragging'),
+      customVisible: isVisible(document.querySelector<HTMLElement>('.dm-block-drop-indicator')),
+      nativeBlockVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-block')),
+      nativeInlineVisible: isVisible(document.querySelector<HTMLElement>('.prosemirror-dropcursor-inline')),
+    };
+  });
+}
+
+/**
+ * Start a synthetic HTML5 drag from the first block's handle and fire a
+ * single dragover at a position inside the editor. Returns the shared
+ * DataTransfer handle so the caller can run dragend later.
+ */
+async function startDragOverFirstBlock(page: Page): Promise<JSHandle<DataTransfer>> {
+  // Surface the handle by hovering the first block.
+  const firstBlock = page.locator(`${editorSelector} > *`).first();
+  await firstBlock.hover();
+  await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+  const dt = await page.evaluateHandle(() => new DataTransfer());
+  const handle = page.locator(dragBtnSelector);
+
+  // Target the second block to ensure the drop position is meaningful
+  // (PM's dropcursor needs a resolved position to render).
+  const target = page.locator(`${editorSelector} > *`).nth(1);
+  const targetBox = await target.boundingBox();
+  expect(targetBox).not.toBeNull();
+  if (!targetBox) throw new Error('target rect missing');
+  const clientX = targetBox.x + targetBox.width / 2;
+  const clientY = targetBox.y + targetBox.height * 0.8;
+
+  await handle.dispatchEvent('dragstart', { dataTransfer: dt });
+  // dragover wakes both indicators: BlockHandle's `dragover` listener
+  // positions `.dm-block-drop-indicator`, and PM's dropcursor plugin
+  // creates its DOM element (then the CSS rule hides it).
+  await page.locator(editorSelector).dispatchEvent('dragover', {
+    dataTransfer: dt,
+    clientX,
+    clientY,
+  });
+
+  // Two RAFs give layout time to flush so getBoundingClientRect reads
+  // the latest values for both indicator elements.
+  await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+
+  return dt;
+}
+
+async function endDrag(page: Page, dt: JSHandle<DataTransfer>): Promise<void> {
+  await page.locator(dragBtnSelector).dispatchEvent('dragend', { dataTransfer: dt });
+  await dt.dispose();
+  // PM dropcursor schedules its element removal ~20ms after dragend
+  // (`scheduleRemoval(20)`); wait past that so the post-drag assertions
+  // see the cleared state.
+  await page.waitForTimeout(80);
+}
+
+test.describe('BlockHandle drag - single drop indicator only', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('editor gets `dm-block-handle-dragging` class while a handle drag is in flight', async ({ page }) => {
+    const before = await readIndicatorState(page);
+    expect(before.hasDraggingClass).toBe(false);
+
+    const dt = await startDragOverFirstBlock(page);
+
+    const during = await readIndicatorState(page);
+    expect(during.hasDraggingClass).toBe(true);
+
+    await endDrag(page, dt);
+
+    const after = await readIndicatorState(page);
+    expect(after.hasDraggingClass).toBe(false);
+  });
+
+  test('custom `.dm-block-drop-indicator` is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('native PM dropcursor is hidden during a handle drag (no double line)', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    // Whichever of the two PM cursor flavours got mounted MUST be invisible.
+    // The bug this guards against: both visible at the same time.
+    expect(state.nativeBlockVisible).toBe(false);
+    expect(state.nativeInlineVisible).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('only one drop indicator is visible during a handle drag', async ({ page }) => {
+    const dt = await startDragOverFirstBlock(page);
+    const state = await readIndicatorState(page);
+    const visibleCount = [state.customVisible, state.nativeBlockVisible, state.nativeInlineVisible]
+      .filter(Boolean).length;
+    expect(visibleCount).toBe(1);
+    expect(state.customVisible).toBe(true);
+    await endDrag(page, dt);
+  });
+
+  test('PM dropcursor element carries a `prosemirror-dropcursor-*` class (not the legacy `ProseMirror-dropcursor`)', async ({ page }) => {
+    // Sanity check that pins down the class name PM actually emits. If
+    // the underlying library renames these, this test fires first and
+    // the hide rule needs the same rename.
+    const dt = await startDragOverFirstBlock(page);
+    const data = await page.evaluate(() => {
+      const block = document.querySelector('.prosemirror-dropcursor-block');
+      const inline = document.querySelector('.prosemirror-dropcursor-inline');
+      const legacy = document.querySelector('.ProseMirror-dropcursor');
+      return {
+        hasBlockOrInline: !!(block || inline),
+        hasLegacy: !!legacy,
+      };
+    });
+    expect(data.hasBlockOrInline).toBe(true);
+    expect(data.hasLegacy).toBe(false);
+    await endDrag(page, dt);
+  });
+
+  test('custom indicator and dragging class clear after dragend', async ({ page }) => {
+    // PM dropcursor's own cleanup runs on its `dragend` listener attached
+    // to `view.dom`. Our synthetic dragend fires on the handle button (a
+    // sibling of `.ProseMirror`, not a descendant), so PM never sees it
+    // and its element lingers until the 5s scheduled removal. We assert
+    // only what BlockHandle owns: its custom indicator is hidden and the
+    // `.dm-block-handle-dragging` class is cleared.
+    const dt = await startDragOverFirstBlock(page);
+    await endDrag(page, dt);
+    const state = await readIndicatorState(page);
+    expect(state.customVisible).toBe(false);
+    expect(state.hasDraggingClass).toBe(false);
+  });
+});

--- a/apps/demo-vue/e2e/notion-scrollable.spec.ts
+++ b/apps/demo-vue/e2e/notion-scrollable.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E for "Notion scrollable" mode: editor inside a fixed-height
+ * `.notion-page--scrollable` wrapper. Plugin runs `data-scroll-mode='container'`
+ * (skips 50vh sticky + bottom-visible IO + middle/center/frozen modes).
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleScrollable = '[data-testid="mode-notion-scrollable"]';
+const containerSelector = '.notion-page--scrollable';
+
+async function goScrollable(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleScrollable);
+  await page.click(modeToggleScrollable);
+  await page.waitForSelector(editorSelector);
+  // Outline mounts as soon as TableOfContents storage has >= minHeadings.
+  await page.waitForSelector('.dm-toc-outline');
+  // Sticky positioning needs `--dm-toc-mid-half-height` resolved before
+  // the layout settles - wait for the plugin to publish it.
+  await page.waitForFunction(() => {
+    const o = document.querySelector('.dm-toc-outline') as HTMLElement | null;
+    return o !== null && o.style.getPropertyValue('--dm-toc-mid-half-height') !== '';
+  });
+}
+
+test.describe('Notion scrollable - container layout', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('page wrapper has max-height + overflow-y: auto', async ({ page }) => {
+    const styles = await page.locator(containerSelector).evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return { maxHeight: cs.maxHeight, overflowY: cs.overflowY };
+    });
+    expect(styles.maxHeight).toBe('700px');
+    expect(styles.overflowY).toBe('auto');
+  });
+
+  test('outline carries data-scroll-mode="container"', async ({ page }) => {
+    const outline = page.locator('.dm-toc-outline');
+    await expect(outline).toHaveAttribute('data-scroll-mode', 'container');
+    const shell = page.locator('.dm-toc-outline-shell');
+    await expect(shell).toHaveAttribute('data-scroll-mode', 'container');
+  });
+
+  test('mounting the outline does not introduce a horizontal scrollbar', async ({ page }) => {
+    // Regression: absolute nav without `right` pokes past the host's right
+    // edge and triggers the host's overflow-x scrollbar.
+    const dims = await page.locator(containerSelector).evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(dims.scrollWidth).toBeLessThanOrEqual(dims.clientWidth + 1);
+  });
+
+  test('outline uses sticky positioning (no 50vh page-scroll model)', async ({ page }) => {
+    const data = await page.locator('.dm-toc-outline').evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return {
+        position: cs.position,
+        midTopVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-top'),
+        halfHeightVar: (el as HTMLElement).style.getPropertyValue('--dm-toc-mid-half-height'),
+        bottomVisible: (el as HTMLElement).dataset['bottomVisible'] ?? null,
+        mode: (el as HTMLElement).dataset['mode'] ?? null,
+      };
+    });
+    expect(data.position).toBe('sticky');
+    expect(data.halfHeightVar).not.toBe('');
+    // Page-scroll model is fully skipped in container mode.
+    expect(data.midTopVar).toBe('');
+    expect(data.bottomVisible).toBeNull();
+    expect(data.mode).toBeNull();
+  });
+});
+
+test.describe('Notion scrollable - outline stays centered on container scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('outline.y stays the same regardless of host scrollTop', async ({ page }) => {
+    const initial = await page.locator('.dm-toc-outline').boundingBox();
+    expect(initial).not.toBeNull();
+
+    // Drive host scroll directly; the outline must not move with content.
+    for (const scrollTop of [50, 200, 500, 800]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const after = await page.locator('.dm-toc-outline').boundingBox();
+      expect(after).not.toBeNull();
+      expect(Math.abs(after!.y - initial!.y)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test('outline sits at the vertical middle of the visible container viewport', async ({ page }) => {
+    const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+    const hostBox = await page.locator(containerSelector).boundingBox();
+    if (!outlineBox || !hostBox) throw new Error('missing rect');
+    const hostMid = hostBox.y + hostBox.height / 2;
+    const outlineMid = outlineBox.y + outlineBox.height / 2;
+    expect(Math.abs(outlineMid - hostMid)).toBeLessThanOrEqual(4);
+  });
+
+  test('outline never escapes the container bounds at any scroll position', async ({ page }) => {
+    for (const scrollTop of [0, 100, 300, 600, 900]) {
+      await page.evaluate(({ sel, y }) => {
+        const host = document.querySelector(sel) as HTMLElement | null;
+        if (host) host.scrollTop = y;
+      }, { sel: containerSelector, y: scrollTop });
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+      const outlineBox = await page.locator('.dm-toc-outline').boundingBox();
+      const hostBox = await page.locator(containerSelector).boundingBox();
+      if (!outlineBox || !hostBox) continue;
+      expect(outlineBox.y).toBeGreaterThanOrEqual(hostBox.y - 2);
+      expect(outlineBox.y + outlineBox.height)
+        .toBeLessThanOrEqual(hostBox.y + hostBox.height + 2);
+    }
+  });
+});
+
+test.describe('Notion scrollable - clicking a tick scrolls the host only', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('clicking a tick moves the host scrollTop, not window.scrollY', async ({ page }) => {
+    // Push the page so window.scrollY > 0; the click must NOT reset it.
+    await page.evaluate(() => { window.scrollTo(0, 200); });
+    await page.waitForTimeout(50);
+
+    const before = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    // DOM click bypasses Playwright actionability so the tick column's
+    // pointer-events gating doesn't get in the way.
+    await page.evaluate(() => {
+      const ticks = document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+      ticks[ticks.length - 1]?.click();
+    });
+    await page.waitForTimeout(600);
+
+    const after = await page.evaluate(() => ({
+      windowY: window.scrollY,
+      hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement).scrollTop,
+    }));
+
+    expect(after.hostTop).toBeGreaterThan(before.hostTop);
+    expect(Math.abs(after.windowY - before.windowY)).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('Notion scrollable - scroll-spy follows host scroll', () => {
+  test.beforeEach(async ({ page }) => { await goScrollable(page); });
+
+  test('scrolling host past first H2 makes that H2 the active tick', async ({ page }) => {
+    const ticks = page.locator('.dm-toc-outline-tick');
+    expect(await ticks.count()).toBeGreaterThanOrEqual(2);
+
+    // scrollIntoView scrolls the nearest overflow:auto ancestor (= host).
+    await page.evaluate(() => {
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2');
+      if (h2) h2.scrollIntoView({ behavior: 'auto', block: 'start' });
+    });
+    await page.waitForTimeout(300);
+
+    const data = await page.evaluate(() => {
+      const active = document.querySelector('.dm-toc-outline-tick.dm-toc--active') as HTMLElement | null;
+      const h2 = document.querySelector('.app-notion-demo .ProseMirror h2') as HTMLElement | null;
+      return { activeAnchor: active?.dataset['tocAnchor'] ?? null, firstH2Id: h2?.id ?? null };
+    });
+    expect(data.firstH2Id).toBeTruthy();
+    expect(data.activeAnchor).toBe(data.firstH2Id);
+  });
+});

--- a/apps/demo-vue/e2e/notion-toc-dynamic.spec.ts
+++ b/apps/demo-vue/e2e/notion-toc-dynamic.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * E2E: FloatingTocOutline picks up dynamically inserted headings AND the
+ * outline becomes visible as soon as the first heading exists.
+ *
+ * Default `minHeadings: 1` (matches Notion). The "delete-all then add 1
+ * H1" regression specifically guards against the prior 2-heading
+ * threshold that left the outline `display: none` after typing a single
+ * heading into an empty doc.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = label === 'Notion scrollable'
+    ? '[data-testid="mode-notion-scrollable"]'
+    : '[data-testid="mode-notion"]';
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline');
+  await page.waitForTimeout(200);
+}
+
+async function placeCursorAtEnd(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(pm);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+async function selectAllAndDelete(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.querySelector<HTMLElement>('.ProseMirror')?.focus();
+  });
+  await page.keyboard.press('Control+A');
+  await page.keyboard.press('Meta+A');
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(150);
+}
+
+async function readOutlineState(page: Page): Promise<{
+  tickCount: number;
+  state: string | null;
+  display: string | null;
+  anchors: string[];
+}> {
+  return await page.evaluate(() => {
+    const outline = document.querySelector<HTMLElement>('.dm-toc-outline');
+    const ticks = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-tick'));
+    return {
+      tickCount: ticks.length,
+      state: outline?.dataset['state'] ?? null,
+      display: outline ? getComputedStyle(outline).display : null,
+      anchors: ticks.map((t) => t.dataset['tocAnchor'] ?? ''),
+    };
+  });
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - TOC tracks new headings`, () => {
+    test('appending H1 via # shortcut adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('# Appended H1');
+      await page.waitForTimeout(300);
+
+      const after = await readOutlineState(page);
+      expect(after.tickCount).toBe(before.tickCount + 1);
+      expect(after.anchors[after.anchors.length - 1]).toBeTruthy();
+    });
+
+    test('appending H1 via slash command adds a tick', async ({ page }) => {
+      await gotoMode(page, mode);
+      const before = await readOutlineState(page);
+
+      await placeCursorAtEnd(page);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/');
+      await page.waitForSelector('.dm-slash-command-menu');
+      await page.keyboard.type('Heading 1');
+      await page.waitForTimeout(150);
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Slash H1');
+      await page.waitForTimeout(300);
+
+      expect((await readOutlineState(page)).tickCount).toBe(before.tickCount + 1);
+    });
+
+    test('clearing the doc then typing one H1 shows the outline (minHeadings:1)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.keyboard.type('# Lone H1');
+      await page.waitForTimeout(400);
+
+      const observed = await readOutlineState(page);
+      expect(observed.tickCount).toBe(1);
+      expect(observed.state).toBe('collapsed');
+      expect(observed.display).not.toBe('none');
+    });
+
+    test('empty doc keeps the outline hidden until a heading exists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await selectAllAndDelete(page);
+      await page.waitForTimeout(200);
+
+      const empty = await readOutlineState(page);
+      expect(empty.tickCount).toBe(0);
+      expect(empty.state).toBe('hidden');
+      expect(empty.display).toBe('none');
+
+      await page.keyboard.type('# First');
+      await page.waitForTimeout(400);
+
+      const withOne = await readOutlineState(page);
+      expect(withOne.tickCount).toBe(1);
+      expect(withOne.state).toBe('collapsed');
+      expect(withOne.display).not.toBe('none');
+    });
+  });
+}

--- a/apps/demo-vue/e2e/notion-toc-overflow.spec.ts
+++ b/apps/demo-vue/e2e/notion-toc-overflow.spec.ts
@@ -1,0 +1,399 @@
+/**
+ * E2E: tick column caps at 50% of the container and clips extras
+ * (Notion behavior - no compression, no scroll on the column). The
+ * hover card opens at the top and is fully scrollable.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+async function gotoMode(page: Page, label: 'Notion scrollable' | 'Notion style'): Promise<void> {
+  await page.goto('/');
+  const btn = label === 'Notion scrollable'
+    ? '[data-testid="mode-notion-scrollable"]'
+    : '[data-testid="mode-notion"]';
+  await page.waitForSelector(btn);
+  await page.click(btn);
+  await page.waitForSelector('.ProseMirror');
+  await page.waitForSelector('.dm-toc-outline-ticks');
+  await page.waitForTimeout(200);
+}
+
+async function pasteManyH2s(page: Page, count: number): Promise<void> {
+  const html = Array.from({ length: count }, (_, i) => `<h2>S${String(i)}</h2>`).join('');
+  await page.evaluate((h) => {
+    const pm = document.querySelector<HTMLElement>('.ProseMirror');
+    if (!pm) return;
+    pm.focus();
+    const data = new DataTransfer();
+    data.setData('text/html', h);
+    pm.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true }));
+  }, html);
+  await page.waitForTimeout(700);
+}
+
+for (const mode of ['Notion scrollable', 'Notion style'] as const) {
+  test.describe(`${mode} - tick column caps at 50% + card scrolls`, () => {
+    test('DOM structure: ticks live in `.dm-toc-outline-ticks`, sibling of `.dm-toc-outline-card`', async ({ page }) => {
+      await gotoMode(page, mode);
+      const data = await page.evaluate(() => {
+        const nav = document.querySelector<HTMLElement>('.dm-toc-outline');
+        const wrapper = nav?.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = nav?.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return {
+          wrapperExists: !!wrapper,
+          cardExists: !!card,
+          wrapperHasTicks: (wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0) > 0,
+          cardIsSiblingOfWrapper: card?.parentElement === nav && wrapper?.parentElement === nav,
+        };
+      });
+      expect(data.wrapperExists).toBe(true);
+      expect(data.cardExists).toBe(true);
+      expect(data.wrapperHasTicks).toBe(true);
+      expect(data.cardIsSiblingOfWrapper).toBe(true);
+    });
+
+    test('inter-tick gap stays at the CSS default with many headings (no compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const gap = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w ? parseFloat(getComputedStyle(w).gap) : -1;
+      });
+      // Default is 10px - must stay constant regardless of heading count.
+      expect(gap).toBeCloseTo(10, 0);
+    });
+
+    test('ticks wrapper caps at ~50% and clips overflow (hidden, not scroll)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const data = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return null;
+        const cs = getComputedStyle(w);
+        const maxH = parseFloat(cs.maxHeight);
+        return {
+          overflow: cs.overflow,
+          overflowX: cs.overflowX,
+          overflowY: cs.overflowY,
+          maxHeight: maxH,
+          scrollHeight: w.scrollHeight,
+          clientHeight: w.clientHeight,
+          tickCount: w.querySelectorAll('.dm-toc-outline-tick').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      // Overflow MUST be hidden, never auto/scroll - the column doesn't scroll.
+      expect(data!.overflowY).not.toBe('auto');
+      expect(data!.overflowY).not.toBe('scroll');
+      expect(['hidden', 'clip']).toContain(data!.overflowY);
+      // Natural content far exceeds the visible wrapper.
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight + 100);
+      // ~50% of the container; page-mode 50vh ≈ 360, container ≈ 382.
+      expect(data!.maxHeight).toBeGreaterThan(300);
+      expect(data!.maxHeight).toBeLessThan(450);
+    });
+
+    test('hover opens the card with scrollTop = 0 (starts at the first row)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+
+      // Pre-scroll the (collapsed) card so we can prove the reset on open.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 200;
+      });
+
+      // Hover the nav to trigger the in-delay (120ms default) + expand.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          opacity: parseFloat(getComputedStyle(card).opacity),
+          scrollTop: card.scrollTop,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.opacity).toBeGreaterThan(0.5);
+      // Plugin reset scrollTop to 0 on the collapsed→expanded transition.
+      expect(data!.scrollTop).toBe(0);
+    });
+
+    test('card itself is scrollable for long heading lists', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!card) return null;
+        return {
+          overflowY: getComputedStyle(card).overflowY,
+          scrollHeight: card.scrollHeight,
+          clientHeight: card.clientHeight,
+          rowCount: card.querySelectorAll('.dm-toc-outline-row').length,
+        };
+      });
+      expect(data).not.toBeNull();
+      expect(data!.overflowY).toBe('auto');
+      expect(data!.rowCount).toBeGreaterThan(100);
+      expect(data!.scrollHeight).toBeGreaterThan(data!.clientHeight);
+    });
+
+    test('card rows keep a uniform height regardless of count (no flex compression)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const heights = await page.evaluate(() => {
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.dm-toc-outline-row'));
+        return rows.slice(0, 20).map((r) => r.getBoundingClientRect().height);
+      });
+      expect(heights.length).toBeGreaterThanOrEqual(10);
+      // All rows match the first - no flex-shrink compression.
+      const first = heights[0];
+      expect(first).toBeGreaterThan(10);
+      for (const h of heights) {
+        expect(Math.abs(h - first)).toBeLessThan(0.5);
+      }
+    });
+
+    test('card max-height matches the ticks wrapper (= 50% of the container)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (!wrapper || !card) return null;
+        return {
+          wrapperMaxH: parseFloat(getComputedStyle(wrapper).maxHeight),
+          cardMaxH: parseFloat(getComputedStyle(card).maxHeight),
+        };
+      });
+      expect(data).not.toBeNull();
+      // Card uses the same CSS var so the values match exactly.
+      expect(data!.cardMaxH).toBeCloseTo(data!.wrapperMaxH, 1);
+    });
+
+    test('removing headings shifts the visible window (no orphan ticks)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      const beforeCount = await page.evaluate(
+        () => document.querySelectorAll('.dm-toc-outline-tick').length,
+      );
+
+      // Clear the doc; the outline should re-render with just the seeded heading(s).
+      await page.evaluate(() => {
+        const pm = document.querySelector<HTMLElement>('.ProseMirror');
+        pm?.focus();
+      });
+      await page.keyboard.press('Control+A');
+      await page.keyboard.press('Meta+A');
+      await page.keyboard.press('Delete');
+      await page.waitForTimeout(300);
+      await page.keyboard.type('# Only one');
+      await page.waitForTimeout(300);
+
+      const after = await page.evaluate(() => ({
+        count: document.querySelectorAll('.dm-toc-outline-tick').length,
+        wrapperChildrenCount:
+          document.querySelector('.dm-toc-outline-ticks')?.children.length ?? 0,
+      }));
+      expect(beforeCount).toBeGreaterThan(100);
+      expect(after.count).toBe(1);
+      expect(after.wrapperChildrenCount).toBe(1);
+    });
+
+    test('every heading produces a tick in the DOM (clipped, not truncated)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const headings = document.querySelectorAll('.ProseMirror h1, .ProseMirror h2, .ProseMirror h3');
+        return {
+          tickCount: wrapper?.querySelectorAll('.dm-toc-outline-tick').length ?? 0,
+          headingCount: headings.length,
+        };
+      });
+      // Plugin renders ALL; CSS clip hides the ones past the 50% mark.
+      expect(data.tickCount).toBe(data.headingCount);
+      expect(data.tickCount).toBeGreaterThan(80);
+    });
+
+    test('a clipped tick exists in DOM with valid anchor (just not visible)', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 100);
+      const data = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = Array.from(wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick') ?? []);
+        const wrapperRect = wrapper?.getBoundingClientRect();
+        // Find a tick that sits below the wrapper's visible bottom edge.
+        const clipped = ticks.find((t) => {
+          const r = t.getBoundingClientRect();
+          return wrapperRect && r.top > wrapperRect.bottom;
+        });
+        return {
+          clippedExists: !!clipped,
+          clippedAnchor: clipped?.dataset['tocAnchor'] ?? '',
+          totalTicks: ticks.length,
+        };
+      });
+      expect(data.totalTicks).toBeGreaterThan(80);
+      expect(data.clippedExists).toBe(true);
+      // UniqueID stamped it - the anchor is non-empty even for clipped ticks.
+      expect(data.clippedAnchor).toBeTruthy();
+    });
+
+    test('tick column does not scroll on wheel - scrollTop stays 0', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      // Synthesize a wheel event on the wrapper - overflow:hidden ignores it.
+      await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        if (!w) return;
+        w.dispatchEvent(new WheelEvent('wheel', { deltaY: 500, bubbles: true }));
+      });
+      await page.waitForTimeout(100);
+      const scrollTop = await page.evaluate(() => {
+        const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        return w?.scrollTop ?? -1;
+      });
+      expect(scrollTop).toBe(0);
+    });
+
+    test('clicking a visible tick scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 60);
+      const before = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // Click a tick deep enough that the scroll has to move appreciably.
+      const anchor = await page.evaluate(() => {
+        const wrapper = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+        const ticks = wrapper?.querySelectorAll<HTMLElement>('.dm-toc-outline-tick');
+        const target = ticks?.[ticks.length - 5];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const after = await page.evaluate(() => ({
+        winY: window.scrollY,
+        hostTop: (document.querySelector('.notion-page--scrollable') as HTMLElement | null)?.scrollTop ?? 0,
+      }));
+      // EITHER the window OR the container scrolled - depends on mode.
+      const movedWindow = after.winY - before.winY;
+      const movedHost = after.hostTop - before.hostTop;
+      expect(Math.max(movedWindow, movedHost)).toBeGreaterThan(50);
+    });
+
+    test('clicking a row in the expanded card scrolls the editor to that heading', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 80);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Click the 5th row deep in the card (likely below the fold for tick column).
+      const anchor = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        const rows = card?.querySelectorAll<HTMLElement>('.dm-toc-outline-row');
+        const target = rows?.[4];
+        target?.click();
+        return target?.dataset['tocAnchor'] ?? '';
+      });
+      expect(anchor).toBeTruthy();
+      await page.waitForTimeout(600);
+      const found = await page.evaluate((id) => {
+        const h = document.querySelector<HTMLElement>(`[id="${id}"]`);
+        return !!h;
+      }, anchor);
+      expect(found).toBe(true);
+    });
+
+    test('card stays expanded while the mouse is over the card itself', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 40);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // Move pointer into the card center; avoids the brief gap-leave
+      // that Playwright's `.hover()` can hit between elements.
+      const cardBox = await page.locator('.dm-toc-outline-card').boundingBox();
+      if (cardBox) {
+        await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2, { steps: 8 });
+      }
+      await page.waitForTimeout(150);
+      const state = await page.evaluate(
+        () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+      );
+      expect(state).toBe('expanded');
+    });
+
+    test('card collapses after the hover-out delay when leaving the outline', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 20);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('expanded');
+      // Move the pointer somewhere harmless.
+      await page.mouse.move(10, 10);
+      // Default hover-out delay is 350ms; allow a buffer.
+      await page.waitForTimeout(500);
+      expect(
+        await page.evaluate(
+          () => document.querySelector<HTMLElement>('.dm-toc-outline')?.dataset['state'] ?? '',
+        ),
+      ).toBe('collapsed');
+    });
+
+    test('reopening the card resets scrollTop to 0 even after the user scrolled it', async ({ page }) => {
+      await gotoMode(page, mode);
+      await pasteManyH2s(page, 120);
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      // User scrolls the card mid-list.
+      await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        if (card) card.scrollTop = 600;
+      });
+      // Collapse.
+      await page.mouse.move(10, 10);
+      await page.waitForTimeout(500);
+      // Reopen.
+      await page.locator('.dm-toc-outline').hover();
+      await page.waitForTimeout(300);
+      const top = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>('.dm-toc-outline-card');
+        return card?.scrollTop ?? -1;
+      });
+      expect(top).toBe(0);
+    });
+
+    if (mode === 'Notion style') {
+      // Page-scroll only: `50vh` tracks viewport. Container mode's host
+      // is pinned at `max-height: 700px`, so resize is a no-op there.
+      test('viewport resize updates the ticks wrapper max-height (page-scroll)', async ({ page }) => {
+        await gotoMode(page, mode);
+        await pasteManyH2s(page, 100);
+        const before = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        await page.setViewportSize({ width: 1280, height: 1000 });
+        await page.waitForTimeout(200);
+        const after = await page.evaluate(() => {
+          const w = document.querySelector<HTMLElement>('.dm-toc-outline-ticks');
+          return parseFloat(getComputedStyle(w!).maxHeight);
+        });
+        expect(after).toBeGreaterThan(before + 50);
+      });
+    }
+  });
+}

--- a/apps/demo-vue/src/App.vue
+++ b/apps/demo-vue/src/App.vue
@@ -8,7 +8,7 @@ import NotionDemo from './NotionDemo.vue';
 
 const isDark = ref(false);
 const useLayout = ref(false);
-const demoMode = ref<'manual' | 'vmodel' | 'compound' | 'nodeview' | 'notion'>('manual');
+const demoMode = ref<'manual' | 'vmodel' | 'compound' | 'nodeview' | 'notion' | 'notion-scrollable'>('manual');
 
 function toggleTheme() {
   isDark.value = !isDark.value;
@@ -66,9 +66,24 @@ function toggleTheme() {
       >
         Notion style
       </button>
+      <button
+        type="button"
+        data-testid="mode-notion-scrollable"
+        :class="{ active: demoMode === 'notion-scrollable' }"
+        @click="demoMode = 'notion-scrollable'"
+      >
+        Notion scrollable
+      </button>
     </div>
 
-    <NotionDemo v-if="demoMode === 'notion'" />
+    <!-- `:key` forces a fresh mount when switching between the two Notion
+         variants - mirrors the vanilla demo which destroys + recreates
+         the NotionDemo on mode change. -->
+    <NotionDemo
+      v-if="demoMode === 'notion' || demoMode === 'notion-scrollable'"
+      :key="demoMode"
+      :scrollable="demoMode === 'notion-scrollable'"
+    />
 
     <div v-else class="app-editor-demo">
       <template v-if="demoMode === 'manual'">

--- a/apps/demo-vue/src/NotionDemo.vue
+++ b/apps/demo-vue/src/NotionDemo.vue
@@ -34,6 +34,7 @@ import {
   LineHeight,
   SelectionDecoration,
   ClearFormatting,
+  Dropcursor,
   UniqueID,
   BlockColor,
   Placeholder,
@@ -120,6 +121,10 @@ const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
     },
   }),
   LinkPopover, SelectionDecoration, ClearFormatting,
+  // Native PM dropcursor; BlockHandle hides it during a handle drag so
+  // only the custom `.dm-block-drop-indicator` shows. Kept loaded for
+  // non-handle drops (text selection, external file drops).
+  Dropcursor,
   // Registered after the list extensions so their in-item Tab/Shift-Tab
   // keymaps keep priority inside list items.
   ListIndent,

--- a/apps/demo-vue/src/NotionDemo.vue
+++ b/apps/demo-vue/src/NotionDemo.vue
@@ -39,6 +39,7 @@ import {
   Placeholder,
   inlineStyles,
   getListItemCursorContext,
+  type AnyExtension,
 } from '@domternal/core';
 import type { IconSet } from '@domternal/core';
 import { CodeBlockLowlight, createCodeHighlighter } from '@domternal/extension-code-block-lowlight';
@@ -92,7 +93,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
  */
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
-const extensions = [
+const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,
@@ -151,7 +152,7 @@ const extensions = [
   SlashCommand,
   SmartPaste,
   TableOfContents,
-  FloatingTocOutline,
+  FloatingTocOutline.configure({ activeScrollParent: scrollParent }),
   TableOfContentsBlock,
   // Empty paragraphs get the slash hint; other empty blocks stay quiet so
   // the hint isn't repeated on every block.
@@ -166,6 +167,37 @@ interface Toast {
   message: string;
   kind: 'success' | 'error';
 }
+
+const props = withDefaults(defineProps<{
+  /** Cap the page wrapper height and scroll its content internally. Adds
+   * `notion-page--scrollable` and wires `activeScrollParent` so the TOC
+   * scroll-spy follows the host scroll instead of the window. */
+  scrollable?: boolean;
+}>(), {
+  scrollable: false,
+});
+
+// Captures the page wrapper element so we can wire it as the TOC's
+// `activeScrollParent` in scrollable mode. Template refs are resolved
+// before `onMounted` fires.
+const pageEl = ref<HTMLDivElement | null>(null);
+
+// Single extensions array reference - we mutate it in-place after the
+// wrapper mounts so useEditor reads the wired value at creation time
+// without firing its recreation watcher (which compares the array
+// reference, not contents).
+const extensions: AnyExtension[] = buildExtensions(null);
+
+// Register BEFORE useEditor so this onMounted fires first; useEditor's
+// onMounted then reads the (mutated) array when it builds the editor,
+// and its watcher stays quiet because the reference never changes.
+onMounted(() => {
+  if (props.scrollable && pageEl.value) {
+    const wired = buildExtensions(pageEl.value);
+    extensions.length = 0;
+    extensions.push(...wired);
+  }
+});
 
 const { editor, editorRef } = useEditor({
   extensions,
@@ -235,7 +267,10 @@ watch(editor, (ed, _old, onCleanup) => {
 
 <template>
   <div class="app-notion-demo">
-    <div class="notion-page">
+    <div
+      ref="pageEl"
+      :class="['notion-page', { 'notion-page--scrollable': props.scrollable }]"
+    >
       <div class="dm-editor dm-notion-mode">
         <div ref="editorRef" />
       </div>

--- a/apps/demo-vue/src/NotionDemo.vue
+++ b/apps/demo-vue/src/NotionDemo.vue
@@ -187,15 +187,11 @@ const props = withDefaults(defineProps<{
 // before `onMounted` fires.
 const pageEl = ref<HTMLDivElement | null>(null);
 
-// Single extensions array reference - we mutate it in-place after the
-// wrapper mounts so useEditor reads the wired value at creation time
-// without firing its recreation watcher (which compares the array
-// reference, not contents).
+// `extensions` keeps a single array reference. This onMounted is
+// registered BEFORE useEditor's own, so we mutate the array in-place
+// before useEditor reads it; the watcher stays quiet because it
+// compares the reference, not contents.
 const extensions: AnyExtension[] = buildExtensions(null);
-
-// Register BEFORE useEditor so this onMounted fires first; useEditor's
-// onMounted then reads the (mutated) array when it builds the editor,
-// and its watcher stays quiet because the reference never changes.
 onMounted(() => {
   if (props.scrollable && pageEl.value) {
     const wired = buildExtensions(pageEl.value);
@@ -233,10 +229,9 @@ let toastCounter = 0;
 const pushToast = (message: string, kind: Toast['kind']): void => {
   const id = ++toastCounter;
   toasts.value = [...toasts.value, { id, message, kind }];
-  const ms = kind === 'success' ? TOAST_MS.success : TOAST_MS.error;
   setTimeout(() => {
     toasts.value = toasts.value.filter((t) => t.id !== id);
-  }, ms);
+  }, TOAST_MS[kind]);
 };
 
 // Expose editor + cursor-context util on window for e2e, and wire the

--- a/apps/demo-vue/src/_notion-demo.scss
+++ b/apps/demo-vue/src/_notion-demo.scss
@@ -29,6 +29,34 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
+// Scrollable variant: caps height and scrolls content internally instead
+// of growing. Pair with `FloatingTocOutline.activeScrollParent` so the
+// outline's scroll-spy follows the host scroll.
+.notion-page--scrollable {
+  max-height: 700px;
+  overflow-y: auto;
+
+  // Tokenised slim scrollbar; dark theme overrides keep contrast.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
+}
+
 // Toast surfaced by the Notion demo when a block link is copied (or fails
 // to copy). Positioned fixed above the viewport bottom. The success
 // variant is neutral dark; the `--error` modifier uses a warning red.

--- a/packages/extension-block-menu/src/BlockContextMenu.ts
+++ b/packages/extension-block-menu/src/BlockContextMenu.ts
@@ -714,11 +714,9 @@ export function createBlockContextMenuPlugin(
     editorEl.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: false }));
     root.setAttribute('data-show', '');
     lockScroll();
-    {
-      const tr = editor.view.state.tr.setMeta(pluginKey, { activeBlockPos: detail.blockPos });
-      tr.setMeta('addToHistory', false);
-      editor.view.dispatch(tr);
-    }
+    const openTr = editor.view.state.tr.setMeta(pluginKey, { activeBlockPos: detail.blockPos });
+    openTr.setMeta('addToHistory', false);
+    editor.view.dispatch(openTr);
 
     cleanupFloating?.();
     // Virtual reference: caches the last valid rect and returns it when the

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -145,9 +145,9 @@ export interface BlockHandleOptions {
    * `posAtCoords` can disagree with our resolver in the side gutter /
    * inter-block gap). While dragging, the editor gets a
    * `dm-block-handle-dragging` class so the theme can hide the native
-   * `.ProseMirror-dropcursor` for this drag only; non-handle drags
-   * (text selection, external file drops) keep the native cursor.
-   * Set to `false` to use the native dropcursor instead.
+   * `.prosemirror-dropcursor-block`/`-inline` for this drag only;
+   * non-handle drags (text selection, external file drops) keep the
+   * native cursor. Set to `false` to use the native dropcursor instead.
    * @default true
    */
   dropIndicator?: boolean;
@@ -1286,7 +1286,7 @@ export function createBlockHandlePlugin(
     // and the drop-indicator. Attached once per drag, removed in dragend.
     startDragListeners();
 
-    // Theme hides native `.ProseMirror-dropcursor` while this class is set.
+    // Theme hides native `.prosemirror-dropcursor-*` while this class is set.
     if (dropIndicator) editorEl?.classList.add('dm-block-handle-dragging');
   };
 

--- a/packages/extension-block-menu/src/FloatingMenu.ts
+++ b/packages/extension-block-menu/src/FloatingMenu.ts
@@ -267,6 +267,14 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
     element.removeAttribute('data-show');
   };
 
+  // Clear the explicit-trigger flag if it's set. No-op when
+  // `requireExplicitTrigger` is off (no flag exists to clear).
+  const clearTriggeredFlag = (view: EditorView): void => {
+    if (!requireExplicitTrigger) return;
+    const triggered = (pluginKey.getState(view.state) as FloatingMenuPluginState | undefined)?.triggered ?? false;
+    if (triggered) view.dispatch(view.state.tr.setMeta(FLOATING_MENU_META, 'hide'));
+  };
+
   // Focus first menuitem. Wrappers mark each item with
   // `data-floating-menu-item`; falls back to any focusable descendant.
   const focusFirstItem = (): boolean => {
@@ -335,12 +343,7 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
       // `triggered=true` doesn't survive across an unrelated dismissal.
       const dismiss = (): void => {
         hideMenu();
-        if (requireExplicitTrigger) {
-          const triggered = (pluginKey.getState(editor.view.state) as FloatingMenuPluginState | undefined)?.triggered ?? false;
-          if (triggered) {
-            editor.view.dispatch(editor.view.state.tr.setMeta(FLOATING_MENU_META, 'hide'));
-          }
-        }
+        clearTriggeredFlag(editor.view);
       };
 
       const onFocus = (): void => {
@@ -391,12 +394,7 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
             // away from the empty paragraph (e.g. types a character or
             // moves the cursor) - otherwise the next empty paragraph
             // they enter would silently re-show the menu.
-            if (requireExplicitTrigger) {
-              const triggered = (pluginKey.getState(view.state) as FloatingMenuPluginState | undefined)?.triggered ?? false;
-              if (triggered) {
-                view.dispatch(view.state.tr.setMeta(FLOATING_MENU_META, 'hide'));
-              }
-            }
+            clearTriggeredFlag(view);
           }
         },
 

--- a/packages/extension-toc/src/FloatingTocOutline.test.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.test.ts
@@ -453,6 +453,45 @@ describe('FloatingTocOutline - anchor option', () => {
     expect(outline?.dataset['anchor']).toBe('editor');
   });
 
+  it('marks the outline as scroll-mode="page" when activeScrollParent is null', async () => {
+    document.body.innerHTML = '';
+    document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    stubMatchMedia();
+    editor = new Editor({
+      element: host,
+      extensions: baseExtensions,
+      content: '<h1>One</h1><h2>Two</h2>',
+    });
+    await flushDeferred();
+    expect(queryOutline()?.dataset['scrollMode']).toBe('page');
+  });
+
+  it('marks the outline as scroll-mode="container" when activeScrollParent is an Element', async () => {
+    document.body.innerHTML = '';
+    document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    stubMatchMedia();
+    editor = new Editor({
+      element: host,
+      extensions: [
+        Document, Text, Paragraph, Heading, BaseKeymap, History, UniqueID,
+        TableOfContents,
+        FloatingTocOutline.configure({ activeScrollParent: host }),
+      ],
+      content: '<h1>One</h1><h2>Two</h2>',
+    });
+    await flushDeferred();
+    const outline = queryOutline();
+    expect(outline?.dataset['scrollMode']).toBe('container');
+    // Page-scroll machinery is skipped in container mode.
+    expect((outline as HTMLElement).style.getPropertyValue('--dm-toc-mid-top')).toBe('');
+    expect(outline?.dataset['bottomVisible']).toBeUndefined();
+    expect(outline?.dataset['mode']).toBeUndefined();
+  });
+
   it('honors anchor="viewport" override', async () => {
     document.body.innerHTML = '';
     document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });

--- a/packages/extension-toc/src/FloatingTocOutline.test.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.test.ts
@@ -505,7 +505,7 @@ describe('FloatingTocOutline - anchor option', () => {
     const outline = queryOutline();
     expect(outline?.dataset['scrollMode']).toBe('container');
     // Page-scroll machinery is skipped in container mode.
-    expect((outline as HTMLElement).style.getPropertyValue('--dm-toc-mid-top')).toBe('');
+    expect(outline!.style.getPropertyValue('--dm-toc-mid-top')).toBe('');
     expect(outline?.dataset['bottomVisible']).toBeUndefined();
     expect(outline?.dataset['mode']).toBeUndefined();
   });
@@ -536,7 +536,7 @@ describe('FloatingTocOutline - anchor option', () => {
         content: '<h1>One</h1><h2>Two</h2>',
       });
       await flushDeferred();
-      const outline = queryOutline() as HTMLElement;
+      const outline = queryOutline()!;
       expect(outline.style.getPropertyValue('--dm-toc-mid-half-height')).toBe('100.00px');
     } finally {
       if (origGetter) {

--- a/packages/extension-toc/src/FloatingTocOutline.test.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.test.ts
@@ -50,6 +50,12 @@ interface MountedEditorOptions {
    * a viewport at or below the mobile breakpoint.
    */
   matchesMobile?: boolean;
+  /**
+   * Optional overrides forwarded to `FloatingTocOutline.configure(...)`.
+   * When set, the plugin is reconfigured with these options instead of
+   * its defaults; everything else stays the same as `baseExtensions`.
+   */
+  floatingOptions?: Partial<Parameters<typeof FloatingTocOutline.configure>[0]>;
 }
 
 describe('FloatingTocOutline - ticks', () => {
@@ -63,7 +69,7 @@ describe('FloatingTocOutline - ticks', () => {
    * past `.dm-editor` looking for a non-overflow-hidden parent, so we
    * use a plain test container as that ancestor.
    */
-  const mount = ({ content, matchesMobile = false }: MountedEditorOptions): Editor => {
+  const mount = ({ content, matchesMobile = false, floatingOptions }: MountedEditorOptions): Editor => {
     document.body.innerHTML = '';
     // Reset any leftover outline from prior tests.
     document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });
@@ -86,9 +92,13 @@ describe('FloatingTocOutline - ticks', () => {
       dispatchEvent: (): boolean => false,
     })) as typeof window.matchMedia;
 
+    const extensions = floatingOptions
+      ? [...baseExtensions.slice(0, -1), FloatingTocOutline.configure(floatingOptions)]
+      : baseExtensions;
+
     return new Editor({
       element: host,
-      extensions: baseExtensions,
+      extensions,
       content,
     });
   };
@@ -155,15 +165,23 @@ describe('FloatingTocOutline - ticks', () => {
     expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('hides itself when fewer headings than minHeadings (default 2)', async () => {
+  it('shows itself with a single heading at the default minHeadings (1)', async () => {
     editor = mount({ content: '<h1>Only One</h1>' });
     await flushDeferred();
-    const outline = queryOutline();
-    expect(outline?.dataset['state']).toBe('hidden');
+    expect(queryOutline()?.dataset['state']).toBe('collapsed');
   });
 
-  it('shows itself when heading count crosses the minHeadings threshold', async () => {
-    editor = mount({ content: '<h1>One</h1>' });
+  it('hides itself with zero headings at the default minHeadings (1)', async () => {
+    editor = mount({ content: '<p>No headings here</p>' });
+    await flushDeferred();
+    expect(queryOutline()?.dataset['state']).toBe('hidden');
+  });
+
+  it('honors a custom minHeadings: hides until the threshold is crossed', async () => {
+    editor = mount({
+      content: '<h1>One</h1>',
+      floatingOptions: { minHeadings: 2 },
+    });
     await flushDeferred();
     expect(queryOutline()?.dataset['state']).toBe('hidden');
 

--- a/packages/extension-toc/src/FloatingTocOutline.test.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.test.ts
@@ -492,6 +492,43 @@ describe('FloatingTocOutline - anchor option', () => {
     expect(outline?.dataset['mode']).toBeUndefined();
   });
 
+  it('sets --dm-toc-mid-half-height in container mode based on nav offsetHeight', async () => {
+    document.body.innerHTML = '';
+    document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    stubMatchMedia();
+    // Pre-stub the nav offsetHeight before any are constructed: the
+    // plugin reads it on mount and on every storage update.
+    const origGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get(): number {
+        return this.classList?.contains('dm-toc-outline') ? 200 : 0;
+      },
+    });
+    try {
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document, Text, Paragraph, Heading, BaseKeymap, History, UniqueID,
+          TableOfContents,
+          FloatingTocOutline.configure({ activeScrollParent: host }),
+        ],
+        content: '<h1>One</h1><h2>Two</h2>',
+      });
+      await flushDeferred();
+      const outline = queryOutline() as HTMLElement;
+      expect(outline.style.getPropertyValue('--dm-toc-mid-half-height')).toBe('100.00px');
+    } finally {
+      if (origGetter) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', origGetter);
+      } else {
+        delete (HTMLElement.prototype as unknown as { offsetHeight?: unknown }).offsetHeight;
+      }
+    }
+  });
+
   it('honors anchor="viewport" override', async () => {
     document.body.innerHTML = '';
     document.querySelectorAll('.dm-toc-outline').forEach((n) => { n.remove(); });

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -246,7 +246,15 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
           // would render hidden because storage stays empty).
           const attrName = editor ? resolveUniqueIDAttrName(editor) : 'id';
 
-          const hostResolver = options.outlineHost ?? resolveDefaultOutlineHost;
+          // Container mode anchors the shell to the scroll parent itself
+          // so the sticky's scroll context and positioned containing
+          // block match. Default walk would land on the editor's
+          // unsized parent and size the shell to scrollHeight.
+          const isScrollContainer = options.activeScrollParent instanceof Element;
+          const hostResolver = options.outlineHost
+            ?? (isScrollContainer
+              ? (): HTMLElement => options.activeScrollParent as HTMLElement
+              : resolveDefaultOutlineHost);
           const host = hostResolver(editorView);
           const nav = document.createElement('nav');
           nav.className = OUTLINE_CLASS;
@@ -266,50 +274,37 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
             host.appendChild(nav);
           }
 
-          // Wiring a scrollable Element as `activeScrollParent` swaps the
-          // page-scroll sticky model for a container-scroll absolute model.
-          // Theme CSS keys off `data-scroll-mode`.
-          const isScrollContainer = options.activeScrollParent instanceof Element;
+          // Theme CSS keys off `data-scroll-mode` to switch between page-
+          // scroll sticky and container-scroll sticky models.
           const scrollMode = isScrollContainer ? 'container' : 'page';
           nav.dataset['scrollMode'] = scrollMode;
           if (shell) shell.dataset['scrollMode'] = scrollMode;
 
-          // Container mode: absolute children of an overflow:auto element
-          // scroll WITH content, so we add scrollTop back into `top` to
-          // hold the nav at the host's visible middle. SHELL_TOP_OFFSET
-          // mirrors the `top: 25px` shell inset.
-          const SHELL_TOP_OFFSET = 25;
-          let containerScrollHandler: (() => void) | null = null;
+          // Container mode: CSS `position: sticky` does the work; JS only
+          // publishes `--dm-toc-mid-half-height` (for the theme's
+          // `calc(50% - var(...))`) and stretches the shell to host
+          // scrollHeight so sticky containment spans the full scroll
+          // range. Reset minHeight before measuring so the read isn't
+          // self-inflated by the shell's previous height.
           let containerResizeObserver: ResizeObserver | null = null;
-          let containerRaf: number | null = null;
-          const recomputeContainerCenter = (): void => {
+          const recomputeContainerLayout = (): void => {
             if (!isScrollContainer) return;
-            const sp = options.activeScrollParent as Element;
             const h = nav.offsetHeight;
-            if (h <= 0) return;
-            const top = sp.scrollTop + sp.clientHeight / 2 - h / 2 - SHELL_TOP_OFFSET;
-            nav.style.top = `${top.toFixed(2)}px`;
-          };
-          if (isScrollContainer) {
-            const sp = options.activeScrollParent as Element;
-            const onScroll = (): void => {
-              if (containerRaf !== null) return;
-              containerRaf = requestAnimationFrame(() => {
-                containerRaf = null;
-                recomputeContainerCenter();
-              });
-            };
-            sp.addEventListener('scroll', onScroll, { passive: true });
-            containerScrollHandler = onScroll;
-            if (typeof ResizeObserver !== 'undefined') {
-              // Host drives the viewport; nav drives the offset (grows as
-              // ticks/headings are added).
-              containerResizeObserver = new ResizeObserver(() => { recomputeContainerCenter(); });
-              containerResizeObserver.observe(sp);
-              containerResizeObserver.observe(nav);
+            if (h > 0) {
+              nav.style.setProperty('--dm-toc-mid-half-height', `${(h / 2).toFixed(2)}px`);
             }
-            recomputeContainerCenter();
+            if (shell) {
+              const sp = options.activeScrollParent as Element;
+              shell.style.minHeight = '';
+              shell.style.minHeight = `${sp.scrollHeight}px`;
+            }
+          };
+          if (isScrollContainer && typeof ResizeObserver !== 'undefined') {
+            containerResizeObserver = new ResizeObserver(recomputeContainerLayout);
+            containerResizeObserver.observe(nav);
+            containerResizeObserver.observe(editorView.dom);
           }
+          if (isScrollContainer) recomputeContainerLayout();
 
           let bottomObserver: IntersectionObserver | null = null;
           let bottomSentinel: HTMLElement | null = null;
@@ -664,11 +659,7 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
               mq?.removeEventListener('change', onMqChange);
               window.removeEventListener('resize', onResize);
               window.removeEventListener('scroll', onWindowScroll);
-              if (containerScrollHandler && options.activeScrollParent instanceof Element) {
-                options.activeScrollParent.removeEventListener('scroll', containerScrollHandler);
-              }
               containerResizeObserver?.disconnect();
-              if (containerRaf !== null) cancelAnimationFrame(containerRaf);
               tracker.destroy();
               unsubscribe?.();
               bottomObserver?.disconnect();

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -10,6 +10,7 @@ import { Plugin, PluginKey } from '@domternal/pm/state';
 import { scrollToHeading } from './helpers/scrollToHeading.js';
 import { createActiveStateTracker } from './helpers/activeStateTracker.js';
 import { resolveUniqueIDAttrName } from './helpers/uniqueIDIntegration.js';
+import { getHeadingLabel, setActiveMarker } from './helpers/outlineDom.js';
 import type { TocStorage, HeadingEntry } from './types.js';
 
 export const floatingTocOutlinePluginKey = new PluginKey('floatingTocOutline');
@@ -162,14 +163,13 @@ function renderOutlineContent(nav: HTMLElement, content: HeadingEntry[]): void {
     tick.className = TICK_CLASS;
     tick.dataset['level'] = String(entry.level);
     tick.dataset[ANCHOR_DATASET_KEY] = entry.id;
-    const label = entry.textContent.trim() || `Heading level ${String(entry.level)}`;
+    const label = getHeadingLabel(entry);
     tick.setAttribute('aria-label', `${label} (heading ${String(entry.level)})`);
     ticks.appendChild(tick);
   }
 
   // Expanded-view card. Always rendered; CSS opacity flips it in/out
-  // via the nav's data-state. Sibling of the ticks wrapper so the
-  // wrapper's `overflow: hidden` never clips it.
+  // via the nav's data-state.
   let card = nav.querySelector<HTMLElement>(`.${CARD_CLASS}`);
   if (!card) {
     card = document.createElement('div');
@@ -184,25 +184,19 @@ function renderOutlineContent(nav: HTMLElement, content: HeadingEntry[]): void {
     row.className = ROW_CLASS;
     row.dataset['level'] = String(entry.level);
     row.dataset[ANCHOR_DATASET_KEY] = entry.id;
-    row.textContent = entry.textContent.trim() || `Heading level ${String(entry.level)}`;
+    row.textContent = getHeadingLabel(entry);
     card.appendChild(row);
   }
 }
 
 /**
- * Toggle the active-state visual on every element with a `data-toc-anchor`
- * attribute (both ticks AND rows in the outline DOM). At most one item
- * gets the active class + `aria-current="location"`, all others have
- * those cleared.
+ * Apply the active marker to ticks AND rows in the outline DOM. Thin
+ * wrapper over the shared `setActiveMarker` helper: queries every
+ * element with `data-toc-anchor` and forwards the toggle work.
  */
 function applyActiveMarker(nav: HTMLElement, activeId: string | null): void {
-  const items = nav.querySelectorAll<HTMLElement>(`[${ANCHOR_ATTR}]`);
-  for (const item of Array.from(items)) {
-    const isActive = activeId !== null && item.dataset[ANCHOR_DATASET_KEY] === activeId;
-    item.classList.toggle(ACTIVE_CLASS, isActive);
-    if (isActive) item.setAttribute('aria-current', 'location');
-    else item.removeAttribute('aria-current');
-  }
+  const items = Array.from(nav.querySelectorAll<HTMLElement>(`[${ANCHOR_ATTR}]`));
+  setActiveMarker(items, activeId, ACTIVE_CLASS);
 }
 
 /**
@@ -300,18 +294,16 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
           nav.dataset['scrollMode'] = scrollMode;
           if (shell) shell.dataset['scrollMode'] = scrollMode;
 
-          // Container mode: CSS `position: sticky` does the work; JS only
-          // publishes `--dm-toc-mid-half-height` (for the theme's
-          // `calc(50% - var(...))`) and stretches the shell to host
-          // scrollHeight so sticky containment spans the full scroll
-          // range. Reset minHeight before measuring so the read isn't
-          // self-inflated by the shell's previous height.
+          // Container mode: CSS `position: sticky` does the work. JS
+          // publishes the variables the theme reads (`--dm-toc-ticks-max-h`,
+          // `--dm-toc-mid-half-height`) and stretches the shell to
+          // host.scrollHeight so sticky containment spans the full
+          // scroll range. Clearing minHeight first avoids reading a
+          // self-inflated scrollHeight.
           let containerResizeObserver: ResizeObserver | null = null;
           const recomputeContainerLayout = (): void => {
             if (!isScrollContainer) return;
             const sp = options.activeScrollParent as Element;
-            // Cap the ticks column at 50% of the host viewport - the
-            // wrapper's CSS reads this var.
             nav.style.setProperty(
               '--dm-toc-ticks-max-h',
               `${(sp.clientHeight * 0.5).toFixed(2)}px`,
@@ -521,7 +513,7 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
           // then write the new shift only when it actually changes.
           const CARD_VIEWPORT_MARGIN = 16;
           const adjustCardPosition = (): void => {
-            const card = nav.querySelector<HTMLElement>('.dm-toc-outline-card');
+            const card = nav.querySelector<HTMLElement>(`.${CARD_CLASS}`);
             if (!card) return;
             const currentShift = parseFloat(
               card.style.getPropertyValue('--dm-toc-card-shift-y'),

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -567,7 +567,12 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
             if (!id) return;
             manualOverrideUntil = Date.now() + options.clickOverrideMs;
             writeActive(id);
-            scrollToHeading(editorView, id, { attrName });
+            scrollToHeading(editorView, id, {
+              attrName,
+              scrollParent: options.activeScrollParent instanceof Element
+                ? options.activeScrollParent
+                : null,
+            });
           };
           nav.addEventListener('click', onClick);
 

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -96,6 +96,10 @@ const OUTLINE_CLASS = 'dm-toc-outline';
 // Editor-mode wrapper spanning the host's full height; provides the
 // sticky containing block for the nav inside.
 const SHELL_CLASS = 'dm-toc-outline-shell';
+// Tick column wrapper. Caps at ~50% of the container with
+// `overflow: hidden`; the card is a SIBLING (not a child) so the
+// clip never touches the hover panel.
+const TICKS_CLASS = 'dm-toc-outline-ticks';
 const TICK_CLASS = 'dm-toc-outline-tick';
 const CARD_CLASS = 'dm-toc-outline-card';
 const ROW_CLASS = 'dm-toc-outline-row';
@@ -135,14 +139,22 @@ function resolveDefaultOutlineHost(view: EditorView): HTMLElement {
 }
 
 /**
- * Build the inner DOM for the outline: a column of tick buttons (the
- * always-visible compact view) plus an absolutely-positioned card
- * containing one row button per heading (revealed on hover/focus).
- * Naive full-rebuild render: doc heading counts are typically <50;
- * the inner DOM cost is microseconds.
+ * Build the inner DOM for the outline: a bounded ticks column (always-
+ * visible compact view) plus an absolutely-positioned card containing
+ * one row button per heading (revealed on hover/focus). The ticks
+ * wrapper isolates `overflow: hidden` from the card so a long heading
+ * list never clips the expanded panel. Wrapper + card are reused
+ * across re-renders.
  */
 function renderOutlineContent(nav: HTMLElement, content: HeadingEntry[]): void {
-  nav.replaceChildren();
+  let ticks = nav.querySelector<HTMLElement>(`.${TICKS_CLASS}`);
+  if (!ticks) {
+    ticks = document.createElement('div');
+    ticks.className = TICKS_CLASS;
+    nav.appendChild(ticks);
+  } else {
+    ticks.replaceChildren();
+  }
 
   for (const entry of content) {
     const tick = document.createElement('button');
@@ -152,13 +164,20 @@ function renderOutlineContent(nav: HTMLElement, content: HeadingEntry[]): void {
     tick.dataset[ANCHOR_DATASET_KEY] = entry.id;
     const label = entry.textContent.trim() || `Heading level ${String(entry.level)}`;
     tick.setAttribute('aria-label', `${label} (heading ${String(entry.level)})`);
-    nav.appendChild(tick);
+    ticks.appendChild(tick);
   }
 
   // Expanded-view card. Always rendered; CSS opacity flips it in/out
-  // based on the parent nav's data-state attribute.
-  const card = document.createElement('div');
-  card.className = CARD_CLASS;
+  // via the nav's data-state. Sibling of the ticks wrapper so the
+  // wrapper's `overflow: hidden` never clips it.
+  let card = nav.querySelector<HTMLElement>(`.${CARD_CLASS}`);
+  if (!card) {
+    card = document.createElement('div');
+    card.className = CARD_CLASS;
+    nav.appendChild(card);
+  } else {
+    card.replaceChildren();
+  }
   for (const entry of content) {
     const row = document.createElement('button');
     row.type = 'button';
@@ -168,7 +187,6 @@ function renderOutlineContent(nav: HTMLElement, content: HeadingEntry[]): void {
     row.textContent = entry.textContent.trim() || `Heading level ${String(entry.level)}`;
     card.appendChild(row);
   }
-  nav.appendChild(card);
 }
 
 /**
@@ -291,12 +309,18 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
           let containerResizeObserver: ResizeObserver | null = null;
           const recomputeContainerLayout = (): void => {
             if (!isScrollContainer) return;
+            const sp = options.activeScrollParent as Element;
+            // Cap the ticks column at 50% of the host viewport - the
+            // wrapper's CSS reads this var.
+            nav.style.setProperty(
+              '--dm-toc-ticks-max-h',
+              `${(sp.clientHeight * 0.5).toFixed(2)}px`,
+            );
             const h = nav.offsetHeight;
             if (h > 0) {
               nav.style.setProperty('--dm-toc-mid-half-height', `${(h / 2).toFixed(2)}px`);
             }
             if (shell) {
-              const sp = options.activeScrollParent as Element;
               shell.style.minHeight = '';
               shell.style.minHeight = `${sp.scrollHeight}px`;
             }
@@ -475,6 +499,9 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
             // which self-clears any stale value before recomputing.
             if (state === 'expanded' && prevState !== 'expanded') {
               requestAnimationFrame(adjustCardPosition);
+              // Open the card at the first row; user scrolls for the rest.
+              const card = nav.querySelector<HTMLElement>(`.${CARD_CLASS}`);
+              if (card) card.scrollTop = 0;
             }
             prevState = state;
           };

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -314,7 +314,7 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
             }
             if (shell) {
               shell.style.minHeight = '';
-              shell.style.minHeight = `${sp.scrollHeight}px`;
+              shell.style.minHeight = `${String(sp.scrollHeight)}px`;
             }
           };
           if (isScrollContainer && typeof ResizeObserver !== 'undefined') {

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -33,8 +33,10 @@ export interface FloatingTocOutlineOptions {
   anchor: 'editor' | 'viewport';
   /**
    * Hide the outline when the document has fewer than this many
-   * headings - on a doc with one heading, the outline is just clutter.
-   * @default 2
+   * headings. Default `1` shows the outline as soon as any heading
+   * exists (matches Notion). Raise to `2` to suppress single-tick
+   * outlines on title-only documents.
+   * @default 1
    */
   minHeadings: number;
   /**
@@ -217,7 +219,7 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
   addOptions() {
     return {
       anchor: 'editor',
-      minHeadings: 2,
+      minHeadings: 1,
       mobileBreakpoint: 1024,
       activeRootMargin: '0px 0px -85% 0px',
       activeScrollParent: null,

--- a/packages/extension-toc/src/FloatingTocOutline.ts
+++ b/packages/extension-toc/src/FloatingTocOutline.ts
@@ -266,11 +266,57 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
             host.appendChild(nav);
           }
 
+          // Wiring a scrollable Element as `activeScrollParent` swaps the
+          // page-scroll sticky model for a container-scroll absolute model.
+          // Theme CSS keys off `data-scroll-mode`.
+          const isScrollContainer = options.activeScrollParent instanceof Element;
+          const scrollMode = isScrollContainer ? 'container' : 'page';
+          nav.dataset['scrollMode'] = scrollMode;
+          if (shell) shell.dataset['scrollMode'] = scrollMode;
+
+          // Container mode: absolute children of an overflow:auto element
+          // scroll WITH content, so we add scrollTop back into `top` to
+          // hold the nav at the host's visible middle. SHELL_TOP_OFFSET
+          // mirrors the `top: 25px` shell inset.
+          const SHELL_TOP_OFFSET = 25;
+          let containerScrollHandler: (() => void) | null = null;
+          let containerResizeObserver: ResizeObserver | null = null;
+          let containerRaf: number | null = null;
+          const recomputeContainerCenter = (): void => {
+            if (!isScrollContainer) return;
+            const sp = options.activeScrollParent as Element;
+            const h = nav.offsetHeight;
+            if (h <= 0) return;
+            const top = sp.scrollTop + sp.clientHeight / 2 - h / 2 - SHELL_TOP_OFFSET;
+            nav.style.top = `${top.toFixed(2)}px`;
+          };
+          if (isScrollContainer) {
+            const sp = options.activeScrollParent as Element;
+            const onScroll = (): void => {
+              if (containerRaf !== null) return;
+              containerRaf = requestAnimationFrame(() => {
+                containerRaf = null;
+                recomputeContainerCenter();
+              });
+            };
+            sp.addEventListener('scroll', onScroll, { passive: true });
+            containerScrollHandler = onScroll;
+            if (typeof ResizeObserver !== 'undefined') {
+              // Host drives the viewport; nav drives the offset (grows as
+              // ticks/headings are added).
+              containerResizeObserver = new ResizeObserver(() => { recomputeContainerCenter(); });
+              containerResizeObserver.observe(sp);
+              containerResizeObserver.observe(nav);
+            }
+            recomputeContainerCenter();
+          }
+
           let bottomObserver: IntersectionObserver | null = null;
           let bottomSentinel: HTMLElement | null = null;
           let recomputeMidTop: () => void = () => { /* no-op outside editor mode */ };
           if (
             options.anchor === 'editor'
+            && !isScrollContainer
             && shell
             && typeof IntersectionObserver !== 'undefined'
           ) {
@@ -618,6 +664,11 @@ export const FloatingTocOutline = Extension.create<FloatingTocOutlineOptions>({
               mq?.removeEventListener('change', onMqChange);
               window.removeEventListener('resize', onResize);
               window.removeEventListener('scroll', onWindowScroll);
+              if (containerScrollHandler && options.activeScrollParent instanceof Element) {
+                options.activeScrollParent.removeEventListener('scroll', containerScrollHandler);
+              }
+              containerResizeObserver?.disconnect();
+              if (containerRaf !== null) cancelAnimationFrame(containerRaf);
               tracker.destroy();
               unsubscribe?.();
               bottomObserver?.disconnect();

--- a/packages/extension-toc/src/TableOfContentsBlock.ts
+++ b/packages/extension-toc/src/TableOfContentsBlock.ts
@@ -10,6 +10,7 @@ import type { NodeViewConstructor } from '@domternal/pm/view';
 import { TextSelection } from '@domternal/pm/state';
 import { scrollToHeading } from './helpers/scrollToHeading.js';
 import { resolveUniqueIDAttrName } from './helpers/uniqueIDIntegration.js';
+import { getHeadingLabel, setActiveMarker } from './helpers/outlineDom.js';
 import type { TocStorage, HeadingEntry } from './types.js';
 
 export interface TableOfContentsBlockOptions {
@@ -74,7 +75,7 @@ function renderBlockContent(
     link.className = LINK_CLASS;
     link.dataset['level'] = String(entry.level);
     link.dataset[ANCHOR_DATASET_KEY] = entry.id;
-    link.textContent = entry.textContent.trim() || `Heading level ${String(entry.level)}`;
+    link.textContent = getHeadingLabel(entry);
 
     item.appendChild(link);
     list.appendChild(item);
@@ -83,20 +84,15 @@ function renderBlockContent(
 }
 
 /**
- * Toggle the active marker on every link button (carrying a
- * `data-toc-anchor` attribute). At most one link gets
- * `aria-current="location"` + the active class. Mirrors
- * `applyActiveMarker` in FloatingTocOutline so the inline block and
- * the floating outline reflect the same active heading.
+ * Apply the active marker to every link button (carrying a
+ * `data-toc-anchor` attribute). Thin wrapper over the shared
+ * `setActiveMarker` helper: queries every `.LINK_CLASS` and forwards
+ * the toggle work so this block stays in lockstep with the floating
+ * outline.
  */
 function applyActiveLink(wrapper: HTMLElement, activeId: string | null): void {
-  const links = wrapper.querySelectorAll<HTMLElement>(`.${LINK_CLASS}`);
-  for (const link of Array.from(links)) {
-    const isActive = activeId !== null && link.dataset[ANCHOR_DATASET_KEY] === activeId;
-    link.classList.toggle(ACTIVE_LINK_CLASS, isActive);
-    if (isActive) link.setAttribute('aria-current', 'location');
-    else link.removeAttribute('aria-current');
-  }
+  const links = Array.from(wrapper.querySelectorAll<HTMLElement>(`.${LINK_CLASS}`));
+  setActiveMarker(links, activeId, ACTIVE_LINK_CLASS);
 }
 
 /**

--- a/packages/extension-toc/src/helpers/outlineDom.ts
+++ b/packages/extension-toc/src/helpers/outlineDom.ts
@@ -1,0 +1,34 @@
+/**
+ * Small DOM helpers shared between the floating outline and the inline
+ * `<TableOfContentsBlock>` node view. Both render heading lists with
+ * the same fallback label and active-state semantics, so the logic
+ * lives here as a single source of truth.
+ */
+import type { HeadingEntry } from '../types.js';
+
+/**
+ * Display text for a heading entry. Falls back to a level-tagged
+ * placeholder when the heading is empty so the outline always has a
+ * non-empty label (and an accessible aria-label).
+ */
+export function getHeadingLabel(entry: HeadingEntry): string {
+  return entry.textContent.trim() || `Heading level ${String(entry.level)}`;
+}
+
+/**
+ * Toggle the active-state visual on a list of button elements. At
+ * most one item matches `activeId` (via `data-toc-anchor`) and gets
+ * `activeClass` + `aria-current="location"`; the rest are cleared.
+ */
+export function setActiveMarker(
+  items: HTMLElement[],
+  activeId: string | null,
+  activeClass: string,
+): void {
+  for (const item of items) {
+    const isActive = activeId !== null && item.dataset['tocAnchor'] === activeId;
+    item.classList.toggle(activeClass, isActive);
+    if (isActive) item.setAttribute('aria-current', 'location');
+    else item.removeAttribute('aria-current');
+  }
+}

--- a/packages/extension-toc/src/helpers/scrollToHeading.ts
+++ b/packages/extension-toc/src/helpers/scrollToHeading.ts
@@ -48,6 +48,11 @@ export interface ScrollToHeadingOptions {
    * @default 'id'
    */
   attrName?: string;
+  /**
+   * Scope the scroll to a specific container instead of bubbling up to
+   * the window. Pair with `FloatingTocOutline.activeScrollParent`.
+   */
+  scrollParent?: Element | null;
 }
 
 /**
@@ -108,7 +113,16 @@ export function scrollToHeading(
 
   const behavior: ScrollBehavior =
     options.behavior ?? (prefersReducedMotion() ? 'auto' : 'smooth');
-  target.scrollIntoView({ behavior, block: 'start' });
+  const scrollParent = options.scrollParent ?? null;
+  if (scrollParent instanceof Element) {
+    // Scoped scroll: only move `scrollParent`, do not bubble to window.
+    const targetRect = target.getBoundingClientRect();
+    const parentRect = scrollParent.getBoundingClientRect();
+    const top = scrollParent.scrollTop + (targetRect.top - parentRect.top);
+    scrollParent.scrollTo({ top, behavior });
+  } else {
+    target.scrollIntoView({ behavior, block: 'start' });
+  }
 
   if (options.updateHash !== false && typeof history !== 'undefined') {
     // Encode the id for the URL fragment. Default IDs are URL-safe

--- a/packages/theme/src/_base.scss
+++ b/packages/theme/src/_base.scss
@@ -19,6 +19,7 @@
 
   .ProseMirror {
     padding: var(--dm-editor-padding);
+    padding-top: calc(var(--dm-editor-padding) + var(--dm-editor-padding-top-extra, 0px));
     min-height: 6rem;
 
     &:focus-visible {

--- a/packages/theme/src/_block-handle.scss
+++ b/packages/theme/src/_block-handle.scss
@@ -50,6 +50,9 @@
 
 .dm-block-handle {
   position: absolute;
+  // Pin static position to parent top so the hidden box doesn't
+  // inflate parent scrollHeight. JS sets `top` inline on show.
+  top: 0;
   // Tokenised so demos with a centered narrower content column can move
   // the handle further out (e.g., `--dm-block-handle-left: -3.5rem`) to
   // place it fully in the surrounding whitespace. Default `-0.5rem` keeps

--- a/packages/theme/src/_block-handle.scss
+++ b/packages/theme/src/_block-handle.scss
@@ -192,8 +192,10 @@
 }
 
 // Hide the native dropcursor during a handle drag so it doesn't double up
-// with `.dm-block-drop-indicator`. Class is set by BlockHandle on dragstart
-// and cleared on dragend.
-.dm-block-handle-dragging .ProseMirror-dropcursor {
+// with `.dm-block-drop-indicator`. `prosemirror-dropcursor` emits one of
+// two classes depending on the drop target ('-block' between blocks,
+// '-inline' within inline content); both must be hidden.
+.dm-block-handle-dragging .prosemirror-dropcursor-block,
+.dm-block-handle-dragging .prosemirror-dropcursor-inline {
   display: none;
 }

--- a/packages/theme/src/_block-handle.scss
+++ b/packages/theme/src/_block-handle.scss
@@ -48,6 +48,14 @@
   }
 }
 
+// `_prosemirror.scss` draws a sharp 2px accent border on selected list
+// items via `li.ProseMirror-selectednode::after`. With BlockHandle the
+// translucent halo above is the canonical selection visual, so suppress
+// the list-item-specific border to avoid a doubled frame.
+.dm-editor--has-block-handle li.ProseMirror-selectednode::after {
+  display: none;
+}
+
 .dm-block-handle {
   position: absolute;
   // Pin static position to parent top so the hidden box doesn't

--- a/packages/theme/src/_bubble-menu.scss
+++ b/packages/theme/src/_bubble-menu.scss
@@ -32,6 +32,10 @@
   }
 
   position: absolute;
+  // Pin static position to parent top-left so the hidden box doesn't
+  // inflate parent scrollHeight. JS overrides on show.
+  top: 0;
+  left: 0;
   display: flex;
   align-items: center;
   gap: var(--dm-toolbar-gap);

--- a/packages/theme/src/_floating-menu.scss
+++ b/packages/theme/src/_floating-menu.scss
@@ -6,6 +6,11 @@
 
 .dm-floating-menu {
   position: absolute;
+  // Pin static position to parent top-left; otherwise the hidden box
+  // inherits an end-of-content static position and inflates parent
+  // scrollHeight. `positionFloating` overrides via transform on show.
+  top: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/packages/theme/src/_toc.scss
+++ b/packages/theme/src/_toc.scss
@@ -213,6 +213,26 @@
   border-radius: var(--dm-toc-card-radius, 6px);
   box-shadow: var(--dm-toc-card-shadow, 0 8px 24px rgba(0, 0, 0, 0.08));
 
+  // Tokenised slim scrollbar so dark theme overrides keep contrast.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.375rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
+
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/packages/theme/src/_toc.scss
+++ b/packages/theme/src/_toc.scss
@@ -5,13 +5,11 @@
 // =============================================================================
 
 .dm-toc-outline {
-  // Stack ticks vertically with even gaps. flex-end keeps the right
-  // edge of every tick aligned even though widths differ per level.
+  // Positioning wrapper. Inner `.dm-toc-outline-ticks` stacks + clips
+  // ticks; card is an absolute sibling, untouched by the clip.
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: var(--dm-toc-tick-gap, 10px);
-  padding: var(--dm-toc-padding-block, 12px) var(--dm-toc-padding-inline, 8px);
   z-index: var(--dm-toc-z-index, 10);
 
   // No background / no border in collapsed state - just a column of ticks.
@@ -110,6 +108,19 @@
   bottom: 0;
 }
 
+// Ticks column - capped at ~50% (Notion behavior): overflow simply
+// clips, gap stays constant, column doesn't scroll. Defaults to
+// `50vh` (page mode); container mode plugin overrides the var.
+.dm-toc-outline-ticks {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--dm-toc-tick-gap, 10px);
+  padding: var(--dm-toc-padding-block, 12px) var(--dm-toc-padding-inline, 8px);
+  max-height: var(--dm-toc-ticks-max-h, 50vh);
+  overflow: hidden;
+}
+
 .dm-toc-outline-tick {
   // Reset button defaults - we draw a solid filled rectangle.
   appearance: none;
@@ -119,6 +130,9 @@
   font: inherit;
   cursor: pointer;
   background: var(--dm-toc-tick-color, rgba(55, 53, 47, 0.4));
+  // Lock tick height so the gap stays constant; overflow is clipped
+  // by the wrapper instead of squeezed.
+  flex-shrink: 0;
   height: var(--dm-toc-tick-height, 2px);
   border-radius: var(--dm-toc-tick-radius, 1px);
   // Width per heading level - h1 widest, deeper levels narrower.
@@ -189,9 +203,9 @@
     translateX(var(--dm-toc-card-offset, 8px));
   min-width: var(--dm-toc-card-min-width, 180px);
   max-width: var(--dm-toc-card-max-width, 260px);
-  // Long heading lists scroll internally rather than overflowing the
-  // viewport; the margin keeps the card off the chrome edges.
-  max-height: calc(100vh - 2 * var(--dm-toc-card-viewport-margin, 16px));
+  // Card matches the ticks wrapper height; the rest of the rows
+  // are reachable by scrolling the card itself.
+  max-height: var(--dm-toc-ticks-max-h, 50vh);
   overflow-y: auto;
   padding: var(--dm-toc-card-padding-block, 6px) 0;
   background: var(--dm-toc-card-bg, rgba(255, 255, 255, 0.98));
@@ -232,6 +246,8 @@
   font-size: var(--dm-toc-row-font-size, 13px);
   line-height: var(--dm-toc-row-line-height, 1.4);
   color: var(--dm-toc-row-color, rgba(55, 53, 47, 0.7));
+  // Constant row height; long lists scroll the card, no squeeze.
+  flex-shrink: 0;
   padding:
     var(--dm-toc-row-padding-block, 4px)
     var(--dm-toc-row-padding-inline-end, 16px)

--- a/packages/theme/src/_toc.scss
+++ b/packages/theme/src/_toc.scss
@@ -44,6 +44,14 @@
   &[data-anchor='editor'][data-bottom-visible='true'] {
     top: var(--dm-toc-editor-top, 1rem);
   }
+  // `scroll-mode='container'`: host is its own scroll viewport. Plugin
+  // sets `top` inline on scroll/resize; `right: 0` keeps the nav inside
+  // the host (without it, the absolute nav's static position pokes past
+  // the host's right edge and triggers a horizontal scrollbar).
+  &[data-anchor='editor'][data-scroll-mode='container'] {
+    position: absolute;
+    right: 0;
+  }
   &[data-anchor='viewport'] {
     position: fixed;
     top: 50%;

--- a/packages/theme/src/_toc.scss
+++ b/packages/theme/src/_toc.scss
@@ -44,12 +44,12 @@
   &[data-anchor='editor'][data-bottom-visible='true'] {
     top: var(--dm-toc-editor-top, 1rem);
   }
-  // `scroll-mode='container'`: host is its own scroll viewport. Plugin
-  // sets `top` inline on scroll/resize; `right: 0` keeps the nav inside
-  // the host (without it, the absolute nav's static position pokes past
-  // the host's right edge and triggers a horizontal scrollbar).
+  // `scroll-mode='container'`: sticky pins the nav at the host's
+  // visible middle, zero JS during scroll. Plugin publishes
+  // `--dm-toc-mid-half-height` (= nav.offsetHeight / 2).
   &[data-anchor='editor'][data-scroll-mode='container'] {
-    position: absolute;
+    position: sticky;
+    top: calc(50% - var(--dm-toc-mid-half-height, 0px));
     right: 0;
   }
   &[data-anchor='viewport'] {
@@ -100,6 +100,14 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+}
+
+// `scroll-mode='container'`: shell spans the host (no top/bottom
+// inset) and is JS-stretched to host.scrollHeight so the sticky's
+// containing block covers the full scroll range.
+.dm-toc-outline-shell[data-anchor='editor'][data-scroll-mode='container'] {
+  top: 0;
+  bottom: 0;
 }
 
 .dm-toc-outline-tick {

--- a/packages/theme/src/_variables.scss
+++ b/packages/theme/src/_variables.scss
@@ -122,6 +122,7 @@
   --dm-editor-font-size: 1rem;
   --dm-editor-line-height: 1.6;
   --dm-editor-padding: 1rem;
+  --dm-editor-padding-top-extra: 0.5rem;
   --dm-editor-border: 1px solid var(--dm-border-color);
   --dm-editor-border-radius: 0.75rem;
   // Override to add a focus ring, e.g. 0 0 0 1px var(--dm-focus-color)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,50 +340,50 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@25.2.3)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.55.1)(sass@1.97.3)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.2.1)
       '@domternal/angular':
-        specifier: 0.7.0
-        version: 0.7.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))
+        specifier: workspace:*
+        version: link:../packages/angular
       '@domternal/core':
-        specifier: 0.7.0
-        version: 0.7.0(linkedom@0.18.12)
+        specifier: workspace:*
+        version: link:../packages/core
       '@domternal/extension-block-menu':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-block-menu
       '@domternal/extension-code-block-lowlight':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)(lowlight@3.3.0)
+        specifier: workspace:*
+        version: link:../packages/extension-code-block-lowlight
       '@domternal/extension-details':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-details
       '@domternal/extension-emoji':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-emoji
       '@domternal/extension-image':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-image
       '@domternal/extension-mention':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-mention
       '@domternal/extension-table':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-table
       '@domternal/extension-toc':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
+        specifier: workspace:*
+        version: link:../packages/extension-toc
       '@domternal/pm':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: workspace:*
+        version: link:../packages/pm
       '@domternal/react':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: workspace:*
+        version: link:../packages/react
       '@domternal/theme':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: workspace:*
+        version: link:../packages/theme
       '@domternal/vanilla':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))
+        specifier: workspace:*
+        version: link:../packages/vanilla
       '@domternal/vue':
-        specifier: 0.7.0
-        version: 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))(vue@3.5.32(typescript@5.9.3))
+        specifier: workspace:*
+        version: link:../packages/vue
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@8.0.7(@types/node@25.2.3)(esbuild@0.27.4)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(yaml@2.8.2))
@@ -1851,14 +1851,6 @@ packages:
       '@angular/forms': ^21.2.5
       '@domternal/core': '>=0.6.1'
 
-  '@domternal/angular@0.7.0':
-    resolution: {integrity: sha512-VJNPjGqO4hXUdLeGAqQ5US/k9zLRjeKtSBXwwJo10xHV1h9rzioxeXlDLG60JYVOTBnvZSaQBmgk745WNXYI7A==}
-    peerDependencies:
-      '@angular/core': ^21.2.5
-      '@angular/forms': ^21.2.5
-      '@domternal/core': '>=0.7.0'
-      '@domternal/extension-block-menu': '>=0.7.0'
-
   '@domternal/core@0.6.2':
     resolution: {integrity: sha512-64KqeNBupxrPWuUsOa3eOGYVrJ+vhObKRyMXx79+6vtT1pwstRnxlG9Q+xnj6m6L4kdpM2+FARQuxjgB7m48SA==}
     engines: {node: '>=20'}
@@ -1867,72 +1859,6 @@ packages:
     peerDependenciesMeta:
       linkedom:
         optional: true
-
-  '@domternal/core@0.7.0':
-    resolution: {integrity: sha512-L9MlmufvHi3QQdc62iBy3boXk/mEF1nyADsLgk4x94qagpY6bkvOsA17Qc73Jj7LkJvXjLCkbYBAy8BfNFj8qQ==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      linkedom: ^0.18.0
-    peerDependenciesMeta:
-      linkedom:
-        optional: true
-
-  '@domternal/extension-block-menu@0.7.0':
-    resolution: {integrity: sha512-DTG6xKVcLJ4qGWqv62W4D6Mt/p5LQV7lLtQnVOdMIQ3JsrjKZJN0mCdELgMLHfa+qBpOVIvBsObZ1GwElaEjSg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-code-block-lowlight@0.7.0':
-    resolution: {integrity: sha512-9idZ+Y466YiNqkPJ1d3U9MczrB6V2QXNrWWSgxf7C7s0ezeE8/3F5Fu1N7arKK2yyzeCPZLNFBVk4LorR+PNwA==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-      lowlight: ^3.0.0
-
-  '@domternal/extension-details@0.7.0':
-    resolution: {integrity: sha512-oT6CqA+ARP9GpBP/gMFBFr2YJIgXP2U15rtanvzkCZn0/3RR82otK1a2qhsmVjPCHymu8e3zpb+kYQNifzZQfg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-emoji@0.7.0':
-    resolution: {integrity: sha512-eXiCQSqJi+vnDl7uVfOfCbGGtnXHFkuZ/vRg7n2BQraftGoDxSj0gMk/sb4NzEZ9ZdsGoY0uUJn0urxgHJBpug==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-image@0.7.0':
-    resolution: {integrity: sha512-SrHPp4hu8lMvCADOxv4G6uQxenmBPmGeB+SrTYDYlT52TCdlj+H2EB4q7doLvZSrXxOsBDnX7Z+sAbgEzp0Hkg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-mention@0.7.0':
-    resolution: {integrity: sha512-ZdQxICSAyqLfDhFFOa2MIMy2LID/p9G/3GoxEcoBDW40MSd4Q2LVxLTQTQH+P6D4fVN196JXKxGCciUfD43LjQ==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-table@0.7.0':
-    resolution: {integrity: sha512-eu0wwL5XC6g7zfoiZNCHAI9y9jI5aBJGkN205YXPz0CJizSCGnhIkDtWV+gPjIqX0lxFJegynT+IZnAUeeO7Lg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
-
-  '@domternal/extension-toc@0.7.0':
-    resolution: {integrity: sha512-+FnNqQxBQ3wUXhGZx6IksBUuyCpJj+qBJGtSM4k2KYIZA9x250Hc35nPTIXN25HeJzrrtNmVdz1ecH2eFA3H/g==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/pm': '>=0.7.0'
 
   '@domternal/pm@0.7.0':
     resolution: {integrity: sha512-inZpurNRQG1SdR9LDYXfKet9ru4CUiiK6mqFYiOf1oaIGYxEjChas6dAgsIzrD7scD3LqkUvcg9bUECj7OWjSA==}
@@ -1944,37 +1870,13 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  '@domternal/react@0.7.0':
-    resolution: {integrity: sha512-JYQTGx+tMp7ex5cnQZ0iNMzOOAcQWntHHXGUuEuO3ucUMnLisG1lqopAri7NIT634x6PutRAj2ieDOFo3DwFug==}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/extension-block-menu': '>=0.7.0'
-      react: '>=18'
-      react-dom: '>=18'
-
   '@domternal/theme@0.6.2':
     resolution: {integrity: sha512-dOezxQwmakDBpx6sgwr6tGL/DP55Pu+NNDVsgUa5guTsYaWi7NS5LI0ymCdoSWnLI40oqKYClOo33ZPF4JB/Og==}
-
-  '@domternal/theme@0.7.0':
-    resolution: {integrity: sha512-4ptjBW3wlfMVCR1crgj4jn+zwuTPhWIURI7804ijXVVp5CcVINTEh78dMqApVTLLNcFxymW6GViUaQSfktNpqw==}
-
-  '@domternal/vanilla@0.7.0':
-    resolution: {integrity: sha512-bzyfVQEOxEpRpQ8zvgDiNlxihJeWEgPBaOFM3MvjnQ/qqefyjGtMPCHRgjgy+2C/yzkJoPsEs+kY+XfQT/KqXA==}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/extension-block-menu': '>=0.7.0'
 
   '@domternal/vue@0.6.2':
     resolution: {integrity: sha512-JeCCOaiorlFx29+ya7O+MN9mP/T5abnl03foCVAOrxMA/U7GhORgr3RtIRtgTDj8UkelLflR2qjcWq9fOdCCnA==}
     peerDependencies:
       '@domternal/core': '>=0.6.0'
-      vue: '>=3.3'
-
-  '@domternal/vue@0.7.0':
-    resolution: {integrity: sha512-83Hh8u6rQJYlxvbLXjR+47uOGdNKUPCDMVzoFVncXOCSvRc/1eqnqNEanDMOHykyE/W2aVWV8enBBDGHJJb0Zg==}
-    peerDependencies:
-      '@domternal/core': '>=0.7.0'
-      '@domternal/extension-block-menu': '>=0.7.0'
       vue: '>=3.3'
 
   '@emnapi/core@1.8.1':
@@ -4416,6 +4318,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-basic-ssl@2.1.4':
     resolution: {integrity: sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==}
@@ -9863,14 +9766,6 @@ snapshots:
       '@domternal/core': 0.6.2(linkedom@0.18.12)
       tslib: 2.8.1
 
-  '@domternal/angular@0.7.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))':
-    dependencies:
-      '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/forms': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/extension-block-menu': 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
-      tslib: 2.8.1
-
   '@domternal/core@0.6.2(linkedom@0.18.12)':
     dependencies:
       '@domternal/pm': 0.7.0
@@ -9878,56 +9773,6 @@ snapshots:
       linkifyjs: 4.3.2
     optionalDependencies:
       linkedom: 0.18.12
-
-  '@domternal/core@0.7.0(linkedom@0.18.12)':
-    dependencies:
-      '@domternal/pm': 0.7.0
-      '@floating-ui/dom': 1.7.5
-      linkifyjs: 4.3.2
-    optionalDependencies:
-      linkedom: 0.18.12
-
-  '@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-code-block-lowlight@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)(lowlight@3.3.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-      hast-util-to-html: 9.0.5
-      lowlight: 3.3.0
-
-  '@domternal/extension-details@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-emoji@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-image@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-mention@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-table@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
-
-  '@domternal/extension-toc@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/pm': 0.7.0
 
   '@domternal/pm@0.7.0':
     dependencies:
@@ -9950,32 +9795,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@domternal/react@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/extension-block-menu': 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   '@domternal/theme@0.6.2': {}
-
-  '@domternal/theme@0.7.0': {}
-
-  '@domternal/vanilla@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/extension-block-menu': 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
 
   '@domternal/vue@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))':
     dependencies:
       '@domternal/core': 0.6.2(linkedom@0.18.12)
       vue: 3.5.32(typescript@6.0.2)
-
-  '@domternal/vue@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/extension-block-menu@0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@domternal/core': 0.7.0(linkedom@0.18.12)
-      '@domternal/extension-block-menu': 0.7.0(@domternal/core@0.7.0(linkedom@0.18.12))(@domternal/pm@0.7.0)
-      vue: 3.5.32(typescript@5.9.3)
 
   '@emnapi/core@1.8.1':
     dependencies:


### PR DESCRIPTION
## Summary

Adds a Notion-style scrollable page wrapper and a matching `scroll-mode='container'` mode for `FloatingTocOutline` that keeps the outline anchored to the host viewport's vertical middle via CSS sticky. Brings full TOC + scrollable parity to React, Vue, and Angular demos. Bundles several fixes touched along the way, plus a round of refactor cleanup.

## Features

- **`@domternal/extension-toc`**: new `activeScrollParent` option on `FloatingTocOutline` enables `scroll-mode='container'`; CSS sticky pins the outline at the host's midpoint with zero JS during scroll. Tick column caps at ~50% of the host viewport with `overflow: hidden` (matches Notion behaviour); the hover card matches that height and scrolls its rows internally.
- **Demos (vanilla, React, Vue, Angular)**: new "Notion scrollable" mode toggle. The container caps height at 700px and scrolls internally; the TOC scroll-spy follows the host scroll, not the window.

## Fixes

- **`@domternal/theme` + `@domternal/extension-block-menu`**: BlockHandle `dragstart` now hides the native `prosemirror-dropcursor-block` / `-inline` element. The previous selector targeted `ProseMirror-dropcursor`, a class PM never emits, so both the custom and native indicators rendered at once. E2E regression coverage added across all 4 demos.
- **`@domternal/extension-toc`**: `FloatingTocOutline` default `minHeadings` lowered from 2 to 1 so the outline appears on a single-heading document (Notion parity). Click-to-scroll no longer bubbles to the window when `activeScrollParent` is set. Container-scroll mode pins absolute children to `top: 0` so the hidden BlockHandle box no longer inflates host `scrollHeight` (eliminates the ghost scroll).
- **`@domternal/theme`**: dark-mode scrollbar tokens applied to the TOC card and Notion scrollable container so contrast holds in dark mode. Suppressed the sharp 2px accent border on `li.ProseMirror-selectednode::after` when BlockHandle is active; the translucent halo is now the single source of truth for selection feedback.

## Refactor

- Extracted shared `getHeadingLabel` + `setActiveMarker` helpers between `FloatingTocOutline` and `TableOfContentsBlock` (new `packages/extension-toc/src/helpers/outlineDom.ts`).
- Extracted `clearTriggeredFlag` helper in `FloatingMenu` (deduplicates the dismiss-and-update branches).
- Switched the Angular demo's copy-link listeners to `AbortController` for parity with the other three demos; standardised `TOAST_MS[kind]` access pattern across all four.

## Verified

- `pnpm typecheck` on all touched packages and demos passes
- `pnpm test` passes in `extension-toc` and `extension-block-menu`
- Manual smoke of the "Notion style" + "Notion scrollable" modes in the vanilla demo: drag from BlockHandle, TOC tick click, hover panel scroll, dark-theme contrast
- New Playwright specs for the drop indicator regression across all 4 demos (`notion-drop-indicator.spec.ts`); existing Notion suites continue to pass
