### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.7.2 (2026-05-24)
+
+### Features
+
+- feat(extension-toc): `FloatingTocOutline.activeScrollParent` option enables `scroll-mode='container'`. The outline pins to the host viewport's vertical middle via CSS sticky (zero JS during scroll) and the scroll-spy follows the host scroll instead of the window. Pair with a fixed-height wrapper for Notion-style scrollable editors. (#86)
+- feat(extension-toc,theme): tick column caps at ~50% of the host viewport with `overflow: hidden` (matches Notion behaviour); the hover card matches that height and scrolls its rows internally. New `--dm-toc-ticks-max-h` token controls the cap. (#86)
+- feat(theme): new `--dm-editor-padding-top-extra` token adds a comfortable gap between the editor's top edge and the first row. Defaults to `1rem` and bumps automatically in Notion mode where there is no toolbar above the column. (#86)
+- feat(demo-vanilla,demo-react,demo-vue,demo-angular): "Notion scrollable" demo mode. Editor sits inside a fixed-height wrapper that scrolls internally; the TOC scroll-spy follows the host scroll, not the window. Full e2e parity across all four demos. (#86)
+
+### Fixes
+
+- fix(theme,extension-block-menu): BlockHandle `dragstart` now hides the native dropcursor element correctly. The previous selector targeted `.ProseMirror-dropcursor`, a class `prosemirror-dropcursor` v1.8+ does not emit, so both the custom and native indicators rendered at once during a handle drag. The hide rule now targets `prosemirror-dropcursor-block` and `prosemirror-dropcursor-inline`. E2E regression coverage added across all four demos. (#86)
+- fix(extension-toc): `FloatingTocOutline` default `minHeadings` lowered from 2 to 1 so the outline appears on a single-heading document (matches Notion). Click-to-scroll no longer bubbles to the window when `activeScrollParent` is set. (#86)
+- fix(extension-toc,theme): zero-jitter container scroll. Absolute UI children (BlockHandle, BubbleMenu, FloatingMenu) are pinned at `top: 0` so the hidden box doesn't inflate the host's `scrollHeight` and create a ghost scroll. (#86)
+- fix(theme): tokenised slim scrollbar on the TOC card and Notion scrollable container so contrast holds in dark mode. (#86)
+- fix(theme): suppressed the sharp 2px accent border on `li.ProseMirror-selectednode::after` when BlockHandle is active. The translucent halo is now the single source of truth for selection feedback so dragging a list item no longer shows a doubled frame. (#86)
+
+### Internal
+
+- refactor(extension-toc): extracted shared `getHeadingLabel` and `setActiveMarker` helpers used by both `FloatingTocOutline` and `TableOfContentsBlock`. (#86)
+- refactor(extension-block-menu): extracted `clearTriggeredFlag` helper in `FloatingMenu` (deduplicates the dismiss and update branches). (#86)
+- refactor(demos): standardised `TOAST_MS[kind]` access pattern across all four demos; Angular's copy-link listeners switched to `AbortController` for parity with the other three. (#86)
+
 ## 0.7.1 (2026-05-23)
 
 ### Features

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Block-menu UX extensions for Domternal editor - FloatingMenu, BlockHandle (hover gutter + drag), SlashCommand, ContextMenu, and keyboard reorder",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Releases v0.7.2: a patch release bundling the Notion scrollable mode + container scroll-spy TOC work that landed in #86, plus a round of theme polish and internal refactor cleanup. No breaking changes.

## Features

- **`@domternal/extension-toc`**: `FloatingTocOutline.activeScrollParent` option enables `scroll-mode='container'`. The outline pins to the host viewport's vertical middle via CSS sticky (zero JS during scroll) and the scroll-spy follows the host scroll instead of the window. Tick column now caps at ~50% of the host viewport with `overflow: hidden`; the hover card matches that height and scrolls its rows internally.
- **`@domternal/theme`**: new `--dm-editor-padding-top-extra` token adds a comfortable gap between the editor's top edge and the first row. Defaults to `1rem` and bumps automatically in Notion mode where there is no toolbar above the column.
- **Demos (vanilla, React, Vue, Angular)**: new "Notion scrollable" mode. Editor sits inside a fixed-height wrapper that scrolls internally; the TOC scroll-spy follows the host scroll, not the window. Full e2e parity across all four demos.

## Fixes

- **`@domternal/theme` + `@domternal/extension-block-menu`**: BlockHandle `dragstart` now hides the native dropcursor element correctly. The previous selector targeted `.ProseMirror-dropcursor`, a class `prosemirror-dropcursor` v1.8+ does not emit, so both indicators rendered at once during a handle drag. The hide rule now targets `prosemirror-dropcursor-block` and `prosemirror-dropcursor-inline`. E2E regression coverage added across all four demos.
- **`@domternal/extension-toc`**: `FloatingTocOutline` default `minHeadings` lowered from 2 to 1 so the outline appears on a single-heading document (matches Notion). Click-to-scroll no longer bubbles to the window when `activeScrollParent` is set. Zero-jitter container scroll: absolute UI children pinned at `top: 0` so the hidden box doesn't inflate the host's `scrollHeight`.
- **`@domternal/theme`**: tokenised slim scrollbar on the TOC card and Notion scrollable container so contrast holds in dark mode. Suppressed the sharp 2px accent border on `li.ProseMirror-selectednode::after` when BlockHandle is active; the translucent halo is now the single source of truth for selection feedback.

## Internal

- Extracted shared `getHeadingLabel` and `setActiveMarker` helpers used by both `FloatingTocOutline` and `TableOfContentsBlock`.
- Extracted `clearTriggeredFlag` helper in `FloatingMenu` (deduplicates dismiss + update branches).
- Standardised `TOAST_MS[kind]` access pattern across all four demos; Angular's copy-link listeners switched to `AbortController` for parity with the other three.