### PR TITLE
fix(extension-table): keep table cell toolbar clickable when the table is at the editor top

### DIFF
--- a/apps/demo-angular/e2e/table.spec.ts
+++ b/apps/demo-angular/e2e/table.spec.ts
@@ -1804,8 +1804,10 @@ test.describe('Table - Cell toolbar positioning', () => {
   });
 
   test('toolbar is centered above selected cells', async ({ page }) => {
-    await setContentAndFocus(page, TABLE_NO_HEADER);
-    await selectCells(page, 0, 1);
+    // Use a table with room above (a paragraph + header row) so the toolbar
+    // keeps its default placement above the selection.
+    await setContentAndFocus(page, TABLE_WITH_PARAGRAPH);
+    await selectCells(page, 2, 3);
 
     const toolbar = page.locator('.dm-table-cell-toolbar');
     await expect(toolbar).toBeVisible();
@@ -1834,6 +1836,40 @@ test.describe('Table - Cell toolbar positioning', () => {
 
     // Toolbar should be above the selection
     expect(toolbarBox!.y + toolbarBox!.height).toBeLessThan(selectionBounds.top + 5);
+  });
+
+  test('toolbar flips below the selection when the table is at the top (no room above)', async ({ page }) => {
+    await setContentAndFocus(page, TABLE_NO_HEADER);
+    await selectCells(page, 0, 1);
+
+    const toolbar = page.locator('.dm-table-cell-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    const toolbarBox = await toolbar.boundingBox();
+    expect(toolbarBox).toBeTruthy();
+
+    const selectionBounds = await page.evaluate((sel) => {
+      const cells = document.querySelectorAll(sel + ' .selectedCell');
+      let left = Infinity, right = -Infinity, top = Infinity, bottom = -Infinity;
+      cells.forEach(c => {
+        const r = c.getBoundingClientRect();
+        if (r.left < left) left = r.left;
+        if (r.right > right) right = r.right;
+        if (r.top < top) top = r.top;
+        if (r.bottom > bottom) bottom = r.bottom;
+      });
+      return { left, right, top, bottom };
+    }, editorSelector);
+
+    const selectionCenter = (selectionBounds.left + selectionBounds.right) / 2;
+    const toolbarCenter = toolbarBox!.x + toolbarBox!.width / 2;
+
+    // Still horizontally centered over the selection
+    expect(Math.abs(toolbarCenter - selectionCenter)).toBeLessThan(10);
+
+    // Flipped below: toolbar top sits below the selection bottom (otherwise it
+    // would render up inside the main editor toolbar's band and be unclickable).
+    expect(toolbarBox!.y).toBeGreaterThan(selectionBounds.bottom - 5);
   });
 });
 
@@ -3667,6 +3703,14 @@ test.describe('Table - Row handle centering on merged cells', () => {
   test('row handle repositions when moving from merged to normal cell', async ({ page }) => {
     const TABLE_3ROWS = '<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr><tr><td>E</td><td>F</td></tr></table>';
     await mergeFirstColumnCells(page, TABLE_3ROWS);
+
+    // Collapse the cell selection left by the merge so the cell toolbar hides
+    // (its flipped-below position would otherwise overlay the rows hovered below).
+    await page.evaluate(() => {
+      const editor = (window as any).__DEMO_EDITOR__;
+      editor?.commands.focus('end');
+    });
+    await page.waitForTimeout(100);
 
     const mergedCell = page.locator(`${editorSelector} td[rowspan]`).first();
     await expect(mergedCell).toBeVisible();

--- a/apps/demo-react/e2e/table.spec.ts
+++ b/apps/demo-react/e2e/table.spec.ts
@@ -1804,8 +1804,10 @@ test.describe('Table - Cell toolbar positioning', () => {
   });
 
   test('toolbar is centered above selected cells', async ({ page }) => {
-    await setContentAndFocus(page, TABLE_NO_HEADER);
-    await selectCells(page, 0, 1);
+    // Use a table with room above (a paragraph + header row) so the toolbar
+    // keeps its default placement above the selection.
+    await setContentAndFocus(page, TABLE_WITH_PARAGRAPH);
+    await selectCells(page, 2, 3);
 
     const toolbar = page.locator('.dm-table-cell-toolbar');
     await expect(toolbar).toBeVisible();
@@ -1834,6 +1836,40 @@ test.describe('Table - Cell toolbar positioning', () => {
 
     // Toolbar should be above the selection
     expect(toolbarBox!.y + toolbarBox!.height).toBeLessThan(selectionBounds.top + 5);
+  });
+
+  test('toolbar flips below the selection when the table is at the top (no room above)', async ({ page }) => {
+    await setContentAndFocus(page, TABLE_NO_HEADER);
+    await selectCells(page, 0, 1);
+
+    const toolbar = page.locator('.dm-table-cell-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    const toolbarBox = await toolbar.boundingBox();
+    expect(toolbarBox).toBeTruthy();
+
+    const selectionBounds = await page.evaluate((sel) => {
+      const cells = document.querySelectorAll(sel + ' .selectedCell');
+      let left = Infinity, right = -Infinity, top = Infinity, bottom = -Infinity;
+      cells.forEach(c => {
+        const r = c.getBoundingClientRect();
+        if (r.left < left) left = r.left;
+        if (r.right > right) right = r.right;
+        if (r.top < top) top = r.top;
+        if (r.bottom > bottom) bottom = r.bottom;
+      });
+      return { left, right, top, bottom };
+    }, editorSelector);
+
+    const selectionCenter = (selectionBounds.left + selectionBounds.right) / 2;
+    const toolbarCenter = toolbarBox!.x + toolbarBox!.width / 2;
+
+    // Still horizontally centered over the selection
+    expect(Math.abs(toolbarCenter - selectionCenter)).toBeLessThan(10);
+
+    // Flipped below: toolbar top sits below the selection bottom (otherwise it
+    // would render up inside the main editor toolbar's band and be unclickable).
+    expect(toolbarBox!.y).toBeGreaterThan(selectionBounds.bottom - 5);
   });
 });
 
@@ -3667,6 +3703,14 @@ test.describe('Table - Row handle centering on merged cells', () => {
   test('row handle repositions when moving from merged to normal cell', async ({ page }) => {
     const TABLE_3ROWS = '<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr><tr><td>E</td><td>F</td></tr></table>';
     await mergeFirstColumnCells(page, TABLE_3ROWS);
+
+    // Collapse the cell selection left by the merge so the cell toolbar hides
+    // (its flipped-below position would otherwise overlay the rows hovered below).
+    await page.evaluate(() => {
+      const editor = (window as any).__DEMO_EDITOR__;
+      editor?.commands.focus('end');
+    });
+    await page.waitForTimeout(100);
 
     const mergedCell = page.locator(`${editorSelector} td[rowspan]`).first();
     await expect(mergedCell).toBeVisible();

--- a/apps/demo-vanilla/e2e/table.spec.ts
+++ b/apps/demo-vanilla/e2e/table.spec.ts
@@ -1804,8 +1804,10 @@ test.describe('Table - Cell toolbar positioning', () => {
   });
 
   test('toolbar is centered above selected cells', async ({ page }) => {
-    await setContentAndFocus(page, TABLE_NO_HEADER);
-    await selectCells(page, 0, 1);
+    // Use a table with room above (a paragraph + header row) so the toolbar
+    // keeps its default placement above the selection.
+    await setContentAndFocus(page, TABLE_WITH_PARAGRAPH);
+    await selectCells(page, 2, 3);
 
     const toolbar = page.locator('.dm-table-cell-toolbar');
     await expect(toolbar).toBeVisible();
@@ -1834,6 +1836,40 @@ test.describe('Table - Cell toolbar positioning', () => {
 
     // Toolbar should be above the selection
     expect(toolbarBox!.y + toolbarBox!.height).toBeLessThan(selectionBounds.top + 5);
+  });
+
+  test('toolbar flips below the selection when the table is at the top (no room above)', async ({ page }) => {
+    await setContentAndFocus(page, TABLE_NO_HEADER);
+    await selectCells(page, 0, 1);
+
+    const toolbar = page.locator('.dm-table-cell-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    const toolbarBox = await toolbar.boundingBox();
+    expect(toolbarBox).toBeTruthy();
+
+    const selectionBounds = await page.evaluate((sel) => {
+      const cells = document.querySelectorAll(sel + ' .selectedCell');
+      let left = Infinity, right = -Infinity, top = Infinity, bottom = -Infinity;
+      cells.forEach(c => {
+        const r = c.getBoundingClientRect();
+        if (r.left < left) left = r.left;
+        if (r.right > right) right = r.right;
+        if (r.top < top) top = r.top;
+        if (r.bottom > bottom) bottom = r.bottom;
+      });
+      return { left, right, top, bottom };
+    }, editorSelector);
+
+    const selectionCenter = (selectionBounds.left + selectionBounds.right) / 2;
+    const toolbarCenter = toolbarBox!.x + toolbarBox!.width / 2;
+
+    // Still horizontally centered over the selection
+    expect(Math.abs(toolbarCenter - selectionCenter)).toBeLessThan(10);
+
+    // Flipped below: toolbar top sits below the selection bottom (otherwise it
+    // would render up inside the main editor toolbar's band and be unclickable).
+    expect(toolbarBox!.y).toBeGreaterThan(selectionBounds.bottom - 5);
   });
 });
 
@@ -3667,6 +3703,14 @@ test.describe('Table - Row handle centering on merged cells', () => {
   test('row handle repositions when moving from merged to normal cell', async ({ page }) => {
     const TABLE_3ROWS = '<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr><tr><td>E</td><td>F</td></tr></table>';
     await mergeFirstColumnCells(page, TABLE_3ROWS);
+
+    // Collapse the cell selection left by the merge so the cell toolbar hides
+    // (its flipped-below position would otherwise overlay the rows hovered below).
+    await page.evaluate(() => {
+      const editor = (window as any).__DEMO_EDITOR__;
+      editor?.commands.focus('end');
+    });
+    await page.waitForTimeout(100);
 
     const mergedCell = page.locator(`${editorSelector} td[rowspan]`).first();
     await expect(mergedCell).toBeVisible();

--- a/apps/demo-vue/e2e/table.spec.ts
+++ b/apps/demo-vue/e2e/table.spec.ts
@@ -1804,8 +1804,10 @@ test.describe('Table - Cell toolbar positioning', () => {
   });
 
   test('toolbar is centered above selected cells', async ({ page }) => {
-    await setContentAndFocus(page, TABLE_NO_HEADER);
-    await selectCells(page, 0, 1);
+    // Use a table with room above (a paragraph + header row) so the toolbar
+    // keeps its default placement above the selection.
+    await setContentAndFocus(page, TABLE_WITH_PARAGRAPH);
+    await selectCells(page, 2, 3);
 
     const toolbar = page.locator('.dm-table-cell-toolbar');
     await expect(toolbar).toBeVisible();
@@ -1834,6 +1836,40 @@ test.describe('Table - Cell toolbar positioning', () => {
 
     // Toolbar should be above the selection
     expect(toolbarBox!.y + toolbarBox!.height).toBeLessThan(selectionBounds.top + 5);
+  });
+
+  test('toolbar flips below the selection when the table is at the top (no room above)', async ({ page }) => {
+    await setContentAndFocus(page, TABLE_NO_HEADER);
+    await selectCells(page, 0, 1);
+
+    const toolbar = page.locator('.dm-table-cell-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    const toolbarBox = await toolbar.boundingBox();
+    expect(toolbarBox).toBeTruthy();
+
+    const selectionBounds = await page.evaluate((sel) => {
+      const cells = document.querySelectorAll(sel + ' .selectedCell');
+      let left = Infinity, right = -Infinity, top = Infinity, bottom = -Infinity;
+      cells.forEach(c => {
+        const r = c.getBoundingClientRect();
+        if (r.left < left) left = r.left;
+        if (r.right > right) right = r.right;
+        if (r.top < top) top = r.top;
+        if (r.bottom > bottom) bottom = r.bottom;
+      });
+      return { left, right, top, bottom };
+    }, editorSelector);
+
+    const selectionCenter = (selectionBounds.left + selectionBounds.right) / 2;
+    const toolbarCenter = toolbarBox!.x + toolbarBox!.width / 2;
+
+    // Still horizontally centered over the selection
+    expect(Math.abs(toolbarCenter - selectionCenter)).toBeLessThan(10);
+
+    // Flipped below: toolbar top sits below the selection bottom (otherwise it
+    // would render up inside the main editor toolbar's band and be unclickable).
+    expect(toolbarBox!.y).toBeGreaterThan(selectionBounds.bottom - 5);
   });
 });
 
@@ -3667,6 +3703,14 @@ test.describe('Table - Row handle centering on merged cells', () => {
   test('row handle repositions when moving from merged to normal cell', async ({ page }) => {
     const TABLE_3ROWS = '<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr><tr><td>E</td><td>F</td></tr></table>';
     await mergeFirstColumnCells(page, TABLE_3ROWS);
+
+    // Collapse the cell selection left by the merge so the cell toolbar hides
+    // (its flipped-below position would otherwise overlay the rows hovered below).
+    await page.evaluate(() => {
+      const editor = (window as any).__DEMO_EDITOR__;
+      editor?.commands.focus('end');
+    });
+    await page.waitForTimeout(100);
 
     const mergedCell = page.locator(`${editorSelector} td[rowspan]`).first();
     await expect(mergedCell).toBeVisible();

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -28,7 +28,7 @@ import {
   isInTable,
   selectedRect,
 } from '@domternal/pm/tables';
-import { positionFloating } from '@domternal/core';
+import { positionFloating, positionFloatingOnce } from '@domternal/core';
 
 import { constrainedAddColumn } from './helpers/constrainedColumn.js';
 
@@ -75,6 +75,7 @@ export class TableView implements NodeView {
   private cellHandleCell: HTMLTableCellElement | null = null;
   private dropdown: HTMLElement | null = null;
   private dropdownCleanup: (() => void) | null = null;
+  private cellToolbarCleanup: (() => void) | null = null;
   /** When true, the plugin skips showing the cell toolbar (row/col dropdown is open). */
   suppressCellToolbar = false;
   /** When true, column resize drag is active - all handles/menus are hidden. */
@@ -200,6 +201,7 @@ export class TableView implements NodeView {
     this.rowHandle.removeEventListener('mouseenter', this.boundCancelHide);
     this.cellHandle.removeEventListener('mouseenter', this.boundCancelHide);
     this.closeDropdown();
+    this.cellToolbarCleanup?.();
     if (this.hideTimeout) clearTimeout(this.hideTimeout);
     tableViewMap.delete(this.dom);
   }
@@ -403,41 +405,45 @@ export class TableView implements NodeView {
   /** Called by the cellHandlePlugin when CellSelection changes. */
   updateCellHandle(active: boolean): void {
     if (!active || this._resizeDragging) {
-      this.cellToolbar.style.display = '';
+      this.hideCellToolbar();
       this.closeDropdown();
       return;
     }
 
-    // Compute bounding box of ALL selected cells → position toolbar centered above
     const selectedCells = this.table.querySelectorAll('.selectedCell');
     if (selectedCells.length === 0) {
-      this.cellToolbar.style.display = '';
+      this.hideCellToolbar();
       return;
     }
 
-    let top = Infinity;
-    let left = Infinity;
-    let right = -Infinity;
-    selectedCells.forEach((c) => {
-      const r = c.getBoundingClientRect();
-      if (r.top < top) top = r.top;
-      if (r.left < left) left = r.left;
-      if (r.right > right) right = r.right;
-    });
+    // Position with floating-ui against a virtual reference spanning the
+    // selected cells. `placement: 'top'` puts the toolbar above the selection
+    // and flips it below when there isn't room above (e.g. the table is the
+    // first block and the top row is selected - otherwise the toolbar would
+    // render up inside the main editor toolbar's band and become unclickable).
+    const reference = {
+      getBoundingClientRect: (): DOMRect => {
+        let top = Infinity;
+        let left = Infinity;
+        let right = -Infinity;
+        let bottom = -Infinity;
+        this.table.querySelectorAll('.selectedCell').forEach((c) => {
+          const r = c.getBoundingClientRect();
+          if (r.top < top) top = r.top;
+          if (r.left < left) left = r.left;
+          if (r.right > right) right = r.right;
+          if (r.bottom > bottom) bottom = r.bottom;
+        });
+        return new DOMRect(left, top, right - left, bottom - top);
+      },
+    };
 
-    const containerRect = this.dom.getBoundingClientRect();
-
-    // Show toolbar first so offsetWidth is accurate (avoids jump on subsequent updates)
+    this.cellToolbarCleanup?.();
     this.cellToolbar.style.display = 'flex';
-    const toolbarWidth = this.cellToolbar.offsetWidth;
-    const selectionCenter = (left + right) / 2;
-    let toolbarLeft = selectionCenter - containerRect.left - toolbarWidth / 2;
-
-    // Clamp to container bounds
-    toolbarLeft = Math.max(0, Math.min(toolbarLeft, containerRect.width - toolbarWidth));
-
-    this.cellToolbar.style.left = String(toolbarLeft) + 'px';
-    this.cellToolbar.style.top = String(top - containerRect.top - 36) + 'px';
+    this.cellToolbarCleanup = positionFloatingOnce(reference, this.cellToolbar, {
+      placement: 'top',
+      offsetValue: 6,
+    });
 
     // Disable merge/split based on whether command can execute (dry-run without dispatch)
     const canMerge = mergeCells(this.view.state);
@@ -462,6 +468,13 @@ export class TableView implements NodeView {
     }
   }
 
+  /** Hide the cell toolbar and stop its floating-ui auto-update. */
+  private hideCellToolbar(): void {
+    this.cellToolbarCleanup?.();
+    this.cellToolbarCleanup = null;
+    this.cellToolbar.style.display = '';
+  }
+
   // ─── Cell handle (small circle for single-cell operations) ──────────
 
   /** Hide all controls during column resize drag. Called by the plugin. */
@@ -470,7 +483,7 @@ export class TableView implements NodeView {
     this.cellHandle.style.display = '';
     this.colHandle.style.display = '';
     this.rowHandle.style.display = '';
-    this.cellToolbar.style.display = '';
+    this.hideCellToolbar();
     this.closeDropdown();
   }
 
@@ -524,7 +537,7 @@ export class TableView implements NodeView {
 
   private onColClick(): void {
     this.suppressCellToolbar = true;
-    this.cellToolbar.style.display = '';
+    this.hideCellToolbar();
     this.dismissOverlays();
     this.selectColumn(this.hoveredCol);
     this.showDropdown('column');
@@ -532,7 +545,7 @@ export class TableView implements NodeView {
 
   private onRowClick(): void {
     this.suppressCellToolbar = true;
-    this.cellToolbar.style.display = '';
+    this.hideCellToolbar();
     this.dismissOverlays();
     this.selectRow(this.hoveredRow);
     this.showDropdown('row');


### PR DESCRIPTION
When a table is the first block and a top-row cell is selected, the cell
toolbar rendered up into the main editor toolbar and its buttons became
unclickable.

Position the cell toolbar via the shared `positionFloatingOnce` util with a
virtual reference over the selection; `flip` drops it below when there is no
room above. This also unifies the last manually-positioned floating element.

When flipped below it can overlay the row beneath the selection (expected,
Notion does the same; only while a selection is active at the very top).

Tests updated in all 4 demo wrappers; pre-existing bug, not a 0.7.4 regression.