### PR TITLE
fix(extension-table): render table dropdowns inside editor container for modal compatibility

### DIFF
--- a/apps/demo-angular/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-angular/e2e/table-dropdown-in-dialog.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Verifies that table dropdowns render inside the `.dm-editor` container
+ * rather than `document.body`. When the editor sits inside a `<dialog>`
+ * top layer, a body-portaled dropdown ends up beneath the dialog backdrop
+ * and is hidden or unclickable. Reparenting into `.dm-editor` keeps the
+ * dropdown in the dialog's stacking context.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'domternal-editor .ProseMirror';
+const SIMPLE_TABLE =
+  '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table>';
+
+async function setContentAndFocus(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as unknown as { ng?: { getComponent?: (e: Element | null) => { editor?: { setContent: (h: string, e: boolean) => void; commands: { focus: () => void } } } } }).ng;
+    const comp = ng?.getComponent?.(el);
+    if (comp?.editor) {
+      comp.editor.setContent(h, false);
+      comp.editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectCells(page: Page, anchorIdx: number, headIdx: number) {
+  await page.evaluate(({ anchor, head }) => {
+    const el = document.querySelector('domternal-editor');
+    const ng = (window as unknown as { ng?: { getComponent?: (e: Element | null) => { editor?: { state: { doc: { descendants: (cb: (node: { type: { name: string } }, pos: number) => void) => void } }; commands: { setCellSelection: (args: { anchorCell: number; headCell: number }) => void } } } } }).ng;
+    const editor = ng?.getComponent?.(el)?.editor;
+    if (!editor) return;
+    const cells: number[] = [];
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        cells.push(pos);
+      }
+    });
+    if (cells[anchor] != null && cells[head] != null) {
+      editor.commands.setCellSelection({ anchorCell: cells[anchor], headCell: cells[head] });
+    }
+  }, { anchor: anchorIdx, head: headIdx });
+  await page.waitForTimeout(200);
+}
+
+async function moveEditorIntoDialog(page: Page) {
+  await page.evaluate(() => {
+    // In Angular `domternal-editor` IS the .dm-editor element (host class).
+    const editorEl = document.querySelector('domternal-editor');
+    if (!(editorEl instanceof HTMLElement)) return;
+    const dialog = document.createElement('dialog');
+    dialog.id = '__test-dialog__';
+    dialog.style.padding = '1rem';
+    dialog.style.width = '600px';
+    dialog.style.maxWidth = '90vw';
+    dialog.style.maxHeight = '90vh';
+    document.body.appendChild(dialog);
+    dialog.appendChild(editorEl);
+    dialog.showModal();
+  });
+  await page.waitForTimeout(100);
+}
+
+async function assertDropdownInsideEditorAndDialog(page: Page, selector: string) {
+  const dropdown = page.locator(selector);
+  await expect(dropdown).toBeVisible();
+  const checks = await dropdown.evaluate((el) => {
+    const editor = el.closest('.dm-editor');
+    const dialog = el.closest('dialog');
+    if (!editor || !dialog) return null;
+    const eRect = editor.getBoundingClientRect();
+    const ddRect = el.getBoundingClientRect();
+    return {
+      insideEditor: editor !== null,
+      insideDialog: dialog !== null,
+      notInBody: el.parentElement?.tagName !== 'BODY',
+      overlapsEditor:
+        ddRect.bottom > eRect.top &&
+        ddRect.top < eRect.bottom &&
+        ddRect.right > eRect.left &&
+        ddRect.left < eRect.right,
+    };
+  });
+  expect(checks).not.toBeNull();
+  if (!checks) return;
+  expect(checks.insideEditor).toBe(true);
+  expect(checks.insideDialog).toBe(true);
+  expect(checks.notInBody).toBe(true);
+  expect(checks.overlapsEditor).toBe(true);
+}
+
+test.describe('Table dropdown - editor inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('domternal-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('column dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('domternal-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-col-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('cell color dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    // Select AFTER the move so the cell toolbar's absolute position is
+    // computed against the editor's new layout inside the dialog.
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-dropdown');
+  });
+
+  test('cell alignment dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const alignBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').nth(1);
+    await alignBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-align-dropdown');
+  });
+});
+
+test.describe('Table dropdown - editor on normal page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    await page.locator('domternal-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+
+  test('cell color dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-cell-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+});

--- a/apps/demo-angular/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-angular/e2e/table-dropdown-in-dialog.spec.ts
@@ -181,3 +181,121 @@ test.describe('Table dropdown - editor on normal page', () => {
     expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
   });
 });
