### PR TITLE
chore: release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.5 (2026-06-03)
+
+### Changes
+
+- fix(core): `StarterKit` makes `ListIndent` opt-in (off by default). Tab on a paragraph that merely follows a list used to capture focus and pull the paragraph into the list; now Tab moves focus to the next field, which suits embedded / form usage. Opt back in with `StarterKit.configure({ listIndent: true })`. In-list Tab/Shift-Tab and block-menu drag-to-nest are unchanged. (#98)
+
+### Fixes
+
+- fix(core): extension instances are now cloned per editor, so several editors on one page no longer clobber each other. Previously creating a second editor repointed the first editor's node types at its own schema, and list `Enter` on the earlier editors dropped an indented child paragraph instead of a new list item. (#91)
+- fix(core): `SelectionDecoration` no longer keeps a ghost range when focus moves from one editor to another on the same page. The "editor UI" blur check is now scoped to the editor that lost focus, so a click into a different editor collapses its selection.
+
 ## 0.7.4 (2026-05-29)
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ pnpm typecheck  # Run type checker
 3. Bump `peerDependencies` and `prepublishOnly` hook versions. For patch releases, keep the existing minimum compatible version. For minor/major releases, bump to `>=X.Y.0`.
 4. Update `CHANGELOG.md` and `domternal.dev` changelog
 5. Update all 16 READMEs (root + 15 packages)
-6. Verify: `pnpm test && pnpm build && pnpm typecheck && pnpm lint`
+6. (skip) Verify: `pnpm test && pnpm build && pnpm typecheck && pnpm lint`
 7. Merge to main, tag `vX.Y.Z`, push with tags
 8. Publish in order: pm, core, theme, angular, react, vue, vanilla, then extensions
 9. Create GitHub release from tag with title `vX.Y.Z` and changelog entry as body

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Block-menu UX extensions for Domternal editor - FloatingMenu, BlockHandle (hover gutter + drag), SlashCommand, ContextMenu, and keyboard reorder",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release 0.7.5: version bump (all 15 packages) + changelog. The code changes landed in #99; this is the release cut.

## What ships in 0.7.5

- **fix(core): `StarterKit` makes `ListIndent` opt-in (off by default).** Tab on a paragraph that merely follows a list no longer captures focus and pulls the paragraph in; it moves focus to the next field. Opt back in with `StarterKit.configure({ listIndent: true })`. (Refs #98)
- **fix(core): extension instances are cloned per editor** - several editors on one page no longer clobber each other; list `Enter` on the earlier editors no longer drops an indented child paragraph instead of a new `<li>`. (Refs #91)
- **fix(core): `SelectionDecoration` no longer keeps a ghost selection across editors** - the "editor UI" blur check is now scoped to the editor that lost focus.

## Changes

- `version` 0.7.4 → 0.7.5 in all 15 `packages/*/package.json`, plus the 0.7.5 entry in `CHANGELOG.md`.
- peerDependencies / `prepublishOnly` minimums unchanged (patch keeps `>=0.7.0`).
- CONTRIBUTING.md: marks the release Verify step as skippable.

## Behavior change

`StarterKit` no longer enables `ListIndent` by default. Integrators relying on Tab-to-indent-into-a-list should opt in with `StarterKit.configure({ listIndent: true })`.

## Verified

Verified in #99: core unit suite (2430) and e2e parity across all four wrappers (288 passing, 72 × 4), lint + typecheck clean, no regressions. This release branch only bumps versions and the changelog.

Refs #91
Refs #98
