### PR TITLE
fix(core): list input rules forward-join so a bullet between two lists merges them into one

### DIFF
--- a/apps/demo-angular/e2e/list-join-on-insert.spec.ts
+++ b/apps/demo-angular/e2e/list-join-on-insert.spec.ts
@@ -1,0 +1,57 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+// Creating a list item (markdown shortcut) on a paragraph that sits BETWEEN two
+// same-type lists must merge all of them into one list. Previously the wrapping
+// input rule joined only backward, so the trailing list was orphaned.
+
+const editorSelector = 'app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+test.describe('list join when inserting a bullet between two lists', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('typing "- " on a line between two bullet lists merges them into one', async ({ page }) => {
+    await page.click(editorSelector);
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { setContent: (h: string, emit: boolean) => void;
+            state: { doc: { descendants: (cb: (n: { type: { name: string }; content: { size: number } }, p: number) => boolean | undefined) => void }; tr: { setSelection: (s: unknown) => unknown }; selection: { constructor: { create: (d: unknown, a: number) => unknown } } };
+            view: { dispatch: (t: unknown) => void; dom: HTMLElement; focus: () => void } }
+        | undefined;
+      if (!ed) return;
+      ed.setContent('<ul><li><p>A</p><ul><li><p>B</p></li></ul></li></ul><p></p><ul><li><p>C</p></li></ul>', false);
+      let pos = -1;
+      ed.state.doc.descendants((n, p) => {
+        if (pos !== -1) return false;
+        if (n.type.name === 'paragraph' && n.content.size === 0) { pos = p + 1; return false; }
+        return true;
+      });
+      const TS = ed.state.selection.constructor;
+      ed.view.dispatch((ed.state.tr.setSelection as (s: unknown) => unknown)(TS.create(ed.state.doc as unknown, pos)));
+      ed.view.dom.focus();
+      ed.view.focus();
+    });
+    await page.waitForTimeout(120);
+    await page.keyboard.type('- ');
+    await page.waitForTimeout(80);
+    const result = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { state: { doc: { forEach: (cb: (n: { type: { name: string }; textContent: string }) => void) => void } } }
+        | undefined;
+      let lists = 0; let hasC = false;
+      ed?.state.doc.forEach((n) => { if (n.type.name === 'bulletList') { lists++; if (n.textContent.includes('C')) hasC = true; } });
+      return { lists, hasC };
+    });
+    // One merged list; the trailing item C is no longer orphaned into a second list.
+    expect(result.lists).toBe(1);
+    expect(result.hasC).toBe(true);
+  });
+});

--- a/apps/demo-react/e2e/list-join-on-insert.spec.ts
+++ b/apps/demo-react/e2e/list-join-on-insert.spec.ts
@@ -1,0 +1,57 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+// Creating a list item (markdown shortcut) on a paragraph that sits BETWEEN two
+// same-type lists must merge all of them into one list. Previously the wrapping
+// input rule joined only backward, so the trailing list was orphaned.
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+test.describe('list join when inserting a bullet between two lists', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('typing "- " on a line between two bullet lists merges them into one', async ({ page }) => {
+    await page.click(editorSelector);
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { setContent: (h: string, emit: boolean) => void;
+            state: { doc: { descendants: (cb: (n: { type: { name: string }; content: { size: number } }, p: number) => boolean | undefined) => void }; tr: { setSelection: (s: unknown) => unknown }; selection: { constructor: { create: (d: unknown, a: number) => unknown } } };
+            view: { dispatch: (t: unknown) => void; dom: HTMLElement; focus: () => void } }
+        | undefined;
+      if (!ed) return;
+      ed.setContent('<ul><li><p>A</p><ul><li><p>B</p></li></ul></li></ul><p></p><ul><li><p>C</p></li></ul>', false);
+      let pos = -1;
+      ed.state.doc.descendants((n, p) => {
+        if (pos !== -1) return false;
+        if (n.type.name === 'paragraph' && n.content.size === 0) { pos = p + 1; return false; }
+        return true;
+      });
+      const TS = ed.state.selection.constructor;
+      ed.view.dispatch((ed.state.tr.setSelection as (s: unknown) => unknown)(TS.create(ed.state.doc as unknown, pos)));
+      ed.view.dom.focus();
+      ed.view.focus();
+    });
+    await page.waitForTimeout(120);
+    await page.keyboard.type('- ');
+    await page.waitForTimeout(80);
+    const result = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { state: { doc: { forEach: (cb: (n: { type: { name: string }; textContent: string }) => void) => void } } }
+        | undefined;
+      let lists = 0; let hasC = false;
+      ed?.state.doc.forEach((n) => { if (n.type.name === 'bulletList') { lists++; if (n.textContent.includes('C')) hasC = true; } });
+      return { lists, hasC };
+    });
+    // One merged list; the trailing item C is no longer orphaned into a second list.
+    expect(result.lists).toBe(1);
+    expect(result.hasC).toBe(true);
+  });
+});