+
+// Functional behavior inside the dialog: the dropdown must not only render in
+// the right place but stay usable (insert/delete row, apply color, close on
+// Escape/outside-click). Run in every framework demo to confirm the wrapper's
+// event and re-render integration, not just the framework-agnostic core.
+test.describe('Table dropdown - functional behavior inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Escape closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('outside click closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    // Click a neutral spot on the editor surface, away from the dropdown.
+    await page.locator(editorSelector).click({ position: { x: 4, y: 4 } });
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('Insert Row Above actually inserts a row inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    // First menu item is "Insert Row Above".
+    await page.locator('.dm-table-controls-dropdown button').first().click();
+    await page.waitForTimeout(150);
+
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+
+  test('color swatch applies a background to the cell inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await page.locator('.dm-table-cell-dropdown .dm-color-swatch').first().click();
+    await page.waitForTimeout(150);
+
+    const bg = await page.locator('.dm-editor th, .dm-editor td').first().getAttribute('data-background');
+    expect(bg).toBeTruthy();
+  });
+});
+
+// The fix mounts the dropdown inside `.dm-editor` (which has `overflow: hidden`)
+// but positions it with `fixed`, so it escapes the editor's clip and stays
+// fully visible and clickable even when the row sits at the editor's edge.
+// Guards against the dropdown being cut off by the editor's overflow.
+test.describe('Table dropdown - not clipped by editor overflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown stays on-screen and clickable for a bottom-edge row', async ({ page }) => {
+    // The table is the only content, so the last row's handle sits near the
+    // editor's bottom edge; an absolutely-positioned dropdown would be clipped
+    // by `overflow: hidden`. With `fixed` it must remain on-screen and usable.
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').last().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Fully inside the viewport (flip/shift keeps it on-screen, not clipped).
+    const inViewport = await dropdown.evaluate((el) => {
+      const d = el.getBoundingClientRect();
+      return d.top >= -1 && d.left >= -1 && d.bottom <= window.innerHeight + 1 && d.right <= window.innerWidth + 1;
+    });
+    expect(inViewport).toBe(true);
+
+    // A menu item must be genuinely clickable - this is what failed when the
+    // dropdown was clipped by the editor's overflow. "Insert Row Above" adds a row.
+    await dropdown.locator('button').first().click();
+    await page.waitForTimeout(150);
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+});
+

--- a/apps/demo-react/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-react/e2e/table-dropdown-in-dialog.spec.ts
@@ -188,3 +188,120 @@ test.describe('Table dropdown - editor on normal page', () => {
     expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
   });
 });
+
+// Functional behavior inside the dialog: the dropdown must not only render in
+// the right place but stay usable (insert/delete row, apply color, close on
+// Escape/outside-click). Run in every framework demo to confirm the wrapper's
+// event and re-render integration, not just the framework-agnostic core.
+test.describe('Table dropdown - functional behavior inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Escape closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('outside click closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    // Click a neutral spot on the editor surface, away from the dropdown.
+    await page.locator(editorSelector).click({ position: { x: 4, y: 4 } });
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('Insert Row Above actually inserts a row inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    // First menu item is "Insert Row Above".
+    await page.locator('.dm-table-controls-dropdown button').first().click();
+    await page.waitForTimeout(150);
+
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+
+  test('color swatch applies a background to the cell inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await page.locator('.dm-table-cell-dropdown .dm-color-swatch').first().click();
+    await page.waitForTimeout(150);
+
+    const bg = await page.locator('.dm-editor th, .dm-editor td').first().getAttribute('data-background');
+    expect(bg).toBeTruthy();
+  });
+});
+
+// The fix mounts the dropdown inside `.dm-editor` (which has `overflow: hidden`)
+// but positions it with `fixed`, so it escapes the editor's clip and stays
+// fully visible and clickable even when the row sits at the editor's edge.
+// Guards against the dropdown being cut off by the editor's overflow.
+test.describe('Table dropdown - not clipped by editor overflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown stays on-screen and clickable for a bottom-edge row', async ({ page }) => {
+    // The table is the only content, so the last row's handle sits near the
+    // editor's bottom edge; an absolutely-positioned dropdown would be clipped
+    // by `overflow: hidden`. With `fixed` it must remain on-screen and usable.
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').last().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Fully inside the viewport (flip/shift keeps it on-screen, not clipped).
+    const inViewport = await dropdown.evaluate((el) => {
+      const d = el.getBoundingClientRect();
+      return d.top >= -1 && d.left >= -1 && d.bottom <= window.innerHeight + 1 && d.right <= window.innerWidth + 1;
+    });
+    expect(inViewport).toBe(true);
+
+    // A menu item must be genuinely clickable - this is what failed when the
+    // dropdown was clipped by the editor's overflow. "Insert Row Above" adds a row.
+    await dropdown.locator('button').first().click();
+    await page.waitForTimeout(150);
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+});

