### PR TITLE
fix(theme): link and image popover visibility on light theme

### DIFF
--- a/packages/theme/src/_image.scss
+++ b/packages/theme/src/_image.scss
@@ -73,12 +73,15 @@
   }
 }
 
-// =============================================================================
-// Image Insert Popover (appended to document.body - same pattern as link popover)
-// =============================================================================
-// The popover JS copies the editor's `dm-theme-*` class onto the
-// popover so the dark-tokens cascade applies on the element itself.
-// All colours read from `--dm-*` tokens; no hardcoded theme values.
+// Popover mounts to `document.body`, outside the `.dm-editor` cascade where
+// `--dm-*` tokens live. Each var() carries a literal fallback so descendants
+// render correctly without depending on token cascade.
+$bg: var(--dm-bg, #ffffff);
+$text: var(--dm-text, #1a1a1a);
+$border: var(--dm-border-color, rgba(0, 0, 0, 0.18));
+$hover: var(--dm-hover, rgba(0, 0, 0, 0.04));
+$accent: var(--dm-accent, #2563eb);
+$shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
 
 .dm-image-popover {
   position: fixed;
@@ -86,13 +89,10 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem;
-  // Popover is appended to `document.body` so the `--dm-*` tokens (defined
-  // on `.dm-editor`) do NOT cascade here. Use literal values with token
-  // fallbacks so theming still works when consumers set tokens on `:root`.
-  background: var(--dm-bg, #ffffff);
-  border: 1px solid var(--dm-border-color, rgba(0, 0, 0, 0.18));
+  background: $bg;
+  border: 1px solid $border;
   border-radius: 0.375rem;
-  box-shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
+  box-shadow: $shadow;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;
@@ -107,18 +107,18 @@
 }
 
 .dm-image-popover-input {
-  border: 1px solid var(--dm-border-color);
-  border-radius: 0.25rem;
+  min-width: 14rem;
   padding: 0.25rem 0.5rem;
+  border: 1px solid $border;
+  border-radius: 0.25rem;
   font-size: 0.8125rem;
   font-family: inherit;
-  min-width: 14rem;
   outline: none;
-  background: var(--dm-bg);
-  color: var(--dm-text);
+  background: $bg;
+  color: $text;
 
   &:focus {
-    border-color: var(--dm-accent);
+    border-color: $accent;
   }
 }
 
@@ -132,16 +132,16 @@
   border: none;
   border-radius: 0.25rem;
   background: transparent;
-  color: var(--dm-text);
+  color: $text;
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
 
   &:hover {
-    background: var(--dm-hover);
+    background: $hover;
   }
 
   &:focus-visible {
-    outline: 2px solid var(--dm-accent);
+    outline: 2px solid $accent;
     outline-offset: 1px;
   }
 
@@ -153,7 +153,7 @@
 
 .dm-image-popover-apply:hover,
 .dm-image-popover-browse:hover {
-  color: var(--dm-accent);
+  color: $accent;
 }
 
 // Drag-and-drop overlay - shown when dragging image files over the editor

--- a/packages/theme/src/_image.scss
+++ b/packages/theme/src/_image.scss
@@ -86,10 +86,13 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem;
-  background: var(--dm-surface);
-  border: 1px solid var(--dm-border-color);
-  border-radius: 0.25rem;
-  box-shadow: var(--dm-popover-shadow, 0 4px 12px rgba(0, 0, 0, 0.12));
+  // Popover is appended to `document.body` so the `--dm-*` tokens (defined
+  // on `.dm-editor`) do NOT cascade here. Use literal values with token
+  // fallbacks so theming still works when consumers set tokens on `:root`.
+  background: var(--dm-bg, #ffffff);
+  border: 1px solid var(--dm-border-color, rgba(0, 0, 0, 0.18));
+  border-radius: 0.375rem;
+  box-shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;

--- a/packages/theme/src/_link-popover.scss
+++ b/packages/theme/src/_link-popover.scss
@@ -13,10 +13,13 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem;
-  background: var(--dm-surface);
-  border: 1px solid var(--dm-border-color);
-  border-radius: 0.25rem;
-  box-shadow: var(--dm-popover-shadow, 0 4px 12px rgba(0, 0, 0, 0.12));
+  // Popover is appended to `document.body` so the `--dm-*` tokens (defined
+  // on `.dm-editor`) do NOT cascade here. Use literal values with token
+  // fallbacks so theming still works when consumers set tokens on `:root`.
+  background: var(--dm-bg, #ffffff);
+  border: 1px solid var(--dm-border-color, rgba(0, 0, 0, 0.18));
+  border-radius: 0.375rem;
+  box-shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;

--- a/packages/theme/src/_link-popover.scss
+++ b/packages/theme/src/_link-popover.scss
@@ -1,11 +1,12 @@
-// =============================================================================
-// Link Popover Styles
-// =============================================================================
-// The popover is appended to document.body to escape overflow:hidden on
-// .dm-editor. The popover JS copies the editor's `dm-theme-*` class onto
-// the popover so the dark-tokens cascade applies on the element itself.
-// All colours read from `--dm-*` tokens; no hardcoded theme values.
-// =============================================================================
+// Popover mounts to `document.body`, outside the `.dm-editor` cascade where
+// `--dm-*` tokens live. Each var() carries a literal fallback so descendants
+// render correctly without depending on token cascade.
+$bg: var(--dm-bg, #ffffff);
+$text: var(--dm-text, #1a1a1a);
+$border: var(--dm-border-color, rgba(0, 0, 0, 0.18));
+$hover: var(--dm-hover, rgba(0, 0, 0, 0.04));
+$accent: var(--dm-accent, #2563eb);
+$shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
 
 .dm-link-popover {
   position: fixed;
@@ -13,13 +14,10 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem;
-  // Popover is appended to `document.body` so the `--dm-*` tokens (defined
-  // on `.dm-editor`) do NOT cascade here. Use literal values with token
-  // fallbacks so theming still works when consumers set tokens on `:root`.
-  background: var(--dm-bg, #ffffff);
-  border: 1px solid var(--dm-border-color, rgba(0, 0, 0, 0.18));
+  background: $bg;
+  border: 1px solid $border;
   border-radius: 0.375rem;
-  box-shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12));
+  box-shadow: $shadow;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;
@@ -34,18 +32,18 @@
 }
 
 .dm-link-popover-input {
-  border: 1px solid var(--dm-border-color);
-  border-radius: 0.25rem;
+  min-width: 14rem;
   padding: 0.25rem 0.5rem;
+  border: 1px solid $border;
+  border-radius: 0.25rem;
   font-size: 0.8125rem;
   font-family: inherit;
-  min-width: 14rem;
   outline: none;
-  background: var(--dm-bg);
-  color: var(--dm-text);
+  background: $bg;
+  color: $text;
 
   &:focus {
-    border-color: var(--dm-accent);
+    border-color: $accent;
   }
 }
 
@@ -59,16 +57,16 @@
   border: none;
   border-radius: 0.25rem;
   background: transparent;
-  color: var(--dm-text);
+  color: $text;
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
 
   &:hover {
-    background: var(--dm-hover);
+    background: $hover;
   }
 
   &:focus-visible {
-    outline: 2px solid var(--dm-accent);
+    outline: 2px solid $accent;
     outline-offset: 1px;
   }
 
@@ -79,17 +77,13 @@
 }
 
 .dm-link-popover-apply:hover {
-  color: var(--dm-accent);
+  color: $accent;
 }
 
-// `--dm-danger` is not a semantic token yet, hardcode for now and bump
-// when the design system introduces one.
 .dm-link-popover-remove:hover {
   color: #dc2626;
 }
 
-// Pending-link decoration - highlights the text range while the popover
-// input has focus (browser hides native selection on editor blur).
 .dm-link-pending {
   background-color: color-mix(in srgb, var(--dm-accent) 12%, transparent);
   border-radius: 1px;

--- a/packages/theme/src/_variables.scss
+++ b/packages/theme/src/_variables.scss
@@ -72,7 +72,7 @@
 
   // Shared drop shadow for popover surfaces (floating menu, slash command,
   // context menu). Override in dark theme for visibility on dark bg.
-  --dm-popover-shadow: 0 10px 25px rgba(0, 0, 0, 0.08), 0 4px 10px rgba(0, 0, 0, 0.04);
+  --dm-popover-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10px -2px rgba(0, 0, 0, 0.12);
   --dm-code-surface: #f0f0f0;
   --dm-code-color: inherit;
 


### PR DESCRIPTION
## Summary

Link and image popovers rendered with transparent background and no shadow on light theme, blending invisibly into the toolbar.

## Changes

Popovers mount to `document.body` to escape `overflow: hidden` on `.dm-editor`, but `--dm-*` tokens are only defined inside `.dm-editor` so they never cascade to body. Hoisted token fallbacks to SCSS variables at the top of `_link-popover.scss` and `_image.scss` (`$bg`, `$text`, `$border`, `$hover`, `$accent`, `$shadow`), each carrying both the cascade lookup and a literal fallback. Also strengthened the default `--dm-popover-shadow` so popovers lift visibly off the toolbar.