--- a/apps/demo-vanilla/e2e/list-join-on-insert.spec.ts
+++ b/apps/demo-vanilla/e2e/list-join-on-insert.spec.ts
@@ -1,0 +1,57 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+// Creating a list item (markdown shortcut) on a paragraph that sits BETWEEN two
+// same-type lists must merge all of them into one list. Previously the wrapping
+// input rule joined only backward, so the trailing list was orphaned.
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+test.describe('list join when inserting a bullet between two lists', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('typing "- " on a line between two bullet lists merges them into one', async ({ page }) => {
+    await page.click(editorSelector);
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { setContent: (h: string, emit: boolean) => void;
+            state: { doc: { descendants: (cb: (n: { type: { name: string }; content: { size: number } }, p: number) => boolean | undefined) => void }; tr: { setSelection: (s: unknown) => unknown }; selection: { constructor: { create: (d: unknown, a: number) => unknown } } };
+            view: { dispatch: (t: unknown) => void; dom: HTMLElement; focus: () => void } }
+        | undefined;
+      if (!ed) return;
+      ed.setContent('<ul><li><p>A</p><ul><li><p>B</p></li></ul></li></ul><p></p><ul><li><p>C</p></li></ul>', false);
+      let pos = -1;
+      ed.state.doc.descendants((n, p) => {
+        if (pos !== -1) return false;
+        if (n.type.name === 'paragraph' && n.content.size === 0) { pos = p + 1; return false; }
+        return true;
+      });
+      const TS = ed.state.selection.constructor;
+      ed.view.dispatch((ed.state.tr.setSelection as (s: unknown) => unknown)(TS.create(ed.state.doc as unknown, pos)));
+      ed.view.dom.focus();
+      ed.view.focus();
+    });
+    await page.waitForTimeout(120);
+    await page.keyboard.type('- ');
+    await page.waitForTimeout(80);
+    const result = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { state: { doc: { forEach: (cb: (n: { type: { name: string }; textContent: string }) => void) => void } } }
+        | undefined;
+      let lists = 0; let hasC = false;
+      ed?.state.doc.forEach((n) => { if (n.type.name === 'bulletList') { lists++; if (n.textContent.includes('C')) hasC = true; } });
+      return { lists, hasC };
+    });
+    // One merged list; the trailing item C is no longer orphaned into a second list.
+    expect(result.lists).toBe(1);
+    expect(result.hasC).toBe(true);
+  });
+});