--- a/apps/demo-react/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-react/e2e/table-dropdown-in-dialog.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Verifies that table dropdowns render inside the `.dm-editor` container
+ * rather than `document.body`. When the editor sits inside a `<dialog>`
+ * top layer, a body-portaled dropdown ends up beneath the dialog backdrop
+ * and is hidden or unclickable. Reparenting into `.dm-editor` keeps the
+ * dropdown in the dialog's stacking context.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const SIMPLE_TABLE =
+  '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table>';
+
+async function setContentAndFocus(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        setContent: (h: string, emit: boolean) => void;
+        commands: { focus: () => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectCells(page: Page, anchorIdx: number, headIdx: number) {
+  await page.evaluate(({ anchor, head }) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        state: { doc: { descendants: (cb: (node: { type: { name: string } }, pos: number) => void) => void } };
+        commands: { setCellSelection: (args: { anchorCell: number; headCell: number }) => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (!editor) return;
+    const cells: number[] = [];
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        cells.push(pos);
+      }
+    });
+    if (cells[anchor] != null && cells[head] != null) {
+      editor.commands.setCellSelection({ anchorCell: cells[anchor], headCell: cells[head] });
+    }
+  }, { anchor: anchorIdx, head: headIdx });
+  await page.waitForTimeout(200);
+}
+
+async function moveEditorIntoDialog(page: Page) {
+  await page.evaluate(() => {
+    const editorEl = document.querySelector('.dm-editor');
+    if (!(editorEl instanceof HTMLElement)) return;
+    const dialog = document.createElement('dialog');
+    dialog.id = '__test-dialog__';
+    dialog.style.padding = '1rem';
+    dialog.style.width = '600px';
+    dialog.style.maxWidth = '90vw';
+    dialog.style.maxHeight = '90vh';
+    document.body.appendChild(dialog);
+    dialog.appendChild(editorEl);
+    dialog.showModal();
+  });
+  await page.waitForTimeout(100);
+}
+
+/** Verify the dropdown lives inside .dm-editor (and the dialog when present),
+ *  and its visual rect overlaps with the editor (not clipped outside). */
+async function assertDropdownInsideEditorAndDialog(page: Page, selector: string) {
+  const dropdown = page.locator(selector);
+  await expect(dropdown).toBeVisible();
+  const checks = await dropdown.evaluate((el) => {
+    const editor = el.closest('.dm-editor');
+    const dialog = el.closest('dialog');
+    if (!editor || !dialog) return null;
+    const eRect = editor.getBoundingClientRect();
+    const ddRect = el.getBoundingClientRect();
+    return {
+      insideEditor: editor !== null,
+      insideDialog: dialog !== null,
+      notInBody: el.parentElement?.tagName !== 'BODY',
+      overlapsEditor:
+        ddRect.bottom > eRect.top &&
+        ddRect.top < eRect.bottom &&
+        ddRect.right > eRect.left &&
+        ddRect.left < eRect.right,
+    };
+  });
+  expect(checks).not.toBeNull();
+  if (!checks) return;
+  expect(checks.insideEditor).toBe(true);
+  expect(checks.insideDialog).toBe(true);
+  expect(checks.notInBody).toBe(true);
+  expect(checks.overlapsEditor).toBe(true);
+}
+
+test.describe('Table dropdown - editor inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('column dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-col-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('cell color dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    // Select AFTER the move so the cell toolbar's absolute position is
+    // computed against the editor's new layout inside the dialog.
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-dropdown');
+  });
+
+  test('cell alignment dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const alignBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').nth(1);
+    await alignBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-align-dropdown');
+  });
+});
+
+test.describe('Table dropdown - editor on normal page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+
+  test('cell color dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-cell-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+});

--- a/apps/demo-vanilla/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-vanilla/e2e/table-dropdown-in-dialog.spec.ts
@@ -186,3 +186,121 @@ test.describe('Table dropdown - editor on normal page', () => {
     expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
   });
 });
+
+// Functional behavior inside the dialog: the dropdown must not only render in
+// the right place but stay usable (insert/delete row, apply color, close on
+// Escape/outside-click). Run in every framework demo to confirm the wrapper's
+// event and re-render integration, not just the framework-agnostic core.
+test.describe('Table dropdown - functional behavior inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Escape closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('outside click closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    // Click a neutral spot on the editor surface, away from the dropdown.
+    await page.locator(editorSelector).click({ position: { x: 4, y: 4 } });
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('Insert Row Above actually inserts a row inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    // First menu item is "Insert Row Above".
+    await page.locator('.dm-table-controls-dropdown button').first().click();
+    await page.waitForTimeout(150);
+
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+
+  test('color swatch applies a background to the cell inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await page.locator('.dm-table-cell-dropdown .dm-color-swatch').first().click();
+    await page.waitForTimeout(150);
+
+    const bg = await page.locator('.dm-editor th, .dm-editor td').first().getAttribute('data-background');
+    expect(bg).toBeTruthy();
+  });
+});
+
+// The fix mounts the dropdown inside `.dm-editor` (which has `overflow: hidden`)
+// but positions it with `fixed`, so it escapes the editor's clip and stays
+// fully visible and clickable even when the row sits at the editor's edge.
+// Guards against the dropdown being cut off by the editor's overflow.
+test.describe('Table dropdown - not clipped by editor overflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown stays on-screen and clickable for a bottom-edge row', async ({ page }) => {
+    // The table is the only content, so the last row's handle sits near the
+    // editor's bottom edge; an absolutely-positioned dropdown would be clipped
+    // by `overflow: hidden`. With `fixed` it must remain on-screen and usable.
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').last().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Fully inside the viewport (flip/shift keeps it on-screen, not clipped).
+    const inViewport = await dropdown.evaluate((el) => {
+      const d = el.getBoundingClientRect();
+      return d.top >= -1 && d.left >= -1 && d.bottom <= window.innerHeight + 1 && d.right <= window.innerWidth + 1;
+    });
+    expect(inViewport).toBe(true);
+
+    // A menu item must be genuinely clickable - this is what failed when the
+    // dropdown was clipped by the editor's overflow. "Insert Row Above" adds a row.
+    await dropdown.locator('button').first().click();
+    await page.waitForTimeout(150);
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+});
+

--- a/apps/demo-vanilla/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-vanilla/e2e/table-dropdown-in-dialog.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Verifies that table dropdowns render inside the `.dm-editor` container
+ * rather than `document.body`. When the editor sits inside a `<dialog>`
+ * top layer, a body-portaled dropdown ends up beneath the dialog backdrop
+ * and is hidden or unclickable. Reparenting into `.dm-editor` keeps the
+ * dropdown in the dialog's stacking context.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const SIMPLE_TABLE =
+  '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table>';
+
+async function setContentAndFocus(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        setContent: (h: string, emit: boolean) => void;
+        commands: { focus: () => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectCells(page: Page, anchorIdx: number, headIdx: number) {
+  await page.evaluate(({ anchor, head }) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        state: { doc: { descendants: (cb: (node: { type: { name: string } }, pos: number) => void) => void } };
+        commands: { setCellSelection: (args: { anchorCell: number; headCell: number }) => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (!editor) return;
+    const cells: number[] = [];
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        cells.push(pos);
+      }
+    });
+    if (cells[anchor] != null && cells[head] != null) {
+      editor.commands.setCellSelection({ anchorCell: cells[anchor], headCell: cells[head] });
+    }
+  }, { anchor: anchorIdx, head: headIdx });
+  await page.waitForTimeout(200);
+}
+
+async function moveEditorIntoDialog(page: Page) {
+  await page.evaluate(() => {
+    const editorEl = document.querySelector('.dm-editor');
+    if (!(editorEl instanceof HTMLElement)) return;
+    const dialog = document.createElement('dialog');
+    dialog.id = '__test-dialog__';
+    dialog.style.padding = '1rem';
+    dialog.style.width = '600px';
+    dialog.style.maxWidth = '90vw';
+    dialog.style.maxHeight = '90vh';
+    document.body.appendChild(dialog);
+    dialog.appendChild(editorEl);
+    dialog.showModal();
+  });
+  await page.waitForTimeout(100);
+}
+
+async function assertDropdownInsideEditorAndDialog(page: Page, selector: string) {
+  const dropdown = page.locator(selector);
+  await expect(dropdown).toBeVisible();
+  const checks = await dropdown.evaluate((el) => {
+    const editor = el.closest('.dm-editor');
+    const dialog = el.closest('dialog');
+    if (!editor || !dialog) return null;
+    const eRect = editor.getBoundingClientRect();
+    const ddRect = el.getBoundingClientRect();
+    return {
+      insideEditor: editor !== null,
+      insideDialog: dialog !== null,
+      notInBody: el.parentElement?.tagName !== 'BODY',
+      overlapsEditor:
+        ddRect.bottom > eRect.top &&
+        ddRect.top < eRect.bottom &&
+        ddRect.right > eRect.left &&
+        ddRect.left < eRect.right,
+    };
+  });
+  expect(checks).not.toBeNull();
+  if (!checks) return;
+  expect(checks.insideEditor).toBe(true);
+  expect(checks.insideDialog).toBe(true);
+  expect(checks.notInBody).toBe(true);
+  expect(checks.overlapsEditor).toBe(true);
+}
+
+test.describe('Table dropdown - editor inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('column dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-col-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('cell color dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    // Select AFTER the move so the cell toolbar's absolute position is
+    // computed against the editor's new layout inside the dialog.
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-dropdown');
+  });
+
+  test('cell alignment dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const alignBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').nth(1);
+    await alignBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-align-dropdown');
+  });
+});
+
+test.describe('Table dropdown - editor on normal page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+
+  test('cell color dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-cell-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+});

--- a/apps/demo-vue/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-vue/e2e/table-dropdown-in-dialog.spec.ts
@@ -186,3 +186,121 @@ test.describe('Table dropdown - editor on normal page', () => {
     expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
   });
 });
+
+// Functional behavior inside the dialog: the dropdown must not only render in
+// the right place but stay usable (insert/delete row, apply color, close on
+// Escape/outside-click). Run in every framework demo to confirm the wrapper's
+// event and re-render integration, not just the framework-agnostic core.
+test.describe('Table dropdown - functional behavior inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Escape closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('outside click closes the row dropdown inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.dm-table-controls-dropdown')).toBeVisible();
+
+    // Click a neutral spot on the editor surface, away from the dropdown.
+    await page.locator(editorSelector).click({ position: { x: 4, y: 4 } });
+    await page.waitForTimeout(100);
+    await expect(page.locator('.dm-table-controls-dropdown')).toHaveCount(0);
+  });
+
+  test('Insert Row Above actually inserts a row inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    // First menu item is "Insert Row Above".
+    await page.locator('.dm-table-controls-dropdown button').first().click();
+    await page.waitForTimeout(150);
+
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+
+  test('color swatch applies a background to the cell inside the dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await page.locator('.dm-table-cell-dropdown .dm-color-swatch').first().click();
+    await page.waitForTimeout(150);
+
+    const bg = await page.locator('.dm-editor th, .dm-editor td').first().getAttribute('data-background');
+    expect(bg).toBeTruthy();
+  });
+});
+
+// The fix mounts the dropdown inside `.dm-editor` (which has `overflow: hidden`)
+// but positions it with `fixed`, so it escapes the editor's clip and stays
+// fully visible and clickable even when the row sits at the editor's edge.
+// Guards against the dropdown being cut off by the editor's overflow.
+test.describe('Table dropdown - not clipped by editor overflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown stays on-screen and clickable for a bottom-edge row', async ({ page }) => {
+    // The table is the only content, so the last row's handle sits near the
+    // editor's bottom edge; an absolutely-positioned dropdown would be clipped
+    // by `overflow: hidden`. With `fixed` it must remain on-screen and usable.
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    const before = await page.locator('.dm-editor tr').count();
+    await page.locator('.dm-editor td').last().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Fully inside the viewport (flip/shift keeps it on-screen, not clipped).
+    const inViewport = await dropdown.evaluate((el) => {
+      const d = el.getBoundingClientRect();
+      return d.top >= -1 && d.left >= -1 && d.bottom <= window.innerHeight + 1 && d.right <= window.innerWidth + 1;
+    });
+    expect(inViewport).toBe(true);
+
+    // A menu item must be genuinely clickable - this is what failed when the
+    // dropdown was clipped by the editor's overflow. "Insert Row Above" adds a row.
+    await dropdown.locator('button').first().click();
+    await page.waitForTimeout(150);
+    const after = await page.locator('.dm-editor tr').count();
+    expect(after).toBe(before + 1);
+  });
+});
+

--- a/apps/demo-vue/e2e/table-dropdown-in-dialog.spec.ts
+++ b/apps/demo-vue/e2e/table-dropdown-in-dialog.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Verifies that table dropdowns render inside the `.dm-editor` container
+ * rather than `document.body`. When the editor sits inside a `<dialog>`
+ * top layer, a body-portaled dropdown ends up beneath the dialog backdrop
+ * and is hidden or unclickable. Reparenting into `.dm-editor` keeps the
+ * dropdown in the dialog's stacking context.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+const SIMPLE_TABLE =
+  '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table>';
+
+async function setContentAndFocus(page: Page, html: string) {
+  await page.evaluate((h) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        setContent: (h: string, emit: boolean) => void;
+        commands: { focus: () => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (editor) {
+      editor.setContent(h, false);
+      editor.commands.focus();
+    }
+  }, html);
+  await page.waitForTimeout(150);
+}
+
+async function selectCells(page: Page, anchorIdx: number, headIdx: number) {
+  await page.evaluate(({ anchor, head }) => {
+    const editor = (window as unknown as {
+      __DEMO_EDITOR__?: {
+        state: { doc: { descendants: (cb: (node: { type: { name: string } }, pos: number) => void) => void } };
+        commands: { setCellSelection: (args: { anchorCell: number; headCell: number }) => void };
+      };
+    }).__DEMO_EDITOR__;
+    if (!editor) return;
+    const cells: number[] = [];
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
+        cells.push(pos);
+      }
+    });
+    if (cells[anchor] != null && cells[head] != null) {
+      editor.commands.setCellSelection({ anchorCell: cells[anchor], headCell: cells[head] });
+    }
+  }, { anchor: anchorIdx, head: headIdx });
+  await page.waitForTimeout(200);
+}
+
+async function moveEditorIntoDialog(page: Page) {
+  await page.evaluate(() => {
+    const editorEl = document.querySelector('.dm-editor');
+    if (!(editorEl instanceof HTMLElement)) return;
+    const dialog = document.createElement('dialog');
+    dialog.id = '__test-dialog__';
+    dialog.style.padding = '1rem';
+    dialog.style.width = '600px';
+    dialog.style.maxWidth = '90vw';
+    dialog.style.maxHeight = '90vh';
+    document.body.appendChild(dialog);
+    dialog.appendChild(editorEl);
+    dialog.showModal();
+  });
+  await page.waitForTimeout(100);
+}
+
+async function assertDropdownInsideEditorAndDialog(page: Page, selector: string) {
+  const dropdown = page.locator(selector);
+  await expect(dropdown).toBeVisible();
+  const checks = await dropdown.evaluate((el) => {
+    const editor = el.closest('.dm-editor');
+    const dialog = el.closest('dialog');
+    if (!editor || !dialog) return null;
+    const eRect = editor.getBoundingClientRect();
+    const ddRect = el.getBoundingClientRect();
+    return {
+      insideEditor: editor !== null,
+      insideDialog: dialog !== null,
+      notInBody: el.parentElement?.tagName !== 'BODY',
+      overlapsEditor:
+        ddRect.bottom > eRect.top &&
+        ddRect.top < eRect.bottom &&
+        ddRect.right > eRect.left &&
+        ddRect.left < eRect.right,
+    };
+  });
+  expect(checks).not.toBeNull();
+  if (!checks) return;
+  expect(checks.insideEditor).toBe(true);
+  expect(checks.insideDialog).toBe(true);
+  expect(checks.notInBody).toBe(true);
+  expect(checks.overlapsEditor).toBe(true);
+}
+
+test.describe('Table dropdown - editor inside <dialog>', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('column dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-col-handle').click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-controls-dropdown');
+  });
+
+  test('cell color dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    // Select AFTER the move so the cell toolbar's absolute position is
+    // computed against the editor's new layout inside the dialog.
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-dropdown');
+  });
+
+  test('cell alignment dropdown renders inside .dm-editor and dialog', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await moveEditorIntoDialog(page);
+    await selectCells(page, 0, 1);
+
+    const alignBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').nth(1);
+    await alignBtn.click();
+    await page.waitForTimeout(150);
+
+    await assertDropdownInsideEditorAndDialog(page, '.dm-table-cell-align-dropdown');
+  });
+});
+
+test.describe('Table dropdown - editor on normal page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('row dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+
+    await page.locator('.dm-editor td').first().hover();
+    await page.waitForTimeout(150);
+    await page.locator('.dm-table-row-handle').click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-controls-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+
+  test('cell color dropdown is not portaled to body', async ({ page }) => {
+    await setContentAndFocus(page, SIMPLE_TABLE);
+    await selectCells(page, 0, 1);
+
+    const colorBtn = page.locator('.dm-table-cell-toolbar .dm-table-cell-toolbar-btn').first();
+    await colorBtn.click();
+    await page.waitForTimeout(150);
+
+    const dropdown = page.locator('.dm-table-cell-dropdown');
+    await expect(dropdown).toBeVisible();
+    expect(await dropdown.evaluate((el) => el.closest('.dm-editor') !== null)).toBe(true);
+    expect(await dropdown.evaluate((el) => el.parentElement?.tagName !== 'BODY')).toBe(true);
+  });
+});

--- a/packages/extension-table/src/TableView.test.ts
+++ b/packages/extension-table/src/TableView.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { Document, Text, Paragraph, Editor } from '@domternal/core';
 import {
   CellSelection,
@@ -543,6 +543,84 @@ describe('TableView', () => {
         // @ts-expect-error - private method
         view.closeDropdown();
       }).not.toThrow();
+    });
+
+    it('falls back to document.body when no .dm-editor ancestor exists', () => {
+      // host has no `dm-editor` class, so closest('.dm-editor') is null.
+      editor = new Editor({
+        element: host,
+        extensions: allExtensions,
+        content: '<table><tr><td><p>A</p></td></tr></table>',
+      });
+      const view = getTableView(editor)!;
+      // @ts-expect-error - private method
+      view.showDropdown('row');
+
+      const dropdown = document.querySelector('.dm-table-controls-dropdown');
+      expect(dropdown?.parentElement).toBe(document.body);
+    });
+
+    it('dropdown is a descendant of the theme-classed editor so tokens cascade', () => {
+      // copyThemeClass() was removed: theme custom properties now reach the
+      // dropdown purely because it is a DOM descendant of the themed editor.
+      host.className = 'dm-editor dm-theme-dark';
+      editor = new Editor({
+        element: host,
+        extensions: allExtensions,
+        content: '<table><tr><td><p>A</p></td></tr></table>',
+      });
+      const view = getTableView(editor)!;
+      // @ts-expect-error - private method
+      view.showDropdown('row');
+
+      const dropdown = document.querySelector('.dm-table-controls-dropdown');
+      expect(dropdown?.closest('.dm-theme-dark')).toBe(host);
+    });
+  });
+
+  describe('floating cleanup (autoUpdate teardown)', () => {
+    it('closeDropdown invokes the floating-ui cleanup and clears the ref', () => {
+      host.className = 'dm-editor';
+      editor = new Editor({
+        element: host,
+        extensions: allExtensions,
+        content: '<table><tr><td><p>A</p></td></tr></table>',
+      });
+      const view = getTableView(editor)!;
+      // @ts-expect-error - private method
+      view.showDropdown('row');
+
+      const cleanup = vi.fn();
+      // @ts-expect-error - private field: swap the real autoUpdate cleanup for a spy
+      view.dropdownCleanup = cleanup;
+
+      // @ts-expect-error - private method
+      view.closeDropdown();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      // @ts-expect-error - private field
+      expect(view.dropdownCleanup).toBeNull();
+    });
+
+    it('NodeView destroy tears down an open dropdown and its floating cleanup', () => {
+      host.className = 'dm-editor';
+      editor = new Editor({
+        element: host,
+        extensions: allExtensions,
+        content: '<table><tr><td><p>A</p></td></tr></table>',
+      });
+      const view = getTableView(editor)!;
+      // @ts-expect-error - private method
+      view.showDropdown('row');
+
+      const cleanup = vi.fn();
+      // @ts-expect-error - private field
+      view.dropdownCleanup = cleanup;
+
+      editor.destroy();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(document.querySelector('.dm-table-controls-dropdown')).toBeNull();
     });
   });
 

--- a/packages/extension-table/src/TableView.test.ts
+++ b/packages/extension-table/src/TableView.test.ts
@@ -442,7 +442,7 @@ describe('TableView', () => {
   });
 
   describe('showDropdown / closeDropdown', () => {
-    it('showDropdown creates a row dropdown appended to body', () => {
+    it('showDropdown creates a row dropdown', () => {
       editor = new Editor({
         element: host,
         extensions: allExtensions,
@@ -511,6 +511,24 @@ describe('TableView', () => {
       const dropdowns = document.querySelectorAll('.dm-table-controls-dropdown');
       expect(dropdowns.length).toBe(1);
       expect(dropdowns[0]?.getAttribute('aria-label')).toBe('Column options');
+    });
+
+    it('showDropdown mounts the dropdown inside .dm-editor when present', () => {
+      host.className = 'dm-editor';
+      editor = new Editor({
+        element: host,
+        extensions: allExtensions,
+        content: '<table><tr><td><p>A</p></td></tr></table>',
+      });
+      const view = getTableView(editor)!;
+      // @ts-expect-error - private method
+      view.hoveredRow = 0;
+      // @ts-expect-error - private method
+      view.showDropdown('row');
+
+      const dropdown = host.querySelector('.dm-table-controls-dropdown');
+      expect(dropdown).not.toBeNull();
+      expect(dropdown?.parentElement).toBe(host);
     });
 
     it('closeDropdown does nothing if no dropdown exists', () => {
@@ -1301,43 +1319,6 @@ describe('TableView', () => {
       // Cell should now be tableHeader
       const cell = editor.state.doc.firstChild?.firstChild?.firstChild;
       expect(cell?.type.name).toBe('tableHeader');
-    });
-  });
-
-  describe('copyThemeClass', () => {
-    it('copies dm-theme-* classes from ancestor to dropdown', () => {
-      // The editor wrapper must have dm-editor class, and an ancestor with dm-theme-*
-      host.className = 'dm-theme-light dm-editor';
-
-      editor = new Editor({
-        element: host,
-        extensions: allExtensions,
-        content: '<table><tr><td><p>A</p></td></tr></table>',
-      });
-      const view = getTableView(editor)!;
-
-      const testDropdown = document.createElement('div');
-      // @ts-expect-error - private method
-      view.copyThemeClass(testDropdown);
-
-      expect(testDropdown.classList.contains('dm-theme-light')).toBe(true);
-    });
-
-    it('does nothing when no .dm-editor ancestor exists', () => {
-      editor = new Editor({
-        element: host,
-        extensions: allExtensions,
-        content: '<table><tr><td><p>A</p></td></tr></table>',
-      });
-      const view = getTableView(editor)!;
-
-      const testDropdown = document.createElement('div');
-      const priorClassCount = testDropdown.classList.length;
-      // @ts-expect-error - private method
-      view.copyThemeClass(testDropdown);
-
-      // No theme class → no change
-      expect(testDropdown.classList.length).toBe(priorClassCount);
     });
   });
 

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -28,7 +28,7 @@ import {
   isInTable,
   selectedRect,
 } from '@domternal/pm/tables';
-import { positionFloatingOnce } from '@domternal/core';
+import { positionFloating } from '@domternal/core';
 
 import { constrainedAddColumn } from './helpers/constrainedColumn.js';
 
@@ -763,13 +763,20 @@ export class TableView implements NodeView {
   }
 
   /**
-   * Mount the dropdown inside `.dm-editor` (matching BubbleMenu pattern).
-   * Rendering inside the editor keeps the dropdown inside the modal/dialog
-   * stacking context when the editor is portaled to one - appending to
-   * document.body would hide it beneath a top-layer <dialog>.
+   * Mount the dropdown inside `.dm-editor` and position it with `fixed`.
+   *
+   * Two constraints have to hold at once:
+   * - The dropdown must be a DOM descendant of the editor so that, when the
+   *   editor is portaled into a modal `<dialog>` (top layer), the dropdown
+   *   paints in the same top layer rather than beneath the dialog. Appending
+   *   to document.body would hide it under the dialog.
+   * - `.dm-editor` has `overflow: hidden`, which would clip an absolutely
+   *   positioned child that extends past the editor box. `position: fixed`
+   *   uses the viewport as its containing block, so it escapes that clip
+   *   while still living inside the dialog subtree.
    */
   private mountDropdown(dropdown: HTMLElement, anchor: HTMLElement, placement: 'bottom-start' | 'bottom'): void {
-    dropdown.style.position = 'absolute';
+    dropdown.style.position = 'fixed';
     dropdown.style.left = '0';
     dropdown.style.top = '0';
 
@@ -777,7 +784,7 @@ export class TableView implements NodeView {
     (editorEl ?? document.body).appendChild(dropdown);
     this.dropdown = dropdown;
 
-    this.dropdownCleanup = positionFloatingOnce(anchor, dropdown, { placement, offsetValue: 4 });
+    this.dropdownCleanup = positionFloating(anchor, dropdown, { placement, offsetValue: 4 });
     this.addDropdownListeners();
   }
 

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -28,6 +28,7 @@ import {
   isInTable,
   selectedRect,
 } from '@domternal/pm/tables';
+import { positionFloatingOnce } from '@domternal/core';
 
 import { constrainedAddColumn } from './helpers/constrainedColumn.js';
 
@@ -73,6 +74,7 @@ export class TableView implements NodeView {
   private cellHandle: HTMLButtonElement;
   private cellHandleCell: HTMLTableCellElement | null = null;
   private dropdown: HTMLElement | null = null;
+  private dropdownCleanup: (() => void) | null = null;
   /** When true, the plugin skips showing the cell toolbar (row/col dropdown is open). */
   suppressCellToolbar = false;
   /** When true, column resize drag is active - all handles/menus are hidden. */
@@ -89,7 +91,6 @@ export class TableView implements NodeView {
   private boundCancelHide: () => void;
   private boundDocMouseDown: (e: MouseEvent) => void;
   private boundDocKeyDown: (e: KeyboardEvent) => void;
-  private boundScroll: () => void;
 
   constructor(node: PMNode, cellMinWidth: number, view: EditorView, defaultCellMinWidth = 100, constrainToContainer = true) {
     this.node = node;
@@ -104,7 +105,6 @@ export class TableView implements NodeView {
     this.boundCancelHide = this.cancelHide.bind(this);
     this.boundDocMouseDown = this.onDocMouseDown.bind(this);
     this.boundDocKeyDown = this.onDocKeyDown.bind(this);
-    this.boundScroll = () => { this.closeDropdown(); };
     // Create outer container (position: relative, overflow: visible)
     this.dom = document.createElement('div');
     this.dom.className = 'dm-table-container';
@@ -636,17 +636,8 @@ export class TableView implements NodeView {
       dropdown.appendChild(btn);
     }
 
-    // Position below the handle - fixed to viewport so it escapes overflow containers
     const handle = type === 'row' ? this.rowHandle : this.colHandle;
-    const handleRect = handle.getBoundingClientRect();
-    dropdown.style.position = 'fixed';
-    dropdown.style.left = String(handleRect.left) + 'px';
-    dropdown.style.top = String(handleRect.bottom + 4) + 'px';
-
-    this.copyThemeClass(dropdown);
-    document.body.appendChild(dropdown);
-    this.dropdown = dropdown;
-    this.addDropdownListeners();
+    this.mountDropdown(dropdown, handle, 'bottom-start');
   }
 
   // ─── Cell toolbar dropdowns ──────────────────────────────────────────
@@ -768,59 +759,45 @@ export class TableView implements NodeView {
   }
 
   private positionToolbarDropdown(dropdown: HTMLElement, triggerBtn: HTMLButtonElement): void {
-    const btnRect = triggerBtn.getBoundingClientRect();
-
-    // Fixed position so dropdown escapes overflow containers
-    dropdown.style.position = 'fixed';
-    dropdown.style.top = String(btnRect.bottom + 4) + 'px';
-
-    // Append to body first to measure
-    this.copyThemeClass(dropdown);
-    document.body.appendChild(dropdown);
-    this.dropdown = dropdown;
-
-    // Try left-aligned to button; if overflows viewport, shift left
-    const dropdownWidth = dropdown.offsetWidth;
-    let leftPos = btnRect.left;
-    if (leftPos + dropdownWidth > window.innerWidth) {
-      leftPos = window.innerWidth - dropdownWidth - 4;
-    }
-    dropdown.style.left = String(Math.max(0, leftPos)) + 'px';
-
-    this.addDropdownListeners();
+    this.mountDropdown(dropdown, triggerBtn, 'bottom-start');
   }
 
-  /** Copy dm-theme-* class from the editor to the dropdown so CSS variables apply when appended to body. */
-  private copyThemeClass(dropdown: HTMLElement): void {
-    const editorEl = this.view.dom.closest('.dm-editor');
-    const themeEl = editorEl?.closest('[class*="dm-theme-"]') ?? editorEl;
-    if (!themeEl) return;
-    themeEl.classList.forEach((cls) => {
-      if (cls.startsWith('dm-theme-')) {
-        dropdown.classList.add(cls);
-      }
-    });
+  /**
+   * Mount the dropdown inside `.dm-editor` (matching BubbleMenu pattern).
+   * Rendering inside the editor keeps the dropdown inside the modal/dialog
+   * stacking context when the editor is portaled to one - appending to
+   * document.body would hide it beneath a top-layer <dialog>.
+   */
+  private mountDropdown(dropdown: HTMLElement, anchor: HTMLElement, placement: 'bottom-start' | 'bottom'): void {
+    dropdown.style.position = 'absolute';
+    dropdown.style.left = '0';
+    dropdown.style.top = '0';
+
+    const editorEl = this.view.dom.closest<HTMLElement>('.dm-editor');
+    (editorEl ?? document.body).appendChild(dropdown);
+    this.dropdown = dropdown;
+
+    this.dropdownCleanup = positionFloatingOnce(anchor, dropdown, { placement, offsetValue: 4 });
+    this.addDropdownListeners();
   }
 
   private addDropdownListeners(): void {
     document.addEventListener('mousedown', this.boundDocMouseDown, true);
     document.addEventListener('keydown', this.boundDocKeyDown);
-    // Close on any scroll (editor or page) so fixed dropdown doesn't drift
-    window.addEventListener('scroll', this.boundScroll, true);
   }
 
   private removeDropdownListeners(): void {
     document.removeEventListener('mousedown', this.boundDocMouseDown, true);
     document.removeEventListener('keydown', this.boundDocKeyDown);
-    window.removeEventListener('scroll', this.boundScroll, true);
   }
 
   private closeDropdown(): void {
     if (!this.dropdown) return;
+    this.dropdownCleanup?.();
+    this.dropdownCleanup = null;
     this.dropdown.remove();
     this.dropdown = null;
     this.suppressCellToolbar = false;
-    // Clear open state from toolbar buttons
     this.cellToolbar.querySelectorAll('.dm-table-cell-toolbar-btn--open').forEach(
       (el) => { el.classList.remove('dm-table-cell-toolbar-btn--open'); },
     );

--- a/packages/theme/src/_table-controls.scss
+++ b/packages/theme/src/_table-controls.scss
@@ -246,10 +246,6 @@
     width: 100%;
     padding: 0.375rem 0.5rem;
     border: none;
-    // Component tokens (--dm-button-*) are defined on .dm-editor. This
-    // dropdown is portaled to document.body, so those tokens may be
-    // undefined here. Fall back to base tokens (which the theme sets via
-    // the .dm-theme-dark/.dm-theme-auto class copied onto the dropdown).
     border-radius: var(--dm-button-border-radius, 0.375rem);
     background: transparent;
     color: var(--dm-button-color, var(--dm-text));


### PR DESCRIPTION
## Problem

Reported via email: the table control dropdowns (row handle, column handle, cell toolbar color/alignment menus) were appended directly to `document.body`. When the editor lives inside a modal/`<dialog>`, this broke them in two ways:

- **Hidden behind the modal**: a `<dialog>` opened with `showModal()` paints in the top layer, so a dropdown attached to `body` (outside that layer) renders *underneath* the modal backdrop.
- **Mispositioned / clipped**: stacking contexts and ancestor `overflow` made the dropdown appear in the wrong place or not at all.

## Fix

Mount the dropdown **inside `.dm-editor`** instead of `body`, and position it with `position: fixed`:

- Being a DOM descendant of the editor means it paints in the same top layer as the surrounding `<dialog>`, so it is no longer hidden.
- `position: fixed` uses the viewport as containing block, so the editor's `overflow: hidden` cannot clip the dropdown (an `absolute` child would get clipped when it flips above the editor's top edge).
- Dropped `copyThemeClass`: the dropdown now inherits theme tokens through the normal CSS cascade since it is a descendant of the theme-classed editor.
- `@floating-ui` `autoUpdate` is now torn down on dropdown close and on editor destroy.

Falls back to `document.body` only when no `.dm-editor` ancestor exists.

## Tests

- **Unit** (`TableView.test.ts`): theme-token cascade from the editor, `document.body` fallback, and `autoUpdate` cleanup on close/destroy.
- **E2E** on all 4 frameworks (Angular, React, Vue, Vanilla): dropdowns render inside the editor and the dialog (not portaled to `body`), are not portaled on a normal page, close on Escape/outside-click, apply their action (insert row, set cell background), and stay on-screen + clickable when the editor `overflow` would otherwise clip them.