--- a/apps/demo-vue/e2e/list-join-on-insert.spec.ts
+++ b/apps/demo-vue/e2e/list-join-on-insert.spec.ts
@@ -1,0 +1,57 @@
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+// Creating a list item (markdown shortcut) on a paragraph that sits BETWEEN two
+// same-type lists must merge all of them into one list. Previously the wrapping
+// input rule joined only backward, so the trailing list was orphaned.
+
+const editorSelector = '.app-notion-demo .ProseMirror';
+const modeToggleNotion = '[data-testid="mode-notion"]';
+
+async function goNotion(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector(modeToggleNotion);
+  await page.click(modeToggleNotion);
+  await page.waitForSelector(editorSelector);
+}
+
+test.describe('list join when inserting a bullet between two lists', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('typing "- " on a line between two bullet lists merges them into one', async ({ page }) => {
+    await page.click(editorSelector);
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { setContent: (h: string, emit: boolean) => void;
+            state: { doc: { descendants: (cb: (n: { type: { name: string }; content: { size: number } }, p: number) => boolean | undefined) => void }; tr: { setSelection: (s: unknown) => unknown }; selection: { constructor: { create: (d: unknown, a: number) => unknown } } };
+            view: { dispatch: (t: unknown) => void; dom: HTMLElement; focus: () => void } }
+        | undefined;
+      if (!ed) return;
+      ed.setContent('<ul><li><p>A</p><ul><li><p>B</p></li></ul></li></ul><p></p><ul><li><p>C</p></li></ul>', false);
+      let pos = -1;
+      ed.state.doc.descendants((n, p) => {
+        if (pos !== -1) return false;
+        if (n.type.name === 'paragraph' && n.content.size === 0) { pos = p + 1; return false; }
+        return true;
+      });
+      const TS = ed.state.selection.constructor;
+      ed.view.dispatch((ed.state.tr.setSelection as (s: unknown) => unknown)(TS.create(ed.state.doc as unknown, pos)));
+      ed.view.dom.focus();
+      ed.view.focus();
+    });
+    await page.waitForTimeout(120);
+    await page.keyboard.type('- ');
+    await page.waitForTimeout(80);
+    const result = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__DEMO_EDITOR__ as
+        | { state: { doc: { forEach: (cb: (n: { type: { name: string }; textContent: string }) => void) => void } } }
+        | undefined;
+      let lists = 0; let hasC = false;
+      ed?.state.doc.forEach((n) => { if (n.type.name === 'bulletList') { lists++; if (n.textContent.includes('C')) hasC = true; } });
+      return { lists, hasC };
+    });
+    // One merged list; the trailing item C is no longer orphaned into a second list.
+    expect(result.lists).toBe(1);
+    expect(result.hasC).toBe(true);
+  });
+});

--- a/packages/core/src/helpers/wrappingInputRule.test.ts
+++ b/packages/core/src/helpers/wrappingInputRule.test.ts
@@ -134,6 +134,63 @@ describe('wrappingInputRule', () => {
   });
 });
 
+describe('forward join (lists merge in both directions; others do not)', () => {
+  /** Fire input rules for typing `lastChar` at the caret (after `before` text). */
+  function fireInputRule(editor: Editor, caret: number, lastChar: string): void {
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, caret)));
+    for (const pl of editor.view.state.plugins) {
+      const handle = pl.props?.handleTextInput as
+        | ((view: unknown, from: number, to: number, text: string) => boolean)
+        | undefined;
+      if (handle && handle(editor.view, caret, caret, lastChar)) break;
+    }
+  }
+
+  function caretAfterText(editor: Editor, text: string): number {
+    let pos = -1;
+    editor.state.doc.descendants((n, p) => {
+      if (pos !== -1) return false;
+      if (n.isText && n.text === text) { pos = p + text.length; return false; }
+      return true;
+    });
+    if (pos === -1) throw new Error(`text "${text}" not found`);
+    return pos;
+  }
+
+  function topTypes(editor: Editor): string[] {
+    const out: string[] = [];
+    editor.state.doc.forEach((n) => out.push(n.type.name));
+    return out;
+  }
+
+  it('bullet "- " between two bullet lists merges all into ONE list', () => {
+    // The middle paragraph holds the trigger marker "-"; typing the trailing
+    // space fires the bullet input rule on it.
+    const editor = new Editor({
+      extensions: [Document, Text, Paragraph, BulletList, ListItem],
+      content: '<ul><li><p>A</p></li></ul><p>-</p><ul><li><p>C</p></li></ul>',
+    });
+    fireInputRule(editor, caretAfterText(editor, '-'), ' ');
+    // One list with three items (A, the wrapped marker line, C) - the trailing
+    // list is no longer orphaned.
+    expect(topTypes(editor)).toEqual(['bulletList']);
+    expect(editor.state.doc.firstChild?.childCount).toBe(3);
+    editor.destroy();
+  });
+
+  it('blockquote "> " does NOT forward-join (adjacent quotes stay separate)', () => {
+    const editor = new Editor({
+      extensions: [Document, Text, Paragraph, Blockquote],
+      content: '<blockquote><p>A</p></blockquote><p>&gt;</p><blockquote><p>C</p></blockquote>',
+    });
+    fireInputRule(editor, caretAfterText(editor, '>'), ' ');
+    // Backward join still merges the marker line into the first quote (existing
+    // behaviour), but the trailing quote is left separate (no forward join).
+    expect(topTypes(editor)).toEqual(['blockquote', 'blockquote']);
+    editor.destroy();
+  });
+});
+
 describe('notInsideList', () => {
   it('returns true when cursor is not in a list', () => {
     const editor = new Editor({

--- a/packages/core/src/helpers/wrappingInputRule.test.ts
+++ b/packages/core/src/helpers/wrappingInputRule.test.ts
@@ -139,10 +139,10 @@ describe('forward join (lists merge in both directions; others do not)', () => {
   function fireInputRule(editor: Editor, caret: number, lastChar: string): void {
     editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, caret)));
     for (const pl of editor.view.state.plugins) {
-      const handle = pl.props?.handleTextInput as
+      const handle = pl.props.handleTextInput as
         | ((view: unknown, from: number, to: number, text: string) => boolean)
         | undefined;
-      if (handle && handle(editor.view, caret, caret, lastChar)) break;
+      if (handle?.(editor.view, caret, caret, lastChar)) break;
     }
   }
 

--- a/packages/core/src/helpers/wrappingInputRule.ts
+++ b/packages/core/src/helpers/wrappingInputRule.ts
@@ -39,6 +39,16 @@ export interface WrappingInputRuleOptions {
   joinPredicate?: (match: RegExpMatchArray, node: Node) => boolean;
 
   /**
+   * When `true`, also join with an adjacent same-type node AFTER the newly
+   * wrapped node, not just the one before. Lists set this so creating a list
+   * item on a paragraph between two same-type lists merges all three into one
+   * (Notion groups consecutive list items into a single list). Off by default
+   * so wrappers like blockquote, where adjacent blocks stay separate, are
+   * unaffected. Honours `joinPredicate` against the following node.
+   */
+  joinForward?: boolean;
+
+  /**
    * Optional guard predicate. When provided, the rule only fires if
    * this returns true. Use this to prevent wrapping in certain contexts
    * (e.g. don't create a nested list inside an existing list item).
@@ -65,7 +75,7 @@ export interface WrappingInputRuleOptions {
  * });
  */
 export function wrappingInputRule(options: WrappingInputRuleOptions): InputRule {
-  const { find, type, getAttributes = null, joinPredicate, undoable, guard } = options;
+  const { find, type, getAttributes = null, joinPredicate, undoable, guard, joinForward } = options;
 
   return new InputRule(
     find,
@@ -82,6 +92,28 @@ export function wrappingInputRule(options: WrappingInputRuleOptions): InputRule 
       if (before?.type === type && canJoin(tr.doc, start - 1) &&
           (!joinPredicate || joinPredicate(match, before))) {
         tr.join(start - 1);
+      }
+
+      // Forward join: merge with an adjacent same-type node AFTER the wrapped
+      // one too (lists only). Without this, wrapping a paragraph that sits
+      // between two same-type lists merges with the list above but leaves the
+      // list below as a separate sibling. Resolve the cursor's wrapping node
+      // (it may already have merged backward) and join the node after it.
+      if (joinForward) {
+        const $cursor = tr.selection.$from;
+        for (let d = $cursor.depth; d >= 0; d--) {
+          if ($cursor.node(d).type === type) {
+            const after = $cursor.after(d);
+            if (after < tr.doc.content.size && canJoin(tr.doc, after)) {
+              const nodeAfter = tr.doc.nodeAt(after);
+              if (nodeAfter?.type === type &&
+                  (!joinPredicate || joinPredicate(match, nodeAfter))) {
+                tr.join(after);
+              }
+            }
+            break;
+          }
+        }
       }
       return tr;
     },

--- a/packages/core/src/nodes/BulletList.ts
+++ b/packages/core/src/nodes/BulletList.ts
@@ -111,11 +111,11 @@ export const BulletList = Node.create<BulletListOptions>({
 
     return [
       // - item
-      wrappingInputRule({ find: /^\s*[-]\s$/, type: nodeType, guard: notInsideList }),
+      wrappingInputRule({ find: /^\s*[-]\s$/, type: nodeType, guard: notInsideList, joinForward: true }),
       // * item
-      wrappingInputRule({ find: /^\s*[*]\s$/, type: nodeType, guard: notInsideList }),
+      wrappingInputRule({ find: /^\s*[*]\s$/, type: nodeType, guard: notInsideList, joinForward: true }),
       // + item
-      wrappingInputRule({ find: /^\s*[+]\s$/, type: nodeType, guard: notInsideList }),
+      wrappingInputRule({ find: /^\s*[+]\s$/, type: nodeType, guard: notInsideList, joinForward: true }),
     ];
   },
 });

--- a/packages/core/src/nodes/OrderedList.ts
+++ b/packages/core/src/nodes/OrderedList.ts
@@ -132,6 +132,7 @@ export const OrderedList = Node.create<OrderedListOptions>({
         find: /^(\d+)\.\s$/,
         type: nodeType,
         guard: notInsideList,
+        joinForward: true,
         getAttributes: (match) => {
           const num = match[1];
           return { start: num ? parseInt(num, 10) : 1 };

--- a/packages/core/src/nodes/TaskList.ts
+++ b/packages/core/src/nodes/TaskList.ts
@@ -122,9 +122,9 @@ export const TaskList = Node.create<TaskListOptions>({
 
     return [
       // [ ] at start of line creates unchecked task
-      wrappingInputRule({ find: /^\s*\[\s?\]\s$/, type: nodeType, guard: notInsideList }),
+      wrappingInputRule({ find: /^\s*\[\s?\]\s$/, type: nodeType, guard: notInsideList, joinForward: true }),
       // [x] or [X] at start of line creates checked task
-      wrappingInputRule({ find: /^\s*\[[xX]\]\s$/, type: nodeType, guard: notInsideList }),
+      wrappingInputRule({ find: /^\s*\[[xX]\]\s$/, type: nodeType, guard: notInsideList, joinForward: true }),
     ];
   },
 });


### PR DESCRIPTION
## Summary

The markdown list shortcuts (`- `, `* `, `+ `, `1. `, `[ ]`, `[x]`) joined only with the list *before* the newly created item. Creating a list item on a paragraph that sits between two same-type lists therefore merged with the list above but left the list below as a separate, orphaned list.

## Changes

- `wrappingInputRule` gains a `joinForward` option. When set, after the existing backward join it also merges with an adjacent same-type node *after* the wrapped one (honours the same `joinPredicate`, validated by `canJoin`).
- The three list types opt in: `BulletList` (`- ` / `* ` / `+ `), `OrderedList` (`1. `), `TaskList` (`[ ]` / `[x]`). They now merge in both directions, matching how Notion groups consecutive list items into a single list.
- `Blockquote` (same helper, for `> `) does NOT opt in, so adjacent quotes stay separate, also matching Notion.

Note: the `toggleList` path (slash menu / toolbar) already joined both ways via `joinListBackwards` + `joinListForwards`. This closes the same gap for the markdown input rules.

## Verified

- **Unit:** new `wrappingInputRule` tests confirm a bullet inserted between two bullet lists merges all into one, and `> ` between two blockquotes does NOT forward-join. Full core suite green (2422 tests), typecheck + lint clean.
- **E2e on all four framework demos** (React, Vue, Angular, Vanilla): typing `- ` on a line between two lists yields a single merged list (`list-join-on-insert.spec.ts`).