### PR TITLE
feat(core,extension-block-menu): multi-level nested block drag-and-drop with stable drop indicator

### DIFF
--- a/apps/demo-vanilla/e2e/notion-drag-drop.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drag-drop.spec.ts
@@ -33,6 +33,28 @@ async function goNotion(page: Page): Promise<void> {
   await waitForAllIds(page);
 }
 
+/**
+ * The dragover -> drop-indicator repaint is rAF-coalesced, so a SHOW lands on
+ * the next animation frame (hide is synchronous). Flush two frames before
+ * reading the indicator state after a synthesised dragover.
+ */
+async function flushIndicatorRaf(page: Page): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((res) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => { res(); }));
+    }),
+  );
+}
+
+/** Dispatch a document-level dragover at (x,y), flush the rAF, read `data-show`. */
+async function probeIndicatorShown(page: Page, x: number, y: number): Promise<boolean> {
+  await page.evaluate(({ cx, cy }) => {
+    document.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, clientX: cx, clientY: cy }));
+  }, { cx: x, cy: y });
+  await flushIndicatorRaf(page);
+  return page.evaluate(() => document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show') ?? false);
+}
+
 async function waitForAllIds(page: Page): Promise<void> {
   await page.waitForFunction(() => {
     const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
@@ -386,18 +408,10 @@ test.describe('Drag & drop - safety rails', () => {
     if (!editorBox) return;
 
     // Just inside top → shows
-    const innerTop = await page.evaluate(({ x, y }) => {
-      document.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: x, clientY: y }));
-      return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-    }, { x: editorBox.x + editorBox.width / 2, y: editorBox.y + 5 });
-    expect(innerTop).toBe(true);
+    expect(await probeIndicatorShown(page, editorBox.x + editorBox.width / 2, editorBox.y + 5)).toBe(true);
 
     // Far above editor → hides
-    const aboveEditor = await page.evaluate(({ x, y }) => {
-      document.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: x, clientY: y }));
-      return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-    }, { x: editorBox.x + editorBox.width / 2, y: editorBox.y - 100 });
-    expect(aboveEditor).toBe(false);
+    expect(await probeIndicatorShown(page, editorBox.x + editorBox.width / 2, editorBox.y - 100)).toBe(false);
 
     await handle.dispatchEvent('dragend', { dataTransfer: dt });
     await dt.dispose();
@@ -466,18 +480,10 @@ test.describe('Drag & drop - safety rails', () => {
     if (!editorBox) return;
 
     // 40px left of editor (within handle gutter, ≤ 80px tolerance) → shows
-    const inGutter = await page.evaluate(({ x, y }) => {
-      document.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: x, clientY: y }));
-      return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-    }, { x: editorBox.x - 40, y: editorBox.y + editorBox.height / 2 });
-    expect(inGutter).toBe(true);
+    expect(await probeIndicatorShown(page, editorBox.x - 40, editorBox.y + editorBox.height / 2)).toBe(true);
 
     // 200px left of editor (way past the gutter) → hides
-    const farLeft = await page.evaluate(({ x, y }) => {
-      document.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: x, clientY: y }));
-      return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-    }, { x: editorBox.x - 200, y: editorBox.y + editorBox.height / 2 });
-    expect(farLeft).toBe(false);
+    expect(await probeIndicatorShown(page, editorBox.x - 200, editorBox.y + editorBox.height / 2)).toBe(false);
 
     await handle.dispatchEvent('dragend', { dataTransfer: dt });
     await dt.dispose();
@@ -495,11 +501,7 @@ test.describe('Drag & drop - safety rails', () => {
     expect(insideBox).not.toBeNull();
     if (!insideBox) return;
 
-    const probe = async (x: number, y: number): Promise<boolean | undefined> =>
-      page.evaluate(({ cx, cy }) => {
-        document.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: cx, clientY: cy }));
-        return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-      }, { cx: x, cy: y });
+    const probe = (x: number, y: number): Promise<boolean> => probeIndicatorShown(page, x, y);
 
     // Show
     expect(await probe(insideBox.x + insideBox.width / 2, insideBox.y + insideBox.height * 0.8)).toBe(true);
@@ -553,11 +555,11 @@ test.describe('Drag & drop - safety rails', () => {
     expect(afterOutside).toBe(false);
 
     // 3. Cursor BACK inside editor → indicator restored.
-    const afterInside = await page.evaluate(({ x, y }) => {
-      const evt = new DragEvent('dragover', { bubbles: true, cancelable: true, clientX: x, clientY: y });
-      document.dispatchEvent(evt);
-      return document.querySelector('.dm-block-drop-indicator')?.hasAttribute('data-show');
-    }, { x: insideBox.x + insideBox.width / 2, y: insideBox.y + insideBox.height * 0.8 });
+    const afterInside = await probeIndicatorShown(
+      page,
+      insideBox.x + insideBox.width / 2,
+      insideBox.y + insideBox.height * 0.8,
+    );
     expect(afterInside).toBe(true);
 
     await handle.dispatchEvent('dragend', { dataTransfer: dt });

--- a/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
@@ -35,6 +35,20 @@ async function goNotion(page: Page): Promise<void> {
 }
 
 /**
+ * The dragover -> drop-indicator repaint is rAF-coalesced, so the indicator
+ * DOM updates on the NEXT animation frame, not synchronously after the
+ * `dragover` event. Tests that read the indicator immediately must flush two
+ * frames first (one for the coalescer's rAF to run, one to settle the write).
+ */
+async function flushIndicatorRaf(page: Page): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((res) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => { res(); }));
+    }),
+  );
+}
+
+/**
  * Wait until every STAMPED top-level node has a UniqueID. UniqueID
  * doesn't stamp every node type (table, details), so we only block on
  * the well-known stamped ones.
@@ -166,6 +180,7 @@ async function startDragOver(page: Page, sourceBlock: Locator, targetBlock: Loca
   const clientX = targetBox.x + 4;
   const clientY = targetBox.y + targetBox.height * 0.8;
   await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+  await flushIndicatorRaf(page);
   return { handle, dt };
 }
 
@@ -542,6 +557,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
     const clientX = targetBox.x + xOffsetFromLeft;
     const clientY = targetBox.y + targetBox.height * 0.5;
     await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+    await flushIndicatorRaf(page);
     const result = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');
       if (!(el instanceof HTMLElement)) return { mode: null, show: false };
@@ -659,6 +675,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
         clientX: targetBox!.x + xOffset,
         clientY: targetBox!.y + targetBox!.height * 0.5,
       });
+      await flushIndicatorRaf(page);
       return page.evaluate(
         () => document.querySelector('.dm-block-drop-indicator')?.getAttribute('data-mode') ?? null,
       );
@@ -761,6 +778,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
     const clientX = targetBox.x + 40;
     const clientY = targetBox.y + targetBox.height * 0.15;
     await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+    await flushIndicatorRaf(page);
 
     const mode = await page.evaluate(
       () => document.querySelector('.dm-block-drop-indicator')?.getAttribute('data-mode'),
@@ -839,6 +857,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
     const clientX = targetBox.x + 40; // nested zone
     const clientY = targetBox.y + targetBox.height * 0.5;
     await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+    await flushIndicatorRaf(page);
     // Indicator carries data-mode='nested' even though the drop will be a no-op.
     const mode = await page.evaluate(
       () => document.querySelector('.dm-block-drop-indicator')?.getAttribute('data-mode'),
@@ -877,6 +896,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
     const clientX = targetBox.x + 40;
     const clientY = targetBox.y + targetBox.height * 0.5;
     await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+    await flushIndicatorRaf(page);
     const mode = await page.evaluate(
       () => document.querySelector('.dm-block-drop-indicator')?.getAttribute('data-mode'),
     );
@@ -904,6 +924,7 @@ test.describe('X-detection - nested mode flip on list-item targets', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const insideMode = await page.evaluate(
       () => document.querySelector('.dm-block-drop-indicator')?.getAttribute('data-mode'),
     );
@@ -978,6 +999,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40, // nested zone
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('nested');
     expect(info?.borderTopStyle).toBe('dashed');
@@ -1002,6 +1024,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 4, // sibling zone (before bullet marker)
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('sibling');
     expect(info?.borderTopStyle).not.toBe('dashed');
@@ -1024,6 +1047,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
 
     // Compare nested left vs sibling left for the same target. Use a
     // separate dragover with sibling-zone X to capture the sibling left.
@@ -1033,6 +1057,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 4,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const siblingLeft = (await indicatorInfo(page))?.leftPx ?? 0;
     // Nested indents by 24px (matches --dm-block-children-indent).
     expect(nestedLeft - siblingLeft).toBeCloseTo(24, 0);
@@ -1055,12 +1080,14 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const nestedWidth = (await indicatorInfo(page))?.widthPx ?? 0;
     await page.locator(editorSelector).dispatchEvent('dragover', {
       dataTransfer: dt,
       clientX: targetBox.x + 4,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const siblingWidth = (await indicatorInfo(page))?.widthPx ?? 0;
     expect(siblingWidth - nestedWidth).toBeCloseTo(24, 0);
     await handle.dispatchEvent('dragend', { dataTransfer: dt });
@@ -1088,6 +1115,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.2,
     });
+    await flushIndicatorRaf(page);
     const upperInfo = await indicatorInfo(page);
     // Lower half Y - same rect.bottom anchor.
     await page.locator(editorSelector).dispatchEvent('dragover', {
@@ -1095,6 +1123,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.8,
     });
+    await flushIndicatorRaf(page);
     const lowerInfo = await indicatorInfo(page);
     expect(upperInfo?.mode).toBe('nested');
     expect(lowerInfo?.mode).toBe('nested');
@@ -1121,6 +1150,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
         clientX: targetBox!.x + xOffset,
         clientY: targetBox!.y + targetBox!.height * 0.5,
       });
+      await flushIndicatorRaf(page);
       return page.evaluate(() => {
         const el = document.querySelector('.dm-block-drop-indicator');
         if (!(el instanceof HTMLElement)) return '';
@@ -1154,6 +1184,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('nested');
     expect(info?.borderTopStyle).toBe('dashed');
@@ -1183,6 +1214,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 4,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const siblingShadow = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');
       return el instanceof HTMLElement ? getComputedStyle(el).boxShadow : '';
@@ -1196,6 +1228,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const nestedShadow = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');
       return el instanceof HTMLElement ? getComputedStyle(el).boxShadow : '';
@@ -1220,6 +1253,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const radius = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');
       return el instanceof HTMLElement ? getComputedStyle(el).borderTopLeftRadius : '';
@@ -1248,6 +1282,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('nested');
     expect(info?.borderTopStyle).toBe('dashed');
@@ -1255,13 +1290,13 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
     await dt.dispose();
   });
 
-  test('nested-mode indicator over a listItem WITH existing nested children anchors at the FULL listItem rect bottom (not the label paragraph)', async ({ page }) => {
-    // listItem with [label paragraph, nested h2] - the listItem's
-    // bounding rect spans BOTH. The dashed line must anchor at the
-    // listItem's overall bottom, not at the label's bottom; otherwise
-    // the indicator would sit visually between the label and the
-    // existing nested heading instead of below the heading where a
-    // new nested child would actually render.
+  test('nested-mode indicator over a listItem WITH existing nested children anchors at the FIRST-CHILD gap when hovering the label band (position-aware)', async ({ page }) => {
+    // listItem with [label paragraph, nested h2]. Hovering the LABEL band
+    // picks the first-child slot (insert BEFORE the existing h2), so the
+    // dashed line anchors at the label's bottom edge (the top of the gap
+    // between the label and the existing nested heading), NOT at the item's
+    // overall bottom. (Position-aware nested drop; the old append-only
+    // behaviour always drew at the item bottom.)
     await setContent(page, '<p>Source</p><ul><li><p>Label</p><h2>Existing</h2></li></ul>');
     const source = page.locator(`${editorSelector} p:has-text("Source")`);
     const liTarget = page.locator(`${editorSelector} li`);
@@ -1272,26 +1307,27 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
     const liBox = await liTarget.boundingBox();
     if (!liBox) throw new Error('no li box');
 
-    // Aim Y at the LABEL portion (top of li rect) so the resolver
-    // lands on the listItem (label first-child excluded by rule).
+    // Aim Y at the LABEL portion so the resolver lands on the listItem and
+    // the child-slot resolves to childIndex 1 (above the existing heading).
     await page.locator(editorSelector).dispatchEvent('dragover', {
       dataTransfer: dt,
       clientX: liBox.x + 40,
       clientY: liBox.y + liBox.height * 0.15,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('nested');
 
-    // Indicator top should equal the listItem's bottom edge in the
-    // editor-relative coordinate space. Read editor rect to convert.
+    // Indicator top should equal the LABEL paragraph's bottom edge (the
+    // first-child gap), in editor-relative coordinates.
     const expectedTop = await page.evaluate(() => {
-      const li = document.querySelector('.ProseMirror li');
+      const label = document.querySelector('.ProseMirror li > p');
       const editor = document.querySelector('.dm-editor');
-      if (!(li instanceof HTMLElement) || !(editor instanceof HTMLElement)) return -1;
-      return li.getBoundingClientRect().bottom - editor.getBoundingClientRect().top;
+      if (!(label instanceof HTMLElement) || !(editor instanceof HTMLElement)) return -1;
+      return label.getBoundingClientRect().bottom - editor.getBoundingClientRect().top;
     });
     expect(expectedTop).toBeGreaterThan(0);
-    expect(Math.abs((info?.topPx ?? 0) - expectedTop)).toBeLessThanOrEqual(1);
+    expect(Math.abs((info?.topPx ?? 0) - expectedTop)).toBeLessThanOrEqual(2);
     await handle.dispatchEvent('dragend', { dataTransfer: dt });
     await dt.dispose();
   });
@@ -1344,6 +1380,7 @@ test.describe('indicator visual - dashed indented line in nested mode', () => {
       clientX: targetBox.x + 40,
       clientY: targetBox.y + targetBox.height * 0.5,
     });
+    await flushIndicatorRaf(page);
     const info = await indicatorInfo(page);
     expect(info?.mode).toBe('nested');
     expect(info?.borderTopStyle).toBe('dashed');
@@ -1699,31 +1736,22 @@ test.describe('nested drop matrix - source types appended as last child', () => 
     });
   });
 
-  test('multi-step nesting: drop A into B, then drop C into A produces 3-level deep structure', async ({ page }) => {
+  test('multi-step nesting: dropping A, B, C onto a Target item at the label band stacks them as first-child (newest on top)', async ({ page }) => {
     await setContent(page, '<p>A</p><p>B</p><p>C</p><ul><li><p>Target</p></li></ul>');
-    // Drop A onto Target → Target now has nested A.
-    await dropNested(
-      page,
-      page.locator(`${editorSelector} > p:has-text("A")`),
-      page.locator(`${editorSelector} li`),
-    );
-    // Drop B onto Target → B becomes second nested child of Target.
-    await dropNested(
-      page,
-      page.locator(`${editorSelector} > p:has-text("B")`),
-      page.locator(`${editorSelector} li`),
-    );
-    // Drop C onto Target → C becomes third nested child of Target.
-    await dropNested(
-      page,
-      page.locator(`${editorSelector} > p:has-text("C")`),
-      page.locator(`${editorSelector} li`),
-    );
+    // Each drop aims Y at the label band -> childIndex 1 (first child), so a
+    // later drop lands ABOVE the earlier ones: the order reverses to C, B, A.
+    for (const t of ['A', 'B', 'C']) {
+      await dropNested(
+        page,
+        page.locator(`${editorSelector} > p:has-text("${t}")`),
+        page.locator(`${editorSelector} li`),
+      );
+    }
     expect(await firstListItemChildren(page)).toEqual([
       { type: 'paragraph', text: 'Target' },
-      { type: 'paragraph', text: 'A' },
-      { type: 'paragraph', text: 'B' },
       { type: 'paragraph', text: 'C' },
+      { type: 'paragraph', text: 'B' },
+      { type: 'paragraph', text: 'A' },
     ]);
     expect((await getBlocks(page)).length).toBe(1); // Just the bulletList; A/B/C all moved.
   });
@@ -1822,7 +1850,10 @@ test.describe('nested drop matrix - source types appended as last child', () => 
     ]);
   });
 
-  test('drop on listItem WITH existing nested children appends the new block AFTER the existing nested heading', async ({ page }) => {
+  test('drop on listItem WITH existing nested children at the LABEL band inserts the new block as the FIRST child (before the existing heading)', async ({ page }) => {
+    // Position-aware: `dropNested` aims Y at the label band, which resolves to
+    // childIndex 1, so Source lands BEFORE the existing heading. (The old
+    // append-only behaviour put it last.)
     await setContent(page, '<p>Source</p><ul><li><p>Label</p><h2>Existing</h2></li></ul>');
     await dropNested(
       page,
@@ -1831,8 +1862,8 @@ test.describe('nested drop matrix - source types appended as last child', () => 
     );
     expect(await firstListItemChildren(page)).toEqual([
       { type: 'paragraph', text: 'Label' },
-      { type: 'heading', text: 'Existing', level: 2 },
       { type: 'paragraph', text: 'Source' },
+      { type: 'heading', text: 'Existing', level: 2 },
     ]);
   });
 });

--- a/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
@@ -1927,3 +1927,51 @@ test.describe('drop result - mode branches the actual transaction', () => {
     expect(texts).toEqual(['Two', 'One']);
   });
 });
+
+test.describe('multi-level outdent - drag a nested item left to a shallower level', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('dragging a 2-level-deep item to the left of its indent outdents it to the top-level list', async ({ page }) => {
+    await setContent(page, '<ul><li><p>Outer</p><ul><li><p>Inner</p></li></ul></li></ul>');
+    const innerLabel = page.locator(`${editorSelector} li li > p:has-text("Inner")`);
+    const outer = page.locator(`${editorSelector} > ul > li`).first();
+
+    // Surface the handle on the Inner item.
+    await innerLabel.hover();
+    await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+    const dt = await page.evaluateHandle(() => new DataTransfer());
+    const handle = page.locator(dragBtnSelector);
+    const innerBox = await innerLabel.boundingBox();
+    const outerBox = await outer.boundingBox();
+    if (!innerBox || !outerBox) throw new Error('no box');
+    // Drop at the OUTER item's left indent (left of Inner's content) at the
+    // Inner row -> outdent one level to the top-level list.
+    const clientX = outerBox.x + 2;
+    const clientY = innerBox.y + innerBox.height / 2;
+
+    await handle.dispatchEvent('dragstart', { dataTransfer: dt });
+    await page.waitForTimeout(20);
+    await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
+    await page.locator(editorSelector).dispatchEvent('drop', { dataTransfer: dt, clientX, clientY });
+    await handle.dispatchEvent('dragend', { dataTransfer: dt });
+    await page.waitForTimeout(80);
+    await dt.dispose();
+
+    // The top-level bulletList now holds Outer and Inner as siblings; Outer's
+    // nested sublist collapsed (it had only Inner).
+    const topItems = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+        | { state: { doc: { firstChild: { childCount: number; child: (i: number) => { textContent: string; childCount: number } | null } | null } } }
+        | undefined;
+      const list = ed?.state.doc.firstChild;
+      const out: string[] = [];
+      for (let i = 0; i < (list?.childCount ?? 0); i++) {
+        const li = list?.child(i);
+        if (li) out.push(li.textContent);
+      }
+      return out;
+    });
+    expect(topItems).toEqual(['Outer', 'Inner']);
+  });
+});

--- a/apps/demo-vanilla/e2e/notion-nested-drag.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-nested-drag.spec.ts
@@ -1015,6 +1015,92 @@ test.describe('Handle alignment: X stays at editor gutter regardless of resolved
 });
 
 // ────────────────────────────────────────────────────────────────────────
+// Gap resolution: hovering the empty gutter gap BELOW a list (and above
+// the next block) must anchor the handle on the nearest list ITEM, not
+// jump to the list wrapper's top edge (its first item). Mirrors the drag
+// path's `adjustDropTargetForListWrapper` descent.
+// ────────────────────────────────────────────────────────────────────────
+
+test.describe('Handle resolution in the gap below a list (wrapper descent)', () => {
+  test.beforeEach(async ({ page }) => { await goNotion(page); });
+
+  test('hovering the gap just below a multi-item list resolves to the LAST item, not the list wrapper (no jump to the first item)', async ({ page }) => {
+    await setContent(
+      page,
+      '<ul><li><p>Item one</p></li><li><p>Item two</p></li></ul>'
+      + '<h2>Heading between</h2>'
+      + '<ul><li><p>Item three</p></li></ul>',
+    );
+
+    const firstList = page.locator(`${editorSelector} > ul`).first();
+    const heading = page.locator(`${editorSelector} > h2`);
+    const itemOne = page.locator(`${editorSelector} li:has-text("Item one")`);
+    const itemTwo = page.locator(`${editorSelector} li:has-text("Item two")`);
+
+    const listBox = await boxOf(firstList);
+    const headingBox = await boxOf(heading);
+    const gapTop = listBox.y + listBox.height;
+    const gapBottom = headingBox.y;
+    // A real gap (the heading's top margin) must exist for this scenario.
+    expect(gapBottom).toBeGreaterThan(gapTop);
+
+    // Hover just inside the gap, close to the list bottom - the spot where
+    // the bug made the handle jump up to the first item.
+    const y = gapTop + Math.min(4, (gapBottom - gapTop) * 0.4);
+    await hoverAt(page, await sideGutterX(page), y);
+    await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+    // Resolves to the LAST list item ("Item two"), not the wrapper.
+    const pos = await hoveredPos(page);
+    const block = pos !== null ? await blockAt(page, pos) : null;
+    expect(block?.type).toBe('listItem');
+    expect(block?.text).toBe('Item two');
+
+    // And the handle sits on the "Item two" row, never the "Item one" row.
+    const itemOneBox = await boxOf(itemOne);
+    const itemTwoBox = await boxOf(itemTwo);
+    const handle = await handleBox(page);
+    const handleCenter = handle.y + handle.height / 2;
+    expect(Math.abs(handleCenter - (itemTwoBox.y + itemTwoBox.height / 2))).toBeLessThan(itemTwoBox.height);
+    expect(handleCenter).toBeGreaterThan(itemOneBox.y + itemOneBox.height);
+  });
+
+  test('hovering the gap between two NESTED task items resolves to the nearest child, not the parent item', async ({ page }) => {
+    await setContent(
+      page,
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>Parent task</p>'
+      + '<ul data-type="taskList">'
+      + '<li data-type="taskItem" data-checked="false"><p>Child one</p></li>'
+      + '<li data-type="taskItem" data-checked="false"><p>Child two</p></li>'
+      + '</ul></li></ul>',
+    );
+
+    const childOne = page.locator(`${editorSelector} li:has-text("Child one")`).last();
+    const childTwo = page.locator(`${editorSelector} li:has-text("Child two")`).last();
+    const c1 = await boxOf(childOne);
+    const c2 = await boxOf(childTwo);
+    expect(c2.y).toBeGreaterThan(c1.y + c1.height); // a real gap between the nested rows
+
+    // Hover the gap between the two nested children.
+    const y = (c1.y + c1.height + c2.y) / 2;
+    await hoverAt(page, await sideGutterX(page), y);
+    await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
+
+    // Resolves to one of the CHILDREN, never the parent (whose text would
+    // include all nested labels).
+    const pos = await hoveredPos(page);
+    const block = pos !== null ? await blockAt(page, pos) : null;
+    expect(block?.type).toBe('taskItem');
+    expect(['Child one', 'Child two']).toContain(block?.text);
+
+    // Handle anchors in the nested region, never on the parent's label row.
+    const handle = await handleBox(page);
+    const handleCenter = handle.y + handle.height / 2;
+    expect(handleCenter).toBeGreaterThanOrEqual(c1.y - 2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
 // Source × container matrix sweep + drag-flow regression: the cases that
 // weren't already covered by the per-feature sections above. Completes
 // the full handle-resolution matrix and the drag-flow regression suite.

--- a/packages/core/src/utils/insertAsListItemChild.test.ts
+++ b/packages/core/src/utils/insertAsListItemChild.test.ts
@@ -368,4 +368,148 @@ describe('insertAsListItemChild', () => {
       expect(dump(editor)).toBe(before);
     });
   });
+
+  describe('childIndex (position-aware insert)', () => {
+    // Item [label "L", para "A", para "B"] (childCount 3). The label is the
+    // immutable child 0; valid insert indices are 1..3.
+    function setup3(): { wrapperPos: number; itemPos: number } {
+      editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+      return {
+        wrapperPos: findPos(editor, (n) => n.type.name === 'bulletList'),
+        itemPos: findPos(editor, (n) => n.type.name === 'listItem'),
+      };
+    }
+
+    it('childIndex=1 inserts as the FIRST child after the label: [L, NEW, A, B]', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const tr = editor!.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor!, 'NEW'), childIndex: 1,
+      });
+      expect(r.ok).toBe(true);
+      editor!.view.dispatch(tr);
+      expect(dump(editor!)).toContain('listItem(paragraph("L"), paragraph("NEW"), paragraph("A"), paragraph("B"))');
+    });
+
+    it('childIndex=2 inserts BETWEEN: [L, A, NEW, B]', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const tr = editor!.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor!, 'NEW'), childIndex: 2,
+      });
+      expect(r.ok).toBe(true);
+      editor!.view.dispatch(tr);
+      expect(dump(editor!)).toContain('listItem(paragraph("L"), paragraph("A"), paragraph("NEW"), paragraph("B"))');
+    });
+
+    it('childIndex=childCount appends, identical to omitting childIndex: [L, A, B, NEW]', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const tr = editor!.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor!, 'NEW'), childIndex: 3,
+      });
+      expect(r.ok).toBe(true);
+      editor!.view.dispatch(tr);
+      expect(dump(editor!)).toContain('listItem(paragraph("L"), paragraph("A"), paragraph("B"), paragraph("NEW"))');
+    });
+
+    it('childIndex past childCount clamps to append-last', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const tr = editor!.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor!, 'NEW'), childIndex: 99,
+      });
+      expect(r.ok).toBe(true);
+      editor!.view.dispatch(tr);
+      expect(dump(editor!)).toContain('listItem(paragraph("L"), paragraph("A"), paragraph("B"), paragraph("NEW"))');
+    });
+
+    it('childIndex=0 is clamped to 1 (never inserts before the label)', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const tr = editor!.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor!, 'NEW'), childIndex: 0,
+      });
+      expect(r.ok).toBe(true);
+      editor!.view.dispatch(tr);
+      expect(dump(editor!)).toContain('listItem(paragraph("L"), paragraph("NEW"), paragraph("A"), paragraph("B"))');
+    });
+
+    it('childIndex=1 on an empty-children item [L] lands as the only extra child', () => {
+      editor = makeEditor('<ul><li><p>L</p></li></ul>');
+      const wrapperPos = findPos(editor, (n) => n.type.name === 'bulletList');
+      const itemPos = findPos(editor, (n) => n.type.name === 'listItem');
+      const tr = editor.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: makeParagraph(editor, 'NEW'), childIndex: 1,
+      });
+      expect(r.ok).toBe(true);
+      editor.view.dispatch(tr);
+      expect(dump(editor)).toContain('listItem(paragraph("L"), paragraph("NEW"))');
+    });
+
+    it('move with childIndex: source BEFORE target lands at the index (not appended)', () => {
+      editor = makeEditor('<h2>Before</h2><ul><li><p>L</p><p>A</p></li></ul>');
+      const wrapperPos = findPos(editor, (n) => n.type.name === 'bulletList');
+      const itemPos = findPos(editor, (n) => n.type.name === 'listItem');
+      const headingPos = findPos(editor, (n) => n.type.name === 'heading');
+      const heading = editor.state.doc.nodeAt(headingPos)!;
+      const tr = editor.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: heading, childIndex: 1,
+        sourceRange: { from: headingPos, to: headingPos + heading.nodeSize },
+      });
+      expect(r.ok).toBe(true);
+      editor.view.dispatch(tr);
+      expect(editor.state.doc.childCount).toBe(1); // heading moved off top level
+      expect(dump(editor)).toContain('listItem(paragraph("L"), heading("Before"), paragraph("A"))');
+    });
+
+    it('self-drop guard: moving a child to its own boundary index returns ok=false', () => {
+      editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+      const wrapperPos = findPos(editor, (n) => n.type.name === 'bulletList');
+      const itemPos = findPos(editor, (n) => n.type.name === 'listItem');
+      const posA = findPos(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'A');
+      const a = editor.state.doc.nodeAt(posA)!;
+      const tr = editor.state.tr;
+      const before = dump(editor);
+      // childIndex=1 -> insertPos == posA (before A) == from -> self-drop.
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: a, childIndex: 1,
+        sourceRange: { from: posA, to: posA + a.nodeSize },
+      });
+      expect(r.ok).toBe(false);
+      expect(dump(editor)).toBe(before);
+    });
+
+    it('self-drop: moving a child PAST itself (childIndex=childCount) reorders cleanly', () => {
+      editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+      const wrapperPos = findPos(editor, (n) => n.type.name === 'bulletList');
+      const itemPos = findPos(editor, (n) => n.type.name === 'listItem');
+      const posA = findPos(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'A');
+      const a = editor.state.doc.nodeAt(posA)!;
+      const tr = editor.state.tr;
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: a, childIndex: 3,
+        sourceRange: { from: posA, to: posA + a.nodeSize },
+      });
+      expect(r.ok).toBe(true);
+      editor.view.dispatch(tr);
+      expect(dump(editor)).toContain('listItem(paragraph("L"), paragraph("B"), paragraph("A"))');
+    });
+
+    it('canReplaceWith reject at a BETWEEN index leaves tr untouched', () => {
+      const { wrapperPos, itemPos } = setup3();
+      const docNode = editor!.state.schema.nodes['doc']!.create(
+        null, editor!.state.schema.nodes['paragraph']!.create(),
+      );
+      const tr = editor!.state.tr;
+      const before = tr.doc.toString();
+      const r = insertAsListItemChild({
+        tr, wrapperPos, targetItemPos: itemPos, blockNode: docNode, childIndex: 1,
+      });
+      expect(r.ok).toBe(false);
+      expect(tr.doc.toString()).toBe(before);
+    });
+  });
 });

--- a/packages/core/src/utils/insertAsListItemChild.ts
+++ b/packages/core/src/utils/insertAsListItemChild.ts
@@ -86,11 +86,10 @@ export function insertAsListItemChild(
     return { ok: false };
   }
 
-  // Position right before child[insertIndex] in the pre-mutation doc.
-  let insertPos = targetItemStart + 1;
-  for (let i = 0; i < insertIndex; i++) {
-    insertPos += targetItem.child(i).nodeSize;
-  }
+  // Position right before child[insertIndex] in the pre-mutation doc
+  // (`posAtIndex(childCount)` is the end-of-content append slot).
+  const $item = tr.doc.resolve(targetItemStart + 1);
+  const insertPos = $item.posAtIndex(insertIndex, $item.depth);
 
   if (sourceRange) {
     const { from, to } = sourceRange;

--- a/packages/core/src/utils/insertAsListItemChild.ts
+++ b/packages/core/src/utils/insertAsListItemChild.ts
@@ -23,6 +23,14 @@ export interface InsertAsListItemChildArgs {
    * math handles source-before-vs-after-target ordering automatically.
    */
   sourceRange?: { from: number; to: number };
+  /**
+   * Child-array index inside the target item where `blockNode` lands.
+   * Index 0 is the immutable label paragraph (schema `paragraph block*`),
+   * so values are clamped to `>= 1`. When omitted OR `>= the item's
+   * childCount`, `blockNode` is appended as the LAST child (legacy default,
+   * byte-identical to the previous behaviour).
+   */
+  childIndex?: number;
 }
 
 export interface InsertAsListItemChildResult {
@@ -37,16 +45,20 @@ export interface InsertAsListItemChildResult {
 }
 
 /**
- * Insert `blockNode` as the LAST child of a list item (target item or, when
- * omitted, the wrapper's last item). When `sourceRange` is set, the source
- * range is removed in the same transaction so the op is a clean MOVE.
- * Returns `{ ok: false }` WITHOUT mutating `tr` on schema reject so callers
- * can fall through to a sibling-mode fallback.
+ * Insert `blockNode` into a list item's children. By default (no
+ * `childIndex`) it appends as the LAST child of the target item (or, when
+ * `targetItemPos` is omitted, the wrapper's last item). Pass `childIndex`
+ * (clamped to `>= 1`, since index 0 is the label paragraph) to land the
+ * block at a specific position among the item's children: `1` = first child
+ * after the label, `childCount` = append. When `sourceRange` is set, the
+ * source range is removed in the same transaction so the op is a clean MOVE.
+ * Returns `{ ok: false }` WITHOUT mutating `tr` on schema reject or self-drop
+ * so callers can fall through to a sibling-mode fallback.
  */
 export function insertAsListItemChild(
   args: InsertAsListItemChildArgs,
 ): InsertAsListItemChildResult {
-  const { tr, wrapperPos, targetItemPos, blockNode, sourceRange } = args;
+  const { tr, wrapperPos, targetItemPos, blockNode, sourceRange, childIndex } = args;
 
   if (wrapperPos < 0 || wrapperPos >= tr.doc.content.size) return { ok: false };
   const wrapper = tr.doc.nodeAt(wrapperPos);
@@ -78,30 +90,44 @@ export function insertAsListItemChild(
     targetItemStart = pos;
   }
 
-  if (!targetItem.canReplaceWith(targetItem.childCount, targetItem.childCount, blockNode.type)) {
+  // Resolve the child-array index. Index 0 is the immutable label
+  // paragraph, so the floor is 1. Omitted or past the last child means
+  // append-last (legacy). `insertIndex === childCount` yields the exact
+  // legacy append position, so the default path is unchanged.
+  const childCount = targetItem.childCount;
+  const insertIndex =
+    childIndex === undefined || childIndex >= childCount ? childCount : Math.max(1, childIndex);
+
+  // Validate the insertion at the ACTUAL index (for append this is the
+  // same (childCount, childCount) check as before).
+  if (!targetItem.canReplaceWith(insertIndex, insertIndex, blockNode.type)) {
     return { ok: false };
   }
 
-  // Position right BEFORE the item's close token = end of its content,
-  // where a new last-child is appended. Computed from the PRE-mutation
-  // doc so the offset reflects the layout the caller can reason about.
-  const targetItemContentEnd = targetItemStart + targetItem.nodeSize - 1;
+  // Position right BEFORE child[insertIndex], computed from the PRE-mutation
+  // doc. For `insertIndex === childCount` this equals
+  // `targetItemStart + targetItem.nodeSize - 1` (the legacy append slot).
+  let insertPos = targetItemStart + 1;
+  for (let i = 0; i < insertIndex; i++) {
+    insertPos += targetItem.child(i).nodeSize;
+  }
 
   if (sourceRange) {
     const { from, to } = sourceRange;
-    // Self-drop guard: target sits inside the deletion range. Caller's
-    // responsibility is primary, but defending here avoids a silent
-    // "insert into removed range" that would corrupt the document.
-    if (targetItemContentEnd >= from && targetItemContentEnd <= to) {
+    // Self-drop guard: the insertion point sits inside the deletion range
+    // (e.g. moving a child to a slot within its own removed span). Caller's
+    // guard is primary, but defending here avoids a silent "insert into
+    // removed range" that would corrupt the document. `sourceRange` is the
+    // EXPANDED range when called from `moveBlockAsNestedChild`.
+    if (insertPos >= from && insertPos <= to) {
       return { ok: false };
     }
     tr.delete(from, to);
-    const adjustedInsertPos =
-      targetItemContentEnd > from ? targetItemContentEnd - (to - from) : targetItemContentEnd;
+    const adjustedInsertPos = insertPos > from ? insertPos - (to - from) : insertPos;
     tr.insert(adjustedInsertPos, blockNode);
     return { ok: true, insertedAt: adjustedInsertPos };
   }
 
-  tr.insert(targetItemContentEnd, blockNode);
-  return { ok: true, insertedAt: targetItemContentEnd };
+  tr.insert(insertPos, blockNode);
+  return { ok: true, insertedAt: insertPos };
 }

--- a/packages/core/src/utils/insertAsListItemChild.ts
+++ b/packages/core/src/utils/insertAsListItemChild.ts
@@ -15,20 +15,13 @@ export interface InsertAsListItemChildArgs {
    * matching the Tab keyboard behaviour ("indent into last item").
    */
   targetItemPos?: number;
-  /** Block node to append as the LAST child of the target item. */
+  /** Block node to insert. */
   blockNode: PMNode;
-  /**
-   * Optional source range to delete in the SAME transaction (when
-   * MOVING an existing block instead of creating a new one). Position
-   * math handles source-before-vs-after-target ordering automatically.
-   */
+  /** Optional source range to delete in the same tr (turns insert into a MOVE). */
   sourceRange?: { from: number; to: number };
   /**
-   * Child-array index inside the target item where `blockNode` lands.
-   * Index 0 is the immutable label paragraph (schema `paragraph block*`),
-   * so values are clamped to `>= 1`. When omitted OR `>= the item's
-   * childCount`, `blockNode` is appended as the LAST child (legacy default,
-   * byte-identical to the previous behaviour).
+   * Child index to insert at. Clamped to `>= 1` (index 0 is the label
+   * paragraph). Omitted or `>= childCount` appends as the last child.
    */
   childIndex?: number;
 }
@@ -45,15 +38,10 @@ export interface InsertAsListItemChildResult {
 }
 
 /**
- * Insert `blockNode` into a list item's children. By default (no
- * `childIndex`) it appends as the LAST child of the target item (or, when
- * `targetItemPos` is omitted, the wrapper's last item). Pass `childIndex`
- * (clamped to `>= 1`, since index 0 is the label paragraph) to land the
- * block at a specific position among the item's children: `1` = first child
- * after the label, `childCount` = append. When `sourceRange` is set, the
- * source range is removed in the same transaction so the op is a clean MOVE.
- * Returns `{ ok: false }` WITHOUT mutating `tr` on schema reject or self-drop
- * so callers can fall through to a sibling-mode fallback.
+ * Insert `blockNode` into a list item's children at `childIndex` (default:
+ * append last; target item defaults to the wrapper's last item). `sourceRange`
+ * makes it a MOVE. Returns `{ ok: false }` without mutating `tr` on schema
+ * reject or self-drop so callers can fall back to a sibling move.
  */
 export function insertAsListItemChild(
   args: InsertAsListItemChildArgs,
@@ -71,9 +59,7 @@ export function insertAsListItemChild(
     if (targetItemPos < 0 || targetItemPos >= tr.doc.content.size) return { ok: false };
     const candidate = tr.doc.nodeAt(targetItemPos);
     if (!candidate || !LIST_ITEM_TYPES.has(candidate.type.name)) return { ok: false };
-    // Verify the candidate item really sits inside the given wrapper -
-    // a mismatched (wrapperPos, targetItemPos) pair would otherwise
-    // produce silently-wrong position math.
+    // Guard against a mismatched (wrapperPos, targetItemPos) pair.
     if (targetItemPos < wrapperPos + 1 || targetItemPos >= wrapperPos + wrapper.nodeSize) {
       return { ok: false };
     }
@@ -90,23 +76,17 @@ export function insertAsListItemChild(
     targetItemStart = pos;
   }
 
-  // Resolve the child-array index. Index 0 is the immutable label
-  // paragraph, so the floor is 1. Omitted or past the last child means
-  // append-last (legacy). `insertIndex === childCount` yields the exact
-  // legacy append position, so the default path is unchanged.
+  // Floor the index at 1 (index 0 is the label); omitted/overflow appends.
+  // `insertIndex === childCount` reproduces the legacy append position.
   const childCount = targetItem.childCount;
   const insertIndex =
     childIndex === undefined || childIndex >= childCount ? childCount : Math.max(1, childIndex);
 
-  // Validate the insertion at the ACTUAL index (for append this is the
-  // same (childCount, childCount) check as before).
   if (!targetItem.canReplaceWith(insertIndex, insertIndex, blockNode.type)) {
     return { ok: false };
   }
 
-  // Position right BEFORE child[insertIndex], computed from the PRE-mutation
-  // doc. For `insertIndex === childCount` this equals
-  // `targetItemStart + targetItem.nodeSize - 1` (the legacy append slot).
+  // Position right before child[insertIndex] in the pre-mutation doc.
   let insertPos = targetItemStart + 1;
   for (let i = 0; i < insertIndex; i++) {
     insertPos += targetItem.child(i).nodeSize;
@@ -114,11 +94,8 @@ export function insertAsListItemChild(
 
   if (sourceRange) {
     const { from, to } = sourceRange;
-    // Self-drop guard: the insertion point sits inside the deletion range
-    // (e.g. moving a child to a slot within its own removed span). Caller's
-    // guard is primary, but defending here avoids a silent "insert into
-    // removed range" that would corrupt the document. `sourceRange` is the
-    // EXPANDED range when called from `moveBlockAsNestedChild`.
+    // Self-drop guard: insertion point lands inside the (expanded) deletion
+    // range, so the move is a no-op; bail without corrupting the doc.
     if (insertPos >= from && insertPos <= to) {
       return { ok: false };
     }

--- a/packages/core/src/utils/insertAsListItemChild.ts
+++ b/packages/core/src/utils/insertAsListItemChild.ts
@@ -76,8 +76,7 @@ export function insertAsListItemChild(
     targetItemStart = pos;
   }
 
-  // Floor the index at 1 (index 0 is the label); omitted/overflow appends.
-  // `insertIndex === childCount` reproduces the legacy append position.
+  // Floor at 1 (index 0 is the label); omitted/overflow appends last.
   const childCount = targetItem.childCount;
   const insertIndex =
     childIndex === undefined || childIndex >= childCount ? childCount : Math.max(1, childIndex);
@@ -93,8 +92,7 @@ export function insertAsListItemChild(
 
   if (sourceRange) {
     const { from, to } = sourceRange;
-    // Self-drop guard: insertion point lands inside the (expanded) deletion
-    // range, so the move is a no-op; bail without corrupting the doc.
+    // Self-drop guard: insert point inside the deletion range is a no-op.
     if (insertPos >= from && insertPos <= to) {
       return { ok: false };
     }

--- a/packages/extension-block-menu/src/BlockHandle.test.ts
+++ b/packages/extension-block-menu/src/BlockHandle.test.ts
@@ -4,9 +4,21 @@ import {
   Text,
   Paragraph,
   Heading,
+  BulletList,
+  OrderedList,
+  ListItem,
+  TaskList,
+  TaskItem,
   Editor,
 } from '@domternal/core';
-import { BlockHandle, blockHandlePluginKey, resolveNestedConfig } from './BlockHandle.js';
+import {
+  BlockHandle,
+  blockHandlePluginKey,
+  resolveNestedConfig,
+  adjustDropTargetForListWrapper,
+  descendToNearestHoverItem,
+} from './BlockHandle.js';
+import type { EditorView } from '@domternal/pm/view';
 import { DEFAULT_BLOCK_MATCHERS } from './helpers/defaultMatchers.js';
 import type { BlockMatcher } from './helpers/blockMatcher.js';
 
@@ -802,5 +814,485 @@ describe('BlockHandle drop indicator class', () => {
 
     dispatchDrag('dragstart');
     expect(host.classList.contains('dm-block-handle-dragging')).toBe(false);
+  });
+});
+
+// Spatial resolution helpers: pure functions over a stubbed `EditorView`
+// (jsdom has no layout, so rects are hand-built and fed through `nodeDOM`).
+describe('BlockHandle spatial resolution helpers', () => {
+  const listExtensions = [
+    Document, Text, Paragraph, BulletList, OrderedList, ListItem, TaskList, TaskItem,
+  ];
+
+  function makeListEditor(html: string): Editor {
+    return new Editor({ extensions: listExtensions, content: html });
+  }
+
+  function elWithRect(rect: DOMRect): HTMLElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => rect;
+    return el;
+  }
+
+  function viewStub(ed: Editor, rects: Map<number, HTMLElement>): EditorView {
+    return {
+      state: ed.state,
+      nodeDOM: (pos: number) => rects.get(pos) ?? null,
+    } as unknown as EditorView;
+  }
+
+  function posOf(ed: Editor, predicate: (n: { type: { name: string }; textContent: string }) => boolean): number {
+    let found = -1;
+    ed.state.doc.descendants((node, pos) => {
+      if (found !== -1) return false;
+      if (predicate(node)) { found = pos; return false; }
+      return true;
+    });
+    if (found === -1) throw new Error('node not found');
+    return found;
+  }
+
+  describe('adjustDropTargetForListWrapper', () => {
+    it('returns the target unchanged when the resolved node is not a list wrapper', () => {
+      const ed = makeListEditor('<p>Plain</p>');
+      const pPos = posOf(ed, (n) => n.type.name === 'paragraph');
+      const dom = elWithRect(new DOMRect(0, 100, 400, 30));
+      const resolved = { pos: pPos, rect: dom.getBoundingClientRect(), dom };
+      const out = adjustDropTargetForListWrapper(viewStub(ed, new Map()), resolved, 50);
+      expect(out.pos).toBe(pPos);
+      ed.destroy();
+    });
+
+    it('returns the target unchanged when nodeAt resolves to no node (doc end)', () => {
+      const ed = makeListEditor('<p>Plain</p>');
+      const dom = elWithRect(new DOMRect(0, 100, 400, 30));
+      // `content.size` is past the last node, so doc.nodeAt(end) === null.
+      const end = ed.state.doc.content.size;
+      const resolved = { pos: end, rect: dom.getBoundingClientRect(), dom };
+      const out = adjustDropTargetForListWrapper(viewStub(ed, new Map()), resolved, 50);
+      expect(out.pos).toBe(end);
+      ed.destroy();
+    });
+
+    it('cursor ABOVE a list wrapper descends to its FIRST child item', () => {
+      const ed = makeListEditor('<ul><li><p>A</p></li><li><p>B</p></li></ul>');
+      const ulPos = posOf(ed, (n) => n.type.name === 'bulletList');
+      const liA = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'A');
+      const ulDom = elWithRect(new DOMRect(0, 100, 400, 100));
+      const aDom = elWithRect(new DOMRect(0, 100, 400, 50));
+      const rects = new Map<number, HTMLElement>([[ulPos, ulDom], [liA, aDom]]);
+      const resolved = { pos: ulPos, rect: ulDom.getBoundingClientRect(), dom: ulDom };
+      // clientY=80 is above the wrapper top (100).
+      const out = adjustDropTargetForListWrapper(viewStub(ed, rects), resolved, 80);
+      expect(out.pos).toBe(liA);
+      ed.destroy();
+    });
+
+    it('cursor BELOW a list wrapper descends to its LAST child item', () => {
+      const ed = makeListEditor('<ul><li><p>A</p></li><li><p>B</p></li></ul>');
+      const ulPos = posOf(ed, (n) => n.type.name === 'bulletList');
+      const liB = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'B');
+      const ulDom = elWithRect(new DOMRect(0, 100, 400, 100));
+      const bDom = elWithRect(new DOMRect(0, 150, 400, 50));
+      const rects = new Map<number, HTMLElement>([[ulPos, ulDom], [liB, bDom]]);
+      const resolved = { pos: ulPos, rect: ulDom.getBoundingClientRect(), dom: ulDom };
+      // clientY=400 is below the wrapper bottom (200); last-child loop runs.
+      const out = adjustDropTargetForListWrapper(viewStub(ed, rects), resolved, 400);
+      expect(out.pos).toBe(liB);
+      ed.destroy();
+    });
+
+    it('cursor INSIDE a list wrapper extent leaves the target on the wrapper', () => {
+      const ed = makeListEditor('<ul><li><p>A</p></li></ul>');
+      const ulPos = posOf(ed, (n) => n.type.name === 'bulletList');
+      const ulDom = elWithRect(new DOMRect(0, 100, 400, 100));
+      const rects = new Map<number, HTMLElement>([[ulPos, ulDom]]);
+      const resolved = { pos: ulPos, rect: ulDom.getBoundingClientRect(), dom: ulDom };
+      const out = adjustDropTargetForListWrapper(viewStub(ed, rects), resolved, 150); // inside 100..200
+      expect(out.pos).toBe(ulPos);
+      ed.destroy();
+    });
+
+    it('returns the wrapper unchanged when the resolved child item has no DOM', () => {
+      const ed = makeListEditor('<ul><li><p>A</p></li></ul>');
+      const ulPos = posOf(ed, (n) => n.type.name === 'bulletList');
+      const ulDom = elWithRect(new DOMRect(0, 100, 400, 100));
+      // Child item rect intentionally omitted -> childDom is null.
+      const rects = new Map<number, HTMLElement>([[ulPos, ulDom]]);
+      const resolved = { pos: ulPos, rect: ulDom.getBoundingClientRect(), dom: ulDom };
+      const out = adjustDropTargetForListWrapper(viewStub(ed, rects), resolved, 80);
+      expect(out.pos).toBe(ulPos);
+      ed.destroy();
+    });
+  });
+
+  describe('descendToNearestHoverItem', () => {
+    it('returns the target unchanged when nodeAt resolves to no node (doc end)', () => {
+      const ed = makeListEditor('<p>Plain</p>');
+      const dom = elWithRect(new DOMRect(0, 100, 400, 30));
+      const end = ed.state.doc.content.size; // doc.nodeAt(end) === null
+      const resolved = { pos: end, rect: dom.getBoundingClientRect(), dom };
+      const out = descendToNearestHoverItem(viewStub(ed, new Map()), resolved, 110);
+      expect(out.pos).toBe(end);
+      ed.destroy();
+    });
+
+    it('returns a non-list block (paragraph) unchanged', () => {
+      const ed = makeListEditor('<p>Plain</p>');
+      const pPos = posOf(ed, (n) => n.type.name === 'paragraph');
+      const dom = elWithRect(new DOMRect(0, 100, 400, 30));
+      const resolved = { pos: pPos, rect: dom.getBoundingClientRect(), dom };
+      const out = descendToNearestHoverItem(viewStub(ed, new Map()), resolved, 110);
+      expect(out.pos).toBe(pPos);
+      ed.destroy();
+    });
+
+    it('descends a list WRAPPER to the child item nearest the cursor row', () => {
+      const ed = makeListEditor('<ul><li><p>A</p></li><li><p>B</p></li></ul>');
+      const ulPos = posOf(ed, (n) => n.type.name === 'bulletList');
+      const liA = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'A');
+      const liB = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'B');
+      const ulDom = elWithRect(new DOMRect(0, 100, 400, 100));
+      const rects = new Map<number, HTMLElement>([
+        [ulPos, ulDom],
+        [liA, elWithRect(new DOMRect(0, 100, 400, 50))],   // 100..150
+        [liB, elWithRect(new DOMRect(0, 150, 400, 50))],   // 150..200
+      ]);
+      const resolved = { pos: ulPos, rect: ulDom.getBoundingClientRect(), dom: ulDom };
+      const out = descendToNearestHoverItem(viewStub(ed, rects), resolved, 180); // inside B
+      expect(out.pos).toBe(liB);
+      ed.destroy();
+    });
+
+    it('descends a list ITEM into its nested sublist when the cursor is in the nested area', () => {
+      const ed = makeListEditor(
+        '<ul><li><p>Outer</p><ul><li><p>I1</p></li><li><p>I2</p></li></ul></li></ul>',
+      );
+      const outerLi = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Outer'));
+      const innerUl = posOf(ed, (n) => n.type.name === 'bulletList' && n.textContent === 'I1I2');
+      const i1 = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'I1');
+      const i2 = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'I2');
+      const outerDom = elWithRect(new DOMRect(0, 100, 400, 200)); // 100..300
+      const rects = new Map<number, HTMLElement>([
+        [outerLi, outerDom],
+        [innerUl, elWithRect(new DOMRect(20, 150, 380, 150))],  // nested list 150..300
+        [i1, elWithRect(new DOMRect(20, 150, 380, 50))],        // 150..200
+        [i2, elWithRect(new DOMRect(20, 250, 380, 50))],        // 250..300
+      ]);
+      const resolved = { pos: outerLi, rect: outerDom.getBoundingClientRect(), dom: outerDom };
+      // clientY=270 is below the outer label and inside I2's row.
+      const out = descendToNearestHoverItem(viewStub(ed, rects), resolved, 270);
+      expect(out.pos).toBe(i2);
+      ed.destroy();
+    });
+
+    it('stays on a list ITEM when the cursor is on its own label row (above the nested list)', () => {
+      const ed = makeListEditor(
+        '<ul><li><p>Outer</p><ul><li><p>Inner</p></li></ul></li></ul>',
+      );
+      const outerLi = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Outer'));
+      const innerUl = posOf(ed, (n) => n.type.name === 'bulletList' && n.textContent === 'Inner');
+      const outerDom = elWithRect(new DOMRect(0, 100, 400, 200));
+      const rects = new Map<number, HTMLElement>([
+        [outerLi, outerDom],
+        [innerUl, elWithRect(new DOMRect(20, 160, 380, 140))], // nested list starts at 160
+      ]);
+      const resolved = { pos: outerLi, rect: outerDom.getBoundingClientRect(), dom: outerDom };
+      // clientY=120 is above the nested list's top (160) -> stay on outer.
+      const out = descendToNearestHoverItem(viewStub(ed, rects), resolved, 120);
+      expect(out.pos).toBe(outerLi);
+      ed.destroy();
+    });
+
+    it('stays on a leaf list ITEM that has no nested sublist', () => {
+      const ed = makeListEditor('<ul><li><p>Solo</p></li></ul>');
+      const li = posOf(ed, (n) => n.type.name === 'listItem');
+      const liDom = elWithRect(new DOMRect(0, 100, 400, 50));
+      const rects = new Map<number, HTMLElement>([[li, liDom]]);
+      const resolved = { pos: li, rect: liDom.getBoundingClientRect(), dom: liDom };
+      const out = descendToNearestHoverItem(viewStub(ed, rects), resolved, 120);
+      expect(out.pos).toBe(li);
+      ed.destroy();
+    });
+  });
+});
+
+// Drag/drop simulation against a mounted editor with hand-stubbed geometry.
+// `dragstart` attaches the document dragover/drop listeners and captures the
+// source, then `dragover`/`drop` on `document` drive the indicator and move.
+describe('BlockHandle nested drag-and-drop (DOM simulation)', () => {
+  const nestedExtensions = [
+    Document, Text, Paragraph, BulletList, OrderedList, ListItem, TaskList, TaskItem,
+    BlockHandle.configure({ nested: true }),
+  ];
+
+  let rafCallbacks: FrameRequestCallback[] = [];
+  function installRafStub(): void {
+    rafCallbacks = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => { /* drained manually */ });
+  }
+  function tickAllRaf(): void {
+    while (rafCallbacks.length > 0) rafCallbacks.shift()?.(performance.now());
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rafCallbacks = [];
+  });
+
+  function mountNested(content: string): Editor {
+    host = document.createElement('div');
+    host.className = 'dm-editor';
+    document.body.appendChild(host);
+    editor = new Editor({ element: host, extensions: nestedExtensions, content });
+    return editor;
+  }
+
+  // Stub the geometry the resolver reads: content element (for
+  // `clampToContent`), the `.dm-editor` host, and per-node rects via `nodeDOM`.
+  // `contentRect` doubles as the top-level list's rect (the `<ul>` IS
+  // `view.dom.firstElementChild`).
+  function stubGeometry(ed: Editor, contentRect: DOMRect, hostRect: DOMRect, rectsByPos: Map<number, DOMRect>): void {
+    const first = ed.view.dom.firstElementChild;
+    if (first instanceof HTMLElement) {
+      Object.defineProperty(first, 'getBoundingClientRect', { value: () => contentRect, configurable: true });
+    }
+    host!.getBoundingClientRect = () => hostRect;
+    const origNodeDOM = ed.view.nodeDOM.bind(ed.view);
+    const view = ed.view as unknown as { nodeDOM: (p: number) => HTMLElement | null };
+    view.nodeDOM = (p: number): HTMLElement | null => {
+      const dom = origNodeDOM(p);
+      const rect = rectsByPos.get(p);
+      if (dom instanceof HTMLElement && rect) {
+        Object.defineProperty(dom, 'getBoundingClientRect', { value: () => rect, configurable: true });
+      }
+      return dom as HTMLElement | null;
+    };
+  }
+
+  function posOf(ed: Editor, predicate: (n: { type: { name: string }; textContent: string }) => boolean): number {
+    let found = -1;
+    ed.state.doc.descendants((node, pos) => {
+      if (found !== -1) return false;
+      if (predicate(node)) { found = pos; return false; }
+      return true;
+    });
+    if (found === -1) throw new Error('node not found');
+    return found;
+  }
+
+  function dragEvent(type: string, clientX: number, clientY: number): Event {
+    const ev = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'clientX', { value: clientX, configurable: true });
+    Object.defineProperty(ev, 'clientY', { value: clientY, configurable: true });
+    return ev;
+  }
+
+  /** Fire dragstart from the drag button with `sourcePos` pre-hovered, so
+   * `onDragStart` captures the source and attaches the document listeners. */
+  function startDrag(ed: Editor, sourcePos: number): void {
+    ed.view.dispatch(ed.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: sourcePos }));
+    const btn = host!.querySelector<HTMLElement>('.dm-block-handle-drag');
+    btn?.dispatchEvent(dragEvent('dragstart', 0, 0));
+  }
+
+  /** Fire dragend so the deferred dragstart commit bails (it guards on a
+   * non-null `pendingDraggedFrom`) and the document listeners detach. */
+  function endDrag(): void {
+    const btn = host!.querySelector<HTMLElement>('.dm-block-handle-drag');
+    btn?.dispatchEvent(dragEvent('dragend', 0, 0));
+  }
+
+  function topListItemTexts(ed: Editor): string[] {
+    const out: string[] = [];
+    ed.state.doc.child(0).forEach((li) => out.push(li.child(0).textContent));
+    return out;
+  }
+  function countType(ed: Editor, name: string): number {
+    let n = 0;
+    ed.state.doc.descendants((node) => { if (node.type.name === name) n += 1; });
+    return n;
+  }
+
+  // Two stacked top-level list items. The wrapper rect (== contentRect)
+  // spans both rows so the Y-walk isn't pruned at the list boundary.
+  function twoItemFixture(): { ed: Editor; target: number; source: number } {
+    const ed = mountNested('<ul><li><p>Target</p></li><li><p>Source</p></li></ul>');
+    const target = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'Target');
+    const targetP = posOf(ed, (n) => n.type.name === 'paragraph' && n.textContent === 'Target');
+    const source = posOf(ed, (n) => n.type.name === 'listItem' && n.textContent === 'Source');
+    const sourceP = posOf(ed, (n) => n.type.name === 'paragraph' && n.textContent === 'Source');
+    const contentRect = new DOMRect(40, 100, 960, 200); // left 40, top 100, bottom 300
+    const hostRect = new DOMRect(0, 90, 1000, 230);      // contains all drop coords
+    stubGeometry(ed, contentRect, hostRect, new Map<number, DOMRect>([
+      [target, new DOMRect(50, 100, 900, 55)],   // 100..155
+      [targetP, new DOMRect(50, 100, 900, 55)],
+      [source, new DOMRect(50, 200, 900, 55)],   // 200..255
+      [sourceP, new DOMRect(50, 200, 900, 55)],
+    ]));
+    return { ed, target, source };
+  }
+
+  it('document drop with nest-zone X nests the source as a child of the target item', () => {
+    const { ed, source } = twoItemFixture();
+    expect(ed.state.doc.child(0).childCount).toBe(2);
+
+    startDrag(ed, source);
+    // X far past the target's left edge (nest zone), Y inside the target row.
+    document.dispatchEvent(dragEvent('drop', 300, 125));
+    endDrag();
+
+    // Source absorbed into Target: one top-level item, both items still exist.
+    expect(ed.state.doc.child(0).childCount).toBe(1);
+    expect(topListItemTexts(ed)).toEqual(['Target']);
+    expect(countType(ed, 'listItem')).toBe(2);
+  });
+
+  it('document drop with sibling X (above mid) reorders the source before the target', () => {
+    const { ed, source } = twoItemFixture();
+
+    startDrag(ed, source);
+    // X just past the left edge but BELOW nestThreshold -> sibling; upper half
+    // of the target row -> insert before it.
+    document.dispatchEvent(dragEvent('drop', 60, 110));
+    endDrag();
+
+    expect(ed.state.doc.child(0).childCount).toBe(2);
+    expect(topListItemTexts(ed)).toEqual(['Source', 'Target']);
+  });
+
+  it('a self-drop (nesting an item onto itself) is consumed as a no-op', () => {
+    const { ed, source } = twoItemFixture();
+    const before = ed.getHTML();
+
+    startDrag(ed, source);
+    // Nest-zone X but the cursor is over the SOURCE's own row.
+    document.dispatchEvent(dragEvent('drop', 300, 225));
+    endDrag();
+
+    expect(ed.getHTML()).toBe(before);
+    expect(ed.state.doc.child(0).childCount).toBe(2);
+  });
+
+  it('PM handleDrop prop runs the same move logic when the drop lands on .ProseMirror', () => {
+    const { ed, source } = twoItemFixture();
+    startDrag(ed, source);
+    // Invoke the registered handleDrop directly (PM would call it for a drop
+    // over the editable). `moved=true` mirrors a same-doc block drag.
+    const slice = ed.state.doc.slice(0, 0);
+    const handled = ed.view.someProp('handleDrop', (fn) =>
+      fn(ed.view, dragEvent('drop', 300, 125) as DragEvent, slice, true),
+    );
+    endDrag();
+
+    expect(handled).toBe(true);
+    expect(ed.state.doc.child(0).childCount).toBe(1);
+  });
+
+  it('handleDrop with moved=false defers to PM (returns false)', () => {
+    const { ed, source } = twoItemFixture();
+    startDrag(ed, source);
+    const slice = ed.state.doc.slice(0, 0);
+    const handled = ed.view.someProp('handleDrop', (fn) =>
+      fn(ed.view, dragEvent('drop', 300, 125) as DragEvent, slice, false),
+    );
+    endDrag();
+    expect(handled).toBeFalsy();
+  });
+
+  it('dragover in the nest zone shows the drop indicator in nested mode', () => {
+    installRafStub();
+    const { ed, source } = twoItemFixture();
+    startDrag(ed, source);
+    document.dispatchEvent(dragEvent('dragover', 300, 125));
+    tickAllRaf();
+
+    const indicator = host!.querySelector<HTMLElement>('.dm-block-drop-indicator');
+    expect(indicator?.getAttribute('data-mode')).toBe('nested');
+    expect(indicator?.hasAttribute('data-show')).toBe(true);
+
+    // A second identical dragover hits the identity gate (same geometry key)
+    // and short-circuits without rewriting the DOM, staying shown afterwards.
+    document.dispatchEvent(dragEvent('dragover', 300, 125));
+    tickAllRaf();
+    expect(indicator?.getAttribute('data-mode')).toBe('nested');
+    expect(indicator?.hasAttribute('data-show')).toBe(true);
+    endDrag();
+  });
+
+  it('mousemove over a list row resolves the hovered item through the nested resolver', () => {
+    installRafStub();
+    const { ed, target } = twoItemFixture();
+    const pm = host!.querySelector<HTMLElement>('.ProseMirror');
+    pm?.dispatchEvent(new MouseEvent('mousemove', { clientX: 300, clientY: 125, bubbles: true }));
+    tickAllRaf();
+    expect(blockHandlePluginKey.getState(ed.state)?.hoveredPos).toBe(target);
+  });
+
+  it('dragstart with no hovered block is cancelled and captures no source', () => {
+    const { ed } = twoItemFixture();
+    const btn = host!.querySelector<HTMLElement>('.dm-block-handle-drag');
+    const ev = dragEvent('dragstart', 0, 0); // hoveredPos still null
+    btn?.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    // No document drop listener was attached, so a drop moves nothing.
+    document.dispatchEvent(dragEvent('drop', 300, 125));
+    expect(ed.state.doc.child(0).childCount).toBe(2);
+  });
+
+  it('dragstart on a hovered pos with no node is cancelled', () => {
+    const { ed } = twoItemFixture();
+    ed.view.dispatch(ed.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: ed.state.doc.content.size }));
+    const btn = host!.querySelector<HTMLElement>('.dm-block-handle-drag');
+    const ev = dragEvent('dragstart', 0, 0);
+    btn?.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('handleDrop with moved=true but no active drag consumes the event without moving', () => {
+    const { ed } = twoItemFixture();
+    const slice = ed.state.doc.slice(0, 0);
+    // No startDrag -> draggedFrom is null; performBlockDrop bails but handleDrop
+    // still consumes the event so PM does not run its default drop logic.
+    const handled = ed.view.someProp('handleDrop', (fn) =>
+      fn(ed.view, dragEvent('drop', 300, 125) as DragEvent, slice, true),
+    );
+    expect(handled).toBe(true);
+    expect(ed.state.doc.child(0).childCount).toBe(2);
+  });
+
+  it('dragover with sibling X shows the drop indicator in sibling mode', () => {
+    installRafStub();
+    const { ed, source } = twoItemFixture();
+    startDrag(ed, source);
+    document.dispatchEvent(dragEvent('dragover', 60, 110));
+    tickAllRaf();
+
+    const indicator = host!.querySelector<HTMLElement>('.dm-block-drop-indicator');
+    expect(indicator?.getAttribute('data-mode')).toBe('sibling');
+    expect(indicator?.hasAttribute('data-show')).toBe(true);
+    endDrag();
+  });
+
+  it('dragover outside the drop zone cancels a pending repaint and hides the indicator', () => {
+    installRafStub();
+    const { ed, source } = twoItemFixture();
+    startDrag(ed, source);
+    // First a valid in-zone dragover to show it.
+    document.dispatchEvent(dragEvent('dragover', 300, 125));
+    tickAllRaf();
+    const indicator = host!.querySelector<HTMLElement>('.dm-block-drop-indicator');
+    expect(indicator?.hasAttribute('data-show')).toBe(true);
+
+    // Queue another repaint WITHOUT ticking, so a coalescing rAF is pending,
+    // then leave the zone: the pending rAF is cancelled and it hides.
+    document.dispatchEvent(dragEvent('dragover', 300, 130));
+    document.dispatchEvent(dragEvent('dragover', 5000, 5000));
+    expect(indicator?.hasAttribute('data-show')).toBe(false);
+    endDrag();
   });
 });

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -454,6 +454,14 @@ function adjustDropTargetForListWrapper(
   return { pos: childPos, rect: childDom.getBoundingClientRect(), dom: childDom };
 }
 
+/** Client-coord gap rect an indicator line draws into. */
+interface ChildGapRect {
+  top: number;
+  bottom: number;
+  left: number;
+  width: number;
+}
+
 /**
  * Resolved drop target, shared by `handleDrop` and `updateDropIndicator` so
  * the indicator draws exactly where the drop lands. `mode` is `'sibling'`
@@ -479,7 +487,7 @@ export interface DropPlacement {
    */
   childIndex?: number;
   /** Client-coord gap the chosen `childIndex` slot occupies (drives the line). */
-  nestedGapRect?: { top: number; bottom: number; left: number; width: number };
+  nestedGapRect?: ChildGapRect;
   /**
    * The deepest-match item the resolver landed on, BEFORE gap-normalization
    * rewrites `pos`. Fed back as `incumbentPos` next dragover for Y-hysteresis.
@@ -536,6 +544,12 @@ export function computeDropPlacement(
       const targetRect = resolved.rect;
       const xInTarget = clientX - targetRect.left;
       const isInsideX = xInTarget >= 0 && xInTarget <= targetRect.width;
+      // The X-latch and child-slot incumbent only apply while the cursor stays
+      // on the SAME item they were captured on, so moving to another list item
+      // re-requires crossing its own enter threshold. A null incumbentPos
+      // (stateless unit callers) counts as "same item" to keep their contract.
+      const inc = options.incumbentPos ?? null;
+      const sameItem = inc === null || inc === resolved.pos;
       // X-hysteresis: with the latch off, enter nested only past
       // `nestThreshold + band`; once latched, stay nested until the cursor
       // falls back below `nestThreshold - band`. The band is 0 unless the
@@ -544,7 +558,7 @@ export function computeDropPlacement(
       const xBand = options.hysteresis ? DROP_HYSTERESIS_X_PX : 0;
       const enterZone = nestThreshold + xBand;
       const leaveZone = nestThreshold - xBand;
-      const isInNestZone = options.nestLatched
+      const isInNestZone = sameItem && options.nestLatched
         ? xInTarget >= leaveZone
         : xInTarget >= enterZone;
       const isInsideY = clientY >= targetRect.top && clientY <= targetRect.bottom;
@@ -562,7 +576,7 @@ export function computeDropPlacement(
           resolved.pos,
           targetRect,
           clientY,
-          options.incumbentChildIndex ?? null,
+          sameItem ? options.incumbentChildIndex ?? null : null,
           childBand,
         );
         // `insertAfter` kept Y-mid-meaningful though the nested drop ignores it.
@@ -615,13 +629,6 @@ function findPreviousSiblingAtSameDepth(
   return { pos: prevPos, rect: prevDom.getBoundingClientRect() };
 }
 
-interface ChildGapRect {
-  top: number;
-  bottom: number;
-  left: number;
-  width: number;
-}
-
 interface ChildSlot {
   /** Child-array index to insert at, in `[1, childCount]`. */
   childIndex: number;
@@ -635,7 +642,9 @@ interface ChildSlot {
  * the cursor)`, clamped to `[1, childCount]` (index 0 is the label; mid-line
  * not gap-edge so flush children aren't ambiguous). `band > 0` keeps the
  * `incumbentChildIndex` sticky within `band` px of a boundary. Degrades to
- * append-last when a child rect is unavailable.
+ * append-last when a child rect is unavailable. All gaps share the item's
+ * horizontal content column (only Y varies), so the indented line lands at a
+ * consistent depth regardless of which child borders the gap.
  */
 function resolveChildSlot(
   view: EditorView,
@@ -647,38 +656,26 @@ function resolveChildSlot(
   band: number,
 ): ChildSlot {
   const childCount = item.childCount;
-  const appendGap: ChildGapRect = {
-    top: itemRect.bottom,
-    bottom: itemRect.bottom,
+  const gap = (top: number, bottom: number): ChildGapRect => ({
+    top,
+    bottom,
     left: itemRect.left,
     width: itemRect.width,
-  };
+  });
+  const append: ChildSlot = { childIndex: childCount, gapRect: gap(itemRect.bottom, itemRect.bottom) };
 
+  // Measure each child's rect; `posAtIndex` gives the position before child i.
+  const $item = view.state.doc.resolve(itemStart + 1);
   const rects: DOMRect[] = [];
-  let allPresent = true;
-  let childPos = itemStart + 1; // one past the item's open token (label start)
   for (let i = 0; i < childCount; i++) {
-    const dom = view.nodeDOM(childPos);
-    if (dom instanceof HTMLElement) {
-      rects.push(dom.getBoundingClientRect());
-    } else {
-      allPresent = false;
-      rects.push(itemRect);
-    }
-    childPos += item.child(i).nodeSize;
+    const dom = view.nodeDOM($item.posAtIndex(i, $item.depth));
+    if (!(dom instanceof HTMLElement)) return append; // degrade on first missing rect
+    rects.push(dom.getBoundingClientRect());
   }
 
-  // Degrade to append-last when a rect is missing.
   const label = rects[0];
-  if (!allPresent || !label) return { childIndex: childCount, gapRect: appendGap };
-
-  // Label only: the one reachable slot is index 1 (== append).
-  if (childCount === 1) {
-    return {
-      childIndex: 1,
-      gapRect: { top: label.bottom, bottom: label.bottom, left: label.left, width: label.width },
-    };
-  }
+  if (!label) return append;
+  if (childCount === 1) return { childIndex: 1, gapRect: gap(label.bottom, label.bottom) };
 
   let index = 1;
   for (let i = 1; i < childCount; i++) {
@@ -701,17 +698,8 @@ function resolveChildSlot(
 
   const above = rects[index - 1];
   const below = index < childCount ? rects[index] : undefined;
-  if (!above) return { childIndex: index, gapRect: appendGap };
-  if (!below) {
-    return {
-      childIndex: index,
-      gapRect: { top: above.bottom, bottom: above.bottom, left: above.left, width: above.width },
-    };
-  }
-  return {
-    childIndex: index,
-    gapRect: { top: above.bottom, bottom: below.top, left: below.left, width: below.width },
-  };
+  if (!above) return append;
+  return { childIndex: index, gapRect: gap(above.bottom, below ? below.top : above.bottom) };
 }
 
 /**
@@ -792,15 +780,23 @@ export function createBlockHandlePlugin(
 
   // Drop-indicator drag-session state. The dragover->indicator path mirrors
   // the hover path: rAF-coalesced, repainted only when the line moves
-  // (`currentDropKey`). The incumbent fields carry the previous resolution
-  // forward for Y/X/child-slot hysteresis; `resetDropState` clears all of them
-  // on every teardown so a stale incumbent can't glue the next drag.
+  // (`currentDropKey`). `dragHyst` carries the previous resolution forward for
+  // Y/X/child-slot hysteresis; bundling the three axes makes every reset
+  // atomic so a stale incumbent can't glue a later resolution.
   let dropRaf: number | null = null;
   let pendingDropCoords: { x: number; y: number } | null = null;
   let currentDropKey: string | null = null;
-  let dragIncumbentPos: number | null = null;
-  let dragNestLatched = false;
-  let dragIncumbentChildIndex: number | null = null;
+  const dragHyst: { incumbentPos: number | null; nestLatched: boolean; childIndex: number | null } = {
+    incumbentPos: null,
+    nestLatched: false,
+    childIndex: null,
+  };
+
+  const resetDragHyst = (): void => {
+    dragHyst.incumbentPos = null;
+    dragHyst.nestLatched = false;
+    dragHyst.childIndex = null;
+  };
 
   const resetDropState = (): void => {
     if (dropRaf !== null) {
@@ -809,9 +805,7 @@ export function createBlockHandlePlugin(
     }
     pendingDropCoords = null;
     currentDropKey = null;
-    dragIncumbentPos = null;
-    dragNestLatched = false;
-    dragIncumbentChildIndex = null;
+    resetDragHyst();
   };
 
   // Auto-scroll state machine (populated during an active drag, reset by
@@ -1092,13 +1086,16 @@ export function createBlockHandlePlugin(
     if (inZone) event.preventDefault();
     if (!dropIndicator) return;
     if (!inZone) {
-      // Left the zone: hide and clear any queued repaint + identity gate.
+      // Left the zone: hide, clear any queued repaint + identity gate, and
+      // drop the hysteresis incumbents so re-entry resolves fresh (a stale
+      // nest-latch must not survive a round-trip out of the editor).
       if (dropRaf !== null) {
         cancelAnimationFrame(dropRaf);
         dropRaf = null;
       }
       pendingDropCoords = null;
       currentDropKey = null;
+      resetDragHyst();
       indicator.removeAttribute('data-show');
       return;
     }
@@ -1171,9 +1168,9 @@ export function createBlockHandlePlugin(
     // Resolve with the SAME hysteresis state the indicator last used, so the
     // drop lands exactly where the (stabilized) line was drawn.
     const placement = computeDropPlacement(view, clientX, clientY, nested, nestThreshold, {
-      incumbentPos: dragIncumbentPos,
-      nestLatched: dragNestLatched,
-      incumbentChildIndex: dragIncumbentChildIndex,
+      incumbentPos: dragHyst.incumbentPos,
+      nestLatched: dragHyst.nestLatched,
+      incumbentChildIndex: dragHyst.childIndex,
       hysteresis: true,
     });
     if (!placement) return false;
@@ -1197,14 +1194,19 @@ export function createBlockHandlePlugin(
         view.dispatch(tr.scrollIntoView());
         return true;
       }
-      // Helper bailed. If the source is inside the target item it was a
-      // self-drop no-op: consume the event rather than ejecting it to a
-      // sibling. A true schema reject falls through to the sibling move.
+      // Helper bailed. Treat a SELF-drop (source and target overlap either
+      // way: source inside the target item, or the target sits inside the
+      // dragged source's subtree) as a no-op and consume the event, rather
+      // than ejecting the block to a sibling. A true schema reject (no
+      // overlap) falls through to the sibling move below.
       const targetItem = view.state.doc.nodeAt(placement.targetItemPos);
       const targetItemEnd = targetItem
         ? placement.targetItemPos + targetItem.nodeSize
         : placement.targetItemPos;
-      if (draggedFrom >= placement.targetItemPos && draggedFrom < targetItemEnd) {
+      const sourceEnd = draggedFrom + sourceNode.nodeSize;
+      const sourceInTarget = draggedFrom >= placement.targetItemPos && draggedFrom < targetItemEnd;
+      const targetInSource = placement.targetItemPos >= draggedFrom && placement.targetItemPos < sourceEnd;
+      if (sourceInTarget || targetInSource) {
         return true;
       }
     }
@@ -1241,9 +1243,9 @@ export function createBlockHandlePlugin(
   const updateDropIndicator = (clientX: number, clientY: number): void => {
     if (!editorEl) return;
     const placement = computeDropPlacement(editor.view, clientX, clientY, nested, nestThreshold, {
-      incumbentPos: dragIncumbentPos,
-      nestLatched: dragNestLatched,
-      incumbentChildIndex: dragIncumbentChildIndex,
+      incumbentPos: dragHyst.incumbentPos,
+      nestLatched: dragHyst.nestLatched,
+      incumbentChildIndex: dragHyst.childIndex,
       hysteresis: true,
     });
     if (!placement) {
@@ -1253,9 +1255,9 @@ export function createBlockHandlePlugin(
     }
     // Carry the resolution forward for next dragover's hysteresis (always,
     // even when the repaint is gated below). Child slot only while nested.
-    dragIncumbentPos = placement.resolvedBlockPos ?? null;
-    dragNestLatched = placement.mode === 'nested';
-    dragIncumbentChildIndex = placement.mode === 'nested' ? placement.childIndex ?? null : null;
+    dragHyst.incumbentPos = placement.resolvedBlockPos ?? null;
+    dragHyst.nestLatched = placement.mode === 'nested';
+    dragHyst.childIndex = placement.mode === 'nested' ? placement.childIndex ?? null : null;
 
     const editorRect = editorEl.getBoundingClientRect();
 
@@ -1263,19 +1265,18 @@ export function createBlockHandlePlugin(
     let left: number;
     let width: number;
     if (placement.mode === 'nested') {
-      // Draw in the chosen child gap, indented to the children zone. Fall back
-      // to the item's bottom (legacy append) when `nestedGapRect` is absent.
+      // Anchor on the gap's TOP edge, indented to the children zone, the same
+      // way the sibling line anchors on a rect edge. The theme's small
+      // `translateY` tuck (see `_block-handle.scss`) then applies uniformly,
+      // so JS owns no CSS-coupled pixel offset. Fall back to the item bottom
+      // (legacy append) when `nestedGapRect` is absent.
       const indent = NESTED_INDICATOR_INDENT_PX;
       const gap = placement.nestedGapRect ?? {
         top: placement.rect.bottom,
-        bottom: placement.rect.bottom,
         left: placement.rect.left,
         width: placement.rect.width,
       };
-      // The nested CSS nudges -2px: add it back for a real gap (center the
-      // line); keep it for a thin edge band (append/flush) to match legacy.
-      const cssNudgeComp = gap.top === gap.bottom ? 0 : 2;
-      lineY = (gap.top + gap.bottom) / 2 + cssNudgeComp - editorRect.top;
+      lineY = gap.top - editorRect.top;
       left = gap.left - editorRect.left + indent;
       width = Math.max(0, gap.width - indent);
     } else {

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -27,6 +27,7 @@ import type { Node, Slice } from '@domternal/pm/model';
 import { findDeepestBlockAtY } from './helpers/findTopLevelBlock.js';
 import { moveBlock } from './helpers/moveBlock.js';
 import { moveBlockAsNestedChild } from './helpers/moveBlockAsNestedChild.js';
+import { resolveDropDepth, hasShallowerListAncestor } from './helpers/resolveDropDepth.js';
 import { createDragGhost } from './helpers/dragGhost.js';
 import { clampToContent } from './helpers/clampCoords.js';
 import { resolveGutterBias } from './helpers/gutterBias.js';
@@ -591,6 +592,44 @@ export function computeDropPlacement(
           nestedGapRect: slot.gapRect,
           resolvedBlockPos,
         };
+      }
+    }
+  }
+
+  // Outdent ladder: when the cursor sits to the LEFT of a NESTED list item's
+  // content (and inside its row), X picks a shallower ancestor level, so the
+  // drop becomes a sibling AFTER that ancestor (drag left to outdent, Notion-
+  // style). This resolves to a plain sibling placement pointing at the
+  // ancestor: the existing sibling drop computes `ancestorPos + nodeSize`
+  // (== the position after the ancestor) and the indicator draws at the
+  // ancestor's bottom edge indented to its left, so indicator == drop.
+  if (nestThreshold > 0) {
+    const targetNode = view.state.doc.nodeAt(resolved.pos);
+    const inRowY = clientY >= resolved.rect.top && clientY <= resolved.rect.bottom;
+    if (
+      targetNode
+      && LIST_ITEM_TYPES.has(targetNode.type.name)
+      && inRowY
+      && clientX < resolved.rect.left
+      && hasShallowerListAncestor(view.state.doc, resolved.pos)
+    ) {
+      const rung = resolveDropDepth({
+        view,
+        itemPos: resolved.pos,
+        clientX,
+        indentStep: nestThreshold,
+      });
+      if (rung?.kind === 'sibling' && rung.itemPos !== resolved.pos) {
+        const ancDom = view.nodeDOM(rung.itemPos);
+        if (ancDom instanceof HTMLElement) {
+          return {
+            pos: rung.itemPos,
+            rect: ancDom.getBoundingClientRect(),
+            insertAfter: true,
+            mode: 'sibling',
+            resolvedBlockPos,
+          };
+        }
       }
     }
   }

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -57,6 +57,23 @@ const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
 export const DEFAULT_NEST_THRESHOLD = 28;
 
 /**
+ * Sticky dead-band (px) for the drag drop-target resolution. The block
+ * resolved on the previous dragover keeps a margin this wide around its
+ * rect, so a sub-band cursor wobble near a nested-list boundary can't flip
+ * the resolved target outer<->inner. Tuned small enough to stay responsive
+ * when the cursor decisively enters a new row. See `findDeepestBlockAtY`.
+ */
+export const DROP_HYSTERESIS_Y_PX = 6;
+
+/**
+ * Sticky dead-band (px) around `nestThreshold` for the sibling<->nested
+ * mode latch. Once nested mode is entered the cursor must fall back below
+ * `nestThreshold - band` to leave it (and exceed `nestThreshold + band`
+ * to enter), removing the solid<->dashed flicker right at the threshold.
+ */
+export const DROP_HYSTERESIS_X_PX = 8;
+
+/**
  * Pixel inset of the nested-mode drop indicator from the resolved
  * block's left edge. Mirrors `--dm-block-children-indent` (1.5rem ≈
  * 24px) so the dashed line lands exactly where a nested child block
@@ -312,6 +329,7 @@ function resolveBlockAtCoords(
   clientX: number,
   clientY: number,
   nested: NestedResolution,
+  incumbentPos: number | null = null,
 ): { pos: number; rect: DOMRect; dom: HTMLElement } | null {
   // Mode A - top-level only (classic). Walk doc children by Y range; X
   // is intentionally ignored so the handle still surfaces when the
@@ -348,7 +366,10 @@ function resolveBlockAtCoords(
   // firstChildOfListItem) applies consistently with Mode C - hosts
   // extending allowedNodes to include `paragraph` get label-paragraph
   // rejection for free.
-  const found = findDeepestBlockAtY(view, clamped.y, nested.allowedNodes, nested.matchers);
+  const found = findDeepestBlockAtY(view, clamped.y, nested.allowedNodes, nested.matchers, {
+    incumbentPos,
+    hysteresisBand: DROP_HYSTERESIS_Y_PX,
+  });
   if (found) {
     return { pos: found.pos, rect: found.rect, dom: found.dom };
   }
@@ -480,6 +501,32 @@ export interface DropPlacement {
   targetItemPos?: number;
   /** Position of the containing list wrapper when `mode === 'nested'`. */
   wrapperPos?: number;
+  /**
+   * Position of the block the spatial resolver actually landed on (the
+   * deepest-match item BEFORE gap-normalization rewrites `pos` to a previous
+   * sibling). The drag pipeline feeds this back as `incumbentPos` on the
+   * next dragover so the Y-hysteresis can keep the same target sticky.
+   * `undefined` for callers that don't track an incumbent (e.g. tests).
+   */
+  resolvedBlockPos?: number;
+}
+
+/**
+ * Per-drag hysteresis state threaded into {@link computeDropPlacement} by
+ * the drag pipeline. Omitted by pure callers (tests) so the resolver keeps
+ * its hard, stateless thresholds.
+ */
+export interface DropPlacementOptions {
+  /** Block resolved on the previous dragover, for Y-hysteresis stickiness. */
+  incumbentPos?: number | null;
+  /** Whether nested mode was latched on the previous dragover, for X-hysteresis. */
+  nestLatched?: boolean;
+  /**
+   * Enable the hysteresis dead-bands. Off by default so unit callers get
+   * the exact-threshold behaviour the contract tests assert; the live
+   * plugin passes `true`.
+   */
+  hysteresis?: boolean;
 }
 
 /**
@@ -513,10 +560,14 @@ export function computeDropPlacement(
   clientY: number,
   nested: NestedResolution,
   nestThreshold: number = DEFAULT_NEST_THRESHOLD,
+  options: DropPlacementOptions = {},
 ): DropPlacement | null {
-  const initial = resolveBlockAtCoords(view, clientX, clientY, nested);
+  const incumbentPos = options.incumbentPos ?? null;
+  const initial = resolveBlockAtCoords(view, clientX, clientY, nested, incumbentPos);
   if (!initial) return null;
   const resolved = adjustDropTargetForListWrapper(view, initial, clientY);
+  // The deepest-match item, fed back as the next dragover's incumbent.
+  const resolvedBlockPos = resolved.pos;
 
   // X-threshold detection: when the resolved target is a list item and
   // the cursor sits >= nestThreshold px from its left edge (inside the
@@ -528,7 +579,17 @@ export function computeDropPlacement(
       const targetRect = resolved.rect;
       const xInTarget = clientX - targetRect.left;
       const isInsideX = xInTarget >= 0 && xInTarget <= targetRect.width;
-      const isInNestZone = xInTarget >= nestThreshold;
+      // X-hysteresis: with the latch off, enter nested only past
+      // `nestThreshold + band`; once latched, stay nested until the cursor
+      // falls back below `nestThreshold - band`. The band is 0 unless the
+      // live plugin opts in, so the stateless contract (enter at exactly
+      // `nestThreshold`) is preserved for unit callers.
+      const xBand = options.hysteresis ? DROP_HYSTERESIS_X_PX : 0;
+      const enterZone = nestThreshold + xBand;
+      const leaveZone = nestThreshold - xBand;
+      const isInNestZone = options.nestLatched
+        ? xInTarget >= leaveZone
+        : xInTarget >= enterZone;
       const isInsideY = clientY >= targetRect.top && clientY <= targetRect.bottom;
       if (isInsideX && isInNestZone && isInsideY) {
         // Walk up to the wrapping list. `$resolved.before()` is the
@@ -547,6 +608,7 @@ export function computeDropPlacement(
           mode: 'nested',
           targetItemPos: resolved.pos,
           wrapperPos,
+          resolvedBlockPos,
         };
       }
     }
@@ -559,10 +621,10 @@ export function computeDropPlacement(
   if (!insertAfter) {
     const prev = findPreviousSiblingAtSameDepth(view, resolved.pos);
     if (prev) {
-      return { pos: prev.pos, rect: prev.rect, insertAfter: true, mode: 'sibling' };
+      return { pos: prev.pos, rect: prev.rect, insertAfter: true, mode: 'sibling', resolvedBlockPos };
     }
   }
-  return { pos: resolved.pos, rect, insertAfter, mode: 'sibling' };
+  return { pos: resolved.pos, rect, insertAfter, mode: 'sibling', resolvedBlockPos };
 }
 
 /**
@@ -667,6 +729,33 @@ export function createBlockHandlePlugin(
   // independent of both, so reading from here is reliable. Cleared on
   // dragend, so it never lingers across drags.
   let pendingDraggedFrom: number | null = null;
+
+  // --- Drop-indicator drag-session state.
+  //
+  // The dragover->indicator path mirrors the hover path's rAF coalescing +
+  // identity gate so the indicator repaints at most once per frame and ONLY
+  // when the line it would draw actually moves. `dragIncumbentPos` and
+  // `dragNestLatched` carry the previous resolution forward so the resolver
+  // and the sibling<->nested flip stay sticky (Y- and X-hysteresis). All
+  // four reset together via `resetDropState` on every drag-teardown path so
+  // a stale incumbent can never glue the indicator to a phantom target on
+  // the next drag.
+  let dropRaf: number | null = null;
+  let pendingDropCoords: { x: number; y: number } | null = null;
+  let currentDropKey: string | null = null;
+  let dragIncumbentPos: number | null = null;
+  let dragNestLatched = false;
+
+  const resetDropState = (): void => {
+    if (dropRaf !== null) {
+      cancelAnimationFrame(dropRaf);
+      dropRaf = null;
+    }
+    pendingDropCoords = null;
+    currentDropKey = null;
+    dragIncumbentPos = null;
+    dragNestLatched = false;
+  };
 
   // Auto-scroll state machine (populated during an active drag, reset by
   // `resetAutoScroll`). Grouped into one object so every reset clears every
@@ -944,13 +1033,32 @@ export function createBlockHandlePlugin(
     // whatever element is under the cursor; bubbles up to our document
     // drop listener, which performs the move.
     if (inZone) event.preventDefault();
-    if (dropIndicator) {
-      if (!inZone) {
-        indicator.removeAttribute('data-show');
-        return;
+    if (!dropIndicator) return;
+    if (!inZone) {
+      // Left the zone: drop the indicator and any queued repaint, and clear
+      // the identity gate so re-entry repaints from scratch.
+      if (dropRaf !== null) {
+        cancelAnimationFrame(dropRaf);
+        dropRaf = null;
       }
-      updateDropIndicator(event.clientX, event.clientY);
+      pendingDropCoords = null;
+      currentDropKey = null;
+      indicator.removeAttribute('data-show');
+      return;
     }
+    // Coalesce indicator updates to one rAF per frame (mirrors the hover
+    // path). dragover fires far faster than 60Hz on high-refresh pointers;
+    // recomputing + repainting per event renders every micro-instability
+    // raw. preventDefault and the auto-scroll Y bookkeeping above MUST stay
+    // synchronous on the event tick - only the indicator repaint defers.
+    pendingDropCoords = { x: event.clientX, y: event.clientY };
+    if (dropRaf !== null) return;
+    dropRaf = requestAnimationFrame(() => {
+      dropRaf = null;
+      const coords = pendingDropCoords;
+      pendingDropCoords = null;
+      if (coords) updateDropIndicator(coords.x, coords.y);
+    });
   };
 
   /**
@@ -1006,7 +1114,13 @@ export function createBlockHandlePlugin(
     if (draggedFrom === null) return false;
     const sourceNode = view.state.doc.nodeAt(draggedFrom);
     if (!sourceNode) return false;
-    const placement = computeDropPlacement(view, clientX, clientY, nested, nestThreshold);
+    // Resolve with the SAME hysteresis state the indicator last used, so the
+    // drop lands exactly where the (stabilized) line was drawn.
+    const placement = computeDropPlacement(view, clientX, clientY, nested, nestThreshold, {
+      incumbentPos: dragIncumbentPos,
+      nestLatched: dragNestLatched,
+      hysteresis: true,
+    });
     if (!placement) return false;
     const tr = view.state.tr;
 
@@ -1074,11 +1188,22 @@ export function createBlockHandlePlugin(
    */
   const updateDropIndicator = (clientX: number, clientY: number): void => {
     if (!editorEl) return;
-    const placement = computeDropPlacement(editor.view, clientX, clientY, nested, nestThreshold);
+    const placement = computeDropPlacement(editor.view, clientX, clientY, nested, nestThreshold, {
+      incumbentPos: dragIncumbentPos,
+      nestLatched: dragNestLatched,
+      hysteresis: true,
+    });
     if (!placement) {
       indicator.removeAttribute('data-show');
+      currentDropKey = null;
       return;
     }
+    // Carry the resolution forward so the NEXT dragover stays sticky to the
+    // same target (Y-hysteresis) and the same mode (X-hysteresis). Always
+    // updated, even when the repaint is gated below.
+    dragIncumbentPos = placement.resolvedBlockPos ?? null;
+    dragNestLatched = placement.mode === 'nested';
+
     const editorRect = editorEl.getBoundingClientRect();
 
     let lineY: number;
@@ -1101,6 +1226,16 @@ export function createBlockHandlePlugin(
       left = placement.rect.left - editorRect.left;
       width = placement.rect.width;
     }
+    // Identity gate: skip the DOM writes when the line would land in the
+    // same pixel spot it already occupies (rounded geometry + mode). This
+    // is the drag-path equivalent of the hover path's `currentHoveredPos`
+    // gate. Gating on the DRAWN geometry (not just placement.pos) keeps the
+    // indicator correct during auto-scroll, where the same logical slot
+    // moves on screen and SHOULD repaint.
+    const key = `${placement.mode}|${String(Math.round(lineY))}|${String(Math.round(left))}|${String(Math.round(width))}`;
+    if (key === currentDropKey && indicator.hasAttribute('data-show')) return;
+    currentDropKey = key;
+
     indicator.style.top = `${String(lineY)}px`;
     indicator.style.left = `${String(left)}px`;
     indicator.style.width = `${String(width)}px`;
@@ -1114,6 +1249,8 @@ export function createBlockHandlePlugin(
 
   const hideDropIndicator = (): void => {
     indicator.removeAttribute('data-show');
+    // Drop the identity gate so the next show repaints from scratch.
+    currentDropKey = null;
   };
 
   let dragoverAttached = false;
@@ -1132,6 +1269,10 @@ export function createBlockHandlePlugin(
     document.removeEventListener('dragover', onDocumentDragover);
     document.removeEventListener('drop', onDocumentDrop);
     dragoverAttached = false;
+    // Every drag-teardown path (dragend, dead-man switch, editor destroy)
+    // funnels through here, so clearing the drop-session state here means a
+    // stale incumbent / latch can never leak into the next drag.
+    resetDropState();
   };
 
   const autoScrollTick = (): void => {
@@ -1278,6 +1419,10 @@ export function createBlockHandlePlugin(
       editorEl?.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: false }));
       hide();
     }, 0);
+
+    // Start this drag with clean hysteresis state - no incumbent yet, no
+    // latched nested mode - so the first dragover resolves freely.
+    resetDropState();
 
     // Begin tracking dragover Y and ramping scroll as the cursor nears
     // viewport edges. No-op when `autoScroll: false` or no scroll ancestor.

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -56,29 +56,13 @@ const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
  */
 export const DEFAULT_NEST_THRESHOLD = 28;
 
-/**
- * Sticky dead-band (px) for the drag drop-target resolution. The block
- * resolved on the previous dragover keeps a margin this wide around its
- * rect, so a sub-band cursor wobble near a nested-list boundary can't flip
- * the resolved target outer<->inner. Tuned small enough to stay responsive
- * when the cursor decisively enters a new row. See `findDeepestBlockAtY`.
- */
+/** Sticky Y dead-band (px) so a wobble near a nested-list boundary can't flip the resolved target. */
 export const DROP_HYSTERESIS_Y_PX = 6;
 
-/**
- * Sticky dead-band (px) around `nestThreshold` for the sibling<->nested
- * mode latch. Once nested mode is entered the cursor must fall back below
- * `nestThreshold - band` to leave it (and exceed `nestThreshold + band`
- * to enter), removing the solid<->dashed flicker right at the threshold.
- */
+/** Sticky X dead-band (px) around `nestThreshold` so the sibling<->nested mode doesn't flicker. */
 export const DROP_HYSTERESIS_X_PX = 8;
 
-/**
- * Pixel inset of the nested-mode drop indicator from the resolved
- * block's left edge. Mirrors `--dm-block-children-indent` (1.5rem ≈
- * 24px) so the dashed line lands exactly where a nested child block
- * would render inside the list item.
- */
+/** Nested-indicator inset from the block's left edge; mirrors `--dm-block-children-indent` (≈24px). */
 const NESTED_INDICATOR_INDENT_PX = 24;
 
 /**
@@ -471,110 +455,61 @@ function adjustDropTargetForListWrapper(
 }
 
 /**
- * Resolved drop target shared by `handleDrop` and `updateDropIndicator`
- * so the indicator draws exactly where the drop lands (no
- * "indicator says X, item drops Y" mismatch).
- *
- * `mode` distinguishes the two ways a block can be dropped over a list
- * item: `'sibling'` (the existing behaviour, drop position becomes a
- * new sibling of the target via the standard `moveBlock` flow) and
- * `'nested'` (drop becomes a nested child of `targetItemPos` inside
- * `wrapperPos`, applied via `insertAsListItemChild`). Today every
- * placement is `'sibling'`; the `'nested'` branch activates in a
- * follow-up that adds X-threshold detection.
+ * Resolved drop target, shared by `handleDrop` and `updateDropIndicator` so
+ * the indicator draws exactly where the drop lands. `mode` is `'sibling'`
+ * (drop as a sibling via `moveBlock`) or `'nested'` (drop as a child of
+ * `targetItemPos` inside `wrapperPos` via `insertAsListItemChild`).
  */
 export interface DropPlacement {
   /** Position right BEFORE the resolved block (same convention as `nodeAt`). */
   pos: number;
   /** Bounding rect of the resolved block, used to draw the indicator line. */
   rect: DOMRect;
-  /**
-   * `true` -> drop lands AFTER the resolved block; `false` -> BEFORE.
-   * Computed from cursor Y vs the resolved block's mid-line. Read by the
-   * sibling-style drop pipeline; ignored when `mode === 'nested'` (the
-   * nested branch dispatches via `insertAsListItemChild`).
-   */
+  /** `true` -> drop AFTER the block, `false` -> BEFORE (Y-mid). Ignored when nested. */
   insertAfter: boolean;
-  /** Sibling drop (current behaviour) vs nested-child drop (drop-indent). */
+  /** Sibling drop vs nested-child drop. */
   mode: 'sibling' | 'nested';
-  /** Position of the target list item when `mode === 'nested'`. */
+  /** Target list item (nested only). */
   targetItemPos?: number;
-  /** Position of the containing list wrapper when `mode === 'nested'`. */
+  /** Containing list wrapper (nested only). */
   wrapperPos?: number;
   /**
-   * Child-array index inside `targetItemPos` where a nested drop lands.
-   * Always `>= 1` (index 0 is the immutable label paragraph) and `<=` the
-   * item's `childCount` (where `=== childCount` means append-last, the
-   * legacy behaviour). Present only when `mode === 'nested'`; lets the drop
-   * land at the FIRST / between / LAST child slot the cursor picked.
+   * Child index a nested drop lands at, in `[1, childCount]` (index 0 is the
+   * label; `=== childCount` means append). Picks first/between/last slot.
    */
   childIndex?: number;
-  /**
-   * Client-coord gap rect the nested indicator draws into (the gap the
-   * chosen `childIndex` slot occupies). Lets `updateDropIndicator` place the
-   * line at the exact child gap instead of the item's bottom edge. Present
-   * only when `mode === 'nested'`.
-   */
+  /** Client-coord gap the chosen `childIndex` slot occupies (drives the line). */
   nestedGapRect?: { top: number; bottom: number; left: number; width: number };
   /**
-   * Position of the block the spatial resolver actually landed on (the
-   * deepest-match item BEFORE gap-normalization rewrites `pos` to a previous
-   * sibling). The drag pipeline feeds this back as `incumbentPos` on the
-   * next dragover so the Y-hysteresis can keep the same target sticky.
-   * `undefined` for callers that don't track an incumbent (e.g. tests).
+   * The deepest-match item the resolver landed on, BEFORE gap-normalization
+   * rewrites `pos`. Fed back as `incumbentPos` next dragover for Y-hysteresis.
    */
   resolvedBlockPos?: number;
 }
 
 /**
- * Per-drag hysteresis state threaded into {@link computeDropPlacement} by
- * the drag pipeline. Omitted by pure callers (tests) so the resolver keeps
- * its hard, stateless thresholds.
+ * Per-drag hysteresis state threaded into {@link computeDropPlacement}.
+ * Omitted by pure callers (tests) so the resolver stays stateless.
  */
 export interface DropPlacementOptions {
-  /** Block resolved on the previous dragover, for Y-hysteresis stickiness. */
+  /** Previous dragover's resolved block, for Y-hysteresis. */
   incumbentPos?: number | null;
-  /** Whether nested mode was latched on the previous dragover, for X-hysteresis. */
+  /** Whether nested was latched last dragover, for X-hysteresis. */
   nestLatched?: boolean;
-  /**
-   * Child slot index resolved on the previous dragover, for the nested
-   * child-slot dead-band so a tiny Y wobble near a gap boundary doesn't flip
-   * `childIndex`. Only meaningful while `nestLatched` stays true on the same
-   * target item.
-   */
+  /** Previous dragover's child slot, for the nested child-slot dead-band. */
   incumbentChildIndex?: number | null;
-  /**
-   * Enable the hysteresis dead-bands. Off by default so unit callers get
-   * the exact-threshold behaviour the contract tests assert; the live
-   * plugin passes `true`.
-   */
+  /** Enable the dead-bands (off for unit callers, `true` from the plugin). */
   hysteresis?: boolean;
 }
 
 /**
- * Computes the FINAL drop placement using the same logic `handleDrop`
- * uses. Returned by both the actual drop handler AND the visual drop
- * indicator so the line draws exactly where the drop will land - no
- * "indicator says one place, item drops elsewhere" mismatch (the classic
- * dropcursor pain point with custom drop handlers).
+ * Computes the final drop placement; returned by BOTH the drop handler and
+ * the indicator so the line draws exactly where the drop lands. Returns
+ * `null` when no candidate is found (e.g. empty doc).
  *
- * - `rect` is the resolved target block's rect (for drawing the line)
- * - `insertAfter` decides whether the line sits above or below the rect
- *   AND whether the drop pos becomes `pos + nodeSize` or `pos`
- *
- * Returns `null` when the resolver finds no candidate (e.g. empty doc).
- *
- * **Inter-block gap normalization.** When the cursor sits in the gap
- * between two siblings, `resolveBlockAtCoords` flips between them based
- * on Y proximity. Without normalization the indicator would draw at two
- * different rect edges (upper.bottom vs lower.top) - visually two lines
- * for what is the SAME logical drop slot (PM treats `endOf(upper)` and
- * `startOf(lower)` as one position in the parent's content array). To
- * unify the visual we canonicalise `insertAfter=false` to "after the
- * previous sibling" whenever a previous sibling exists at the same depth.
- * Net effect: one gap → one line, anchored at the bottom edge of the
- * upper block, with the upper block's width (which equals the lower's
- * for prose at the same depth, so the line spans the content column).
+ * Gap normalization: for `insertAfter=false` with a previous sibling at the
+ * same depth, the slot is canonicalised to "after the previous sibling" so
+ * one inter-block gap maps to one indicator line.
  */
 export function computeDropPlacement(
   view: EditorView,
@@ -619,9 +554,7 @@ export function computeDropPlacement(
         // a position between siblings is the wrapper itself.
         const $resolved = view.state.doc.resolve(resolved.pos);
         const wrapperPos = $resolved.before();
-        // Position-aware nested drop: pick WHICH child slot of the target
-        // item the cursor's Y lands in (first / between / last), so the
-        // block can land under the label instead of always appending last.
+        // Pick which child slot (first/between/last) the cursor's Y lands in.
         const childBand = options.hysteresis ? DROP_HYSTERESIS_Y_PX : 0;
         const slot = resolveChildSlot(
           view,
@@ -632,9 +565,7 @@ export function computeDropPlacement(
           options.incumbentChildIndex ?? null,
           childBand,
         );
-        // `insertAfter` mirrors the sibling-mode Y-mid calculation so the
-        // field stays semantically meaningful when consumers (the nested
-        // branch ignores it).
+        // `insertAfter` kept Y-mid-meaningful though the nested drop ignores it.
         const midY = targetRect.top + targetRect.height / 2;
         return {
           pos: resolved.pos,
@@ -665,16 +596,9 @@ export function computeDropPlacement(
 }
 
 /**
- * Returns the previous sibling at the same parent depth as `pos` (which
- * must be the position immediately BEFORE a node - same convention as
- * `nodeAt`). Returns `null` when the node has no previous sibling (it's
- * the first child of its parent) or when the previous sibling has no DOM
- * representation.
- *
- * Works for any depth: top-level blocks resolve against `doc`; nested
- * blocks (list items, table cells) resolve against their immediate
- * container - so the canonical "between" position is always the upper
- * sibling within the SAME container, never crossing container boundaries.
+ * Previous sibling of the node at `pos` (a position right BEFORE a node),
+ * within the same container. Returns `null` when `pos` is the first child or
+ * the previous sibling has no DOM. Never crosses container boundaries.
  */
 function findPreviousSiblingAtSameDepth(
   view: EditorView,
@@ -706,25 +630,12 @@ interface ChildSlot {
 }
 
 /**
- * Picks WHICH child slot of a list item the cursor's Y lands in, so a
- * nested drop can land as the FIRST child (just below the label), BETWEEN
- * children, or as the LAST child (append) instead of always appending.
- *
- * The item's child 0 is the immutable label paragraph (schema
- * `paragraph block*`), so `childIndex` is always `>= 1`. The slot is chosen
- * by which block child's vertical MID-LINE band the cursor sits in (mid-line,
- * not gap edge, so flush/zero-gap children don't make the choice ambiguous):
- * `childIndex = 1 + (count of block children whose mid-line is at/above the
- * cursor)`, clamped to `[1, childCount]` (`=== childCount` means append).
- *
- * `band > 0` enables a child-slot dead-band: when the freshly chosen index
- * is one off `incumbentChildIndex` and the cursor is within `band` px of the
- * boundary (the adjacent child's mid-line), the incumbent is kept (mirrors
- * the Y/X hysteresis one level up). An out-of-range incumbent is ignored.
- *
- * Falls back to append-last with a thin gap at `itemRect.bottom` when any
- * child DOM rect is unavailable (mid-edit / virtualized), so resolution
- * degrades to the legacy behaviour rather than throwing.
+ * Picks which child slot (first/between/last) of a list item the cursor's Y
+ * lands in. `childIndex` is `1 + (block children whose mid-line is at/above
+ * the cursor)`, clamped to `[1, childCount]` (index 0 is the label; mid-line
+ * not gap-edge so flush children aren't ambiguous). `band > 0` keeps the
+ * `incumbentChildIndex` sticky within `band` px of a boundary. Degrades to
+ * append-last when a child rect is unavailable.
  */
 function resolveChildSlot(
   view: EditorView,
@@ -757,13 +668,11 @@ function resolveChildSlot(
     childPos += item.child(i).nodeSize;
   }
 
-  // Degrade to append-last if a rect is missing: legacy behaviour, anchored
-  // at the item's bottom edge.
+  // Degrade to append-last when a rect is missing.
   const label = rects[0];
   if (!allPresent || !label) return { childIndex: childCount, gapRect: appendGap };
 
-  // Empty children-zone (label only): first child is also the last, so the
-  // single reachable slot is index 1 == append, drawn at the label's bottom.
+  // Label only: the one reachable slot is index 1 (== append).
   if (childCount === 1) {
     return {
       childIndex: 1,
@@ -771,7 +680,6 @@ function resolveChildSlot(
     };
   }
 
-  // Slot = 1 + number of block children whose mid-line is at/above the cursor.
   let index = 1;
   for (let i = 1; i < childCount; i++) {
     const r = rects[i];
@@ -779,9 +687,7 @@ function resolveChildSlot(
   }
   index = Math.min(Math.max(index, 1), childCount);
 
-  // Child-slot dead-band: keep the incumbent when the cursor is within `band`
-  // px of the boundary (the mid-line of the child shared by the two adjacent
-  // slots) between the incumbent and the freshly chosen index.
+  // Dead-band: keep the incumbent within `band` px of the shared boundary.
   if (
     band > 0 &&
     incumbentChildIndex !== null &&
@@ -884,24 +790,16 @@ export function createBlockHandlePlugin(
   // dragend, so it never lingers across drags.
   let pendingDraggedFrom: number | null = null;
 
-  // --- Drop-indicator drag-session state.
-  //
-  // The dragover->indicator path mirrors the hover path's rAF coalescing +
-  // identity gate so the indicator repaints at most once per frame and ONLY
-  // when the line it would draw actually moves. `dragIncumbentPos` and
-  // `dragNestLatched` carry the previous resolution forward so the resolver
-  // and the sibling<->nested flip stay sticky (Y- and X-hysteresis). All
-  // four reset together via `resetDropState` on every drag-teardown path so
-  // a stale incumbent can never glue the indicator to a phantom target on
-  // the next drag.
+  // Drop-indicator drag-session state. The dragover->indicator path mirrors
+  // the hover path: rAF-coalesced, repainted only when the line moves
+  // (`currentDropKey`). The incumbent fields carry the previous resolution
+  // forward for Y/X/child-slot hysteresis; `resetDropState` clears all of them
+  // on every teardown so a stale incumbent can't glue the next drag.
   let dropRaf: number | null = null;
   let pendingDropCoords: { x: number; y: number } | null = null;
   let currentDropKey: string | null = null;
   let dragIncumbentPos: number | null = null;
   let dragNestLatched = false;
-  // Child slot latched on the previous nested dragover, so a tiny Y wobble
-  // near a child-gap boundary doesn't flip first/between/last. Reset whenever
-  // nested mode flips off (handled at the indicator resolve site).
   let dragIncumbentChildIndex: number | null = null;
 
   const resetDropState = (): void => {
@@ -1194,8 +1092,7 @@ export function createBlockHandlePlugin(
     if (inZone) event.preventDefault();
     if (!dropIndicator) return;
     if (!inZone) {
-      // Left the zone: drop the indicator and any queued repaint, and clear
-      // the identity gate so re-entry repaints from scratch.
+      // Left the zone: hide and clear any queued repaint + identity gate.
       if (dropRaf !== null) {
         cancelAnimationFrame(dropRaf);
         dropRaf = null;
@@ -1205,11 +1102,9 @@ export function createBlockHandlePlugin(
       indicator.removeAttribute('data-show');
       return;
     }
-    // Coalesce indicator updates to one rAF per frame (mirrors the hover
-    // path). dragover fires far faster than 60Hz on high-refresh pointers;
-    // recomputing + repainting per event renders every micro-instability
-    // raw. preventDefault and the auto-scroll Y bookkeeping above MUST stay
-    // synchronous on the event tick - only the indicator repaint defers.
+    // Coalesce the indicator repaint to one rAF/frame (dragover fires far
+    // faster). preventDefault + auto-scroll Y above MUST stay synchronous;
+    // only the repaint defers.
     pendingDropCoords = { x: event.clientX, y: event.clientY };
     if (dropRaf !== null) return;
     dropRaf = requestAnimationFrame(() => {
@@ -1289,10 +1184,8 @@ export function createBlockHandlePlugin(
       && placement.targetItemPos !== undefined
       && placement.wrapperPos !== undefined
     ) {
-      // Drop-indent path: insert the source at the resolved child slot of the
-      // target list item (first / between / last) via `insertAsListItemChild`.
-      // `placement.childIndex` is read off the SAME placement the indicator
-      // drew, so the block lands exactly where the line sat.
+      // Drop-indent: insert at `placement.childIndex` (the slot the indicator
+      // drew, so the block lands where the line sat).
       const ok = moveBlockAsNestedChild(
         tr,
         draggedFrom,
@@ -1304,11 +1197,9 @@ export function createBlockHandlePlugin(
         view.dispatch(tr.scrollIntoView());
         return true;
       }
-      // The helper returned false. Distinguish a self-drop no-op (the source
-      // is inside the target item, e.g. reordering a child to its own slot)
-      // from a genuine schema reject. For the no-op, do nothing and consume
-      // the event; only a true reject falls through to the sibling move so we
-      // don't surprise the user by ejecting the block out to a list sibling.
+      // Helper bailed. If the source is inside the target item it was a
+      // self-drop no-op: consume the event rather than ejecting it to a
+      // sibling. A true schema reject falls through to the sibling move.
       const targetItem = view.state.doc.nodeAt(placement.targetItemPos);
       const targetItemEnd = targetItem
         ? placement.targetItemPos + targetItem.nodeSize
@@ -1343,25 +1234,9 @@ export function createBlockHandlePlugin(
   };
 
   /**
-   * Reposition the drop-indicator line at the same target `handleDrop`
-   * would land at for these coordinates. Called from the document-level
-   * `dragover` listener while a drag is in progress.
-   *
-   * Hides the indicator when the resolver finds nothing (e.g. cursor
-   * outside the editor's content range during a no-op drag-out).
-   *
-   * Two visual modes:
-   *
-   *  - **Sibling** - solid line at the rect's top OR bottom edge
-   *    (decided by `insertAfter`), spanning the full block width. The
-   *    line lives in the gap BETWEEN sibling blocks.
-   *  - **Nested** - dashed line at the rect's BOTTOM edge, indented to
-   *    where children render (matching `--dm-block-children-indent`,
-   *    nominally 24px). Communicates "this drop becomes a nested child
-   *    appended at the end" via `insertAsListItemChild`.
-   *
-   * The `data-mode` attribute carries the placement mode so theme CSS
-   * can swap solid for dashed via `&[data-mode='nested']`.
+   * Reposition the drop-indicator line where `handleDrop` would land for
+   * these coords; hide it when nothing resolves. `data-mode` lets theme CSS
+   * draw a solid sibling line vs a dashed indented nested line.
    */
   const updateDropIndicator = (clientX: number, clientY: number): void => {
     if (!editorEl) return;
@@ -1376,13 +1251,10 @@ export function createBlockHandlePlugin(
       currentDropKey = null;
       return;
     }
-    // Carry the resolution forward so the NEXT dragover stays sticky to the
-    // same target (Y-hysteresis) and the same mode (X-hysteresis). Always
-    // updated, even when the repaint is gated below.
+    // Carry the resolution forward for next dragover's hysteresis (always,
+    // even when the repaint is gated below). Child slot only while nested.
     dragIncumbentPos = placement.resolvedBlockPos ?? null;
     dragNestLatched = placement.mode === 'nested';
-    // Carry the child slot forward only while nested; reset when nest mode
-    // flips off so a stale slot from a prior nest episode can't glue the line.
     dragIncumbentChildIndex = placement.mode === 'nested' ? placement.childIndex ?? null : null;
 
     const editorRect = editorEl.getBoundingClientRect();
@@ -1391,13 +1263,8 @@ export function createBlockHandlePlugin(
     let left: number;
     let width: number;
     if (placement.mode === 'nested') {
-      // Indicator sits in the chosen child gap, indented to the children-zone
-      // start. `NESTED_INDICATOR_INDENT_PX` mirrors the default
-      // `--dm-block-children-indent` CSS variable (1.5rem ≈ 24px); custom
-      // themes that override the variable can override the indicator indent
-      // through the same CSS hook (see theme). `nestedGapRect` carries the
-      // first/between/last gap the cursor picked; fall back to the item's
-      // bottom edge (legacy append look) when it's absent.
+      // Draw in the chosen child gap, indented to the children zone. Fall back
+      // to the item's bottom (legacy append) when `nestedGapRect` is absent.
       const indent = NESTED_INDICATOR_INDENT_PX;
       const gap = placement.nestedGapRect ?? {
         top: placement.rect.bottom,
@@ -1405,29 +1272,22 @@ export function createBlockHandlePlugin(
         left: placement.rect.left,
         width: placement.rect.width,
       };
-      // The nested CSS applies `transform: translateY(-2px)`. For a REAL gap
-      // (top !== bottom) add 2px so the visible dashed line lands at the gap
-      // CENTER; for a thin edge band (append / flush children) keep the
-      // legacy -2px nudge that tucks the line just inside the edge.
+      // The nested CSS nudges -2px: add it back for a real gap (center the
+      // line); keep it for a thin edge band (append/flush) to match legacy.
       const cssNudgeComp = gap.top === gap.bottom ? 0 : 2;
       lineY = (gap.top + gap.bottom) / 2 + cssNudgeComp - editorRect.top;
       left = gap.left - editorRect.left + indent;
       width = Math.max(0, gap.width - indent);
     } else {
-      // Sibling line: ABOVE rect when inserting before, BELOW when
-      // inserting after. Spans the full resolved block width.
+      // Sibling line at the rect's top/bottom edge, full block width.
       lineY = (placement.insertAfter ? placement.rect.bottom : placement.rect.top) - editorRect.top;
       left = placement.rect.left - editorRect.left;
       width = placement.rect.width;
     }
-    // Identity gate: skip the DOM writes when the line would land in the
-    // same pixel spot it already occupies (rounded geometry + mode). This
-    // is the drag-path equivalent of the hover path's `currentHoveredPos`
-    // gate. Gating on the DRAWN geometry (not just placement.pos) keeps the
-    // indicator correct during auto-scroll, where the same logical slot
-    // moves on screen and SHOULD repaint.
-    // Include the nested child slot in the key so two child gaps that round
-    // to the same pixel row still repaint when the slot changes.
+    // Identity gate (drag-path equivalent of the hover `currentHoveredPos`):
+    // skip DOM writes when the drawn line is unchanged. Key on drawn geometry
+    // (so auto-scroll still repaints) + child slot (so two gaps rounding to
+    // the same row still repaint on slot change).
     const slotPart = placement.mode === 'nested' ? String(placement.childIndex ?? -1) : 's';
     const key = `${placement.mode}|${slotPart}|${String(Math.round(lineY))}|${String(Math.round(left))}|${String(Math.round(width))}`;
     if (key === currentDropKey && indicator.hasAttribute('data-show')) return;
@@ -1466,9 +1326,7 @@ export function createBlockHandlePlugin(
     document.removeEventListener('dragover', onDocumentDragover);
     document.removeEventListener('drop', onDocumentDrop);
     dragoverAttached = false;
-    // Every drag-teardown path (dragend, dead-man switch, editor destroy)
-    // funnels through here, so clearing the drop-session state here means a
-    // stale incumbent / latch can never leak into the next drag.
+    // Every teardown path funnels through here, so no stale state leaks.
     resetDropState();
   };
 
@@ -1617,12 +1475,10 @@ export function createBlockHandlePlugin(
       hide();
     }, 0);
 
-    // Start this drag with clean hysteresis state - no incumbent yet, no
-    // latched nested mode - so the first dragover resolves freely.
+    // Start with clean hysteresis state so the first dragover resolves freely.
     resetDropState();
 
-    // Begin tracking dragover Y and ramping scroll as the cursor nears
-    // viewport edges. No-op when `autoScroll: false` or no scroll ancestor.
+    // Track dragover Y and ramp scroll near viewport edges (no-op when off).
     startAutoScroll();
     // The shared document-level dragover listener powers BOTH auto-scroll
     // and the drop-indicator. Attached once per drag, removed in dragend.

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -23,7 +23,7 @@ import { Extension, defaultIcons } from '@domternal/core';
 import type { Editor } from '@domternal/core';
 import { NodeSelection, Plugin, PluginKey, TextSelection } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
-import type { Slice } from '@domternal/pm/model';
+import type { Node, Slice } from '@domternal/pm/model';
 import { findDeepestBlockAtY } from './helpers/findTopLevelBlock.js';
 import { moveBlock } from './helpers/moveBlock.js';
 import { moveBlockAsNestedChild } from './helpers/moveBlockAsNestedChild.js';
@@ -502,6 +502,21 @@ export interface DropPlacement {
   /** Position of the containing list wrapper when `mode === 'nested'`. */
   wrapperPos?: number;
   /**
+   * Child-array index inside `targetItemPos` where a nested drop lands.
+   * Always `>= 1` (index 0 is the immutable label paragraph) and `<=` the
+   * item's `childCount` (where `=== childCount` means append-last, the
+   * legacy behaviour). Present only when `mode === 'nested'`; lets the drop
+   * land at the FIRST / between / LAST child slot the cursor picked.
+   */
+  childIndex?: number;
+  /**
+   * Client-coord gap rect the nested indicator draws into (the gap the
+   * chosen `childIndex` slot occupies). Lets `updateDropIndicator` place the
+   * line at the exact child gap instead of the item's bottom edge. Present
+   * only when `mode === 'nested'`.
+   */
+  nestedGapRect?: { top: number; bottom: number; left: number; width: number };
+  /**
    * Position of the block the spatial resolver actually landed on (the
    * deepest-match item BEFORE gap-normalization rewrites `pos` to a previous
    * sibling). The drag pipeline feeds this back as `incumbentPos` on the
@@ -521,6 +536,13 @@ export interface DropPlacementOptions {
   incumbentPos?: number | null;
   /** Whether nested mode was latched on the previous dragover, for X-hysteresis. */
   nestLatched?: boolean;
+  /**
+   * Child slot index resolved on the previous dragover, for the nested
+   * child-slot dead-band so a tiny Y wobble near a gap boundary doesn't flip
+   * `childIndex`. Only meaningful while `nestLatched` stays true on the same
+   * target item.
+   */
+  incumbentChildIndex?: number | null;
   /**
    * Enable the hysteresis dead-bands. Off by default so unit callers get
    * the exact-threshold behaviour the contract tests assert; the live
@@ -597,6 +619,19 @@ export function computeDropPlacement(
         // a position between siblings is the wrapper itself.
         const $resolved = view.state.doc.resolve(resolved.pos);
         const wrapperPos = $resolved.before();
+        // Position-aware nested drop: pick WHICH child slot of the target
+        // item the cursor's Y lands in (first / between / last), so the
+        // block can land under the label instead of always appending last.
+        const childBand = options.hysteresis ? DROP_HYSTERESIS_Y_PX : 0;
+        const slot = resolveChildSlot(
+          view,
+          targetNode,
+          resolved.pos,
+          targetRect,
+          clientY,
+          options.incumbentChildIndex ?? null,
+          childBand,
+        );
         // `insertAfter` mirrors the sibling-mode Y-mid calculation so the
         // field stays semantically meaningful when consumers (the nested
         // branch ignores it).
@@ -608,6 +643,8 @@ export function computeDropPlacement(
           mode: 'nested',
           targetItemPos: resolved.pos,
           wrapperPos,
+          childIndex: slot.childIndex,
+          nestedGapRect: slot.gapRect,
           resolvedBlockPos,
         };
       }
@@ -652,6 +689,123 @@ function findPreviousSiblingAtSameDepth(
   const prevDom = view.nodeDOM(prevPos);
   if (!(prevDom instanceof HTMLElement)) return null;
   return { pos: prevPos, rect: prevDom.getBoundingClientRect() };
+}
+
+interface ChildGapRect {
+  top: number;
+  bottom: number;
+  left: number;
+  width: number;
+}
+
+interface ChildSlot {
+  /** Child-array index to insert at, in `[1, childCount]`. */
+  childIndex: number;
+  /** Client-coord gap the chosen slot occupies (drives the indicator line). */
+  gapRect: ChildGapRect;
+}
+
+/**
+ * Picks WHICH child slot of a list item the cursor's Y lands in, so a
+ * nested drop can land as the FIRST child (just below the label), BETWEEN
+ * children, or as the LAST child (append) instead of always appending.
+ *
+ * The item's child 0 is the immutable label paragraph (schema
+ * `paragraph block*`), so `childIndex` is always `>= 1`. The slot is chosen
+ * by which block child's vertical MID-LINE band the cursor sits in (mid-line,
+ * not gap edge, so flush/zero-gap children don't make the choice ambiguous):
+ * `childIndex = 1 + (count of block children whose mid-line is at/above the
+ * cursor)`, clamped to `[1, childCount]` (`=== childCount` means append).
+ *
+ * `band > 0` enables a child-slot dead-band: when the freshly chosen index
+ * is one off `incumbentChildIndex` and the cursor is within `band` px of the
+ * boundary (the adjacent child's mid-line), the incumbent is kept (mirrors
+ * the Y/X hysteresis one level up). An out-of-range incumbent is ignored.
+ *
+ * Falls back to append-last with a thin gap at `itemRect.bottom` when any
+ * child DOM rect is unavailable (mid-edit / virtualized), so resolution
+ * degrades to the legacy behaviour rather than throwing.
+ */
+function resolveChildSlot(
+  view: EditorView,
+  item: Node,
+  itemStart: number,
+  itemRect: DOMRect,
+  clientY: number,
+  incumbentChildIndex: number | null,
+  band: number,
+): ChildSlot {
+  const childCount = item.childCount;
+  const appendGap: ChildGapRect = {
+    top: itemRect.bottom,
+    bottom: itemRect.bottom,
+    left: itemRect.left,
+    width: itemRect.width,
+  };
+
+  const rects: DOMRect[] = [];
+  let allPresent = true;
+  let childPos = itemStart + 1; // one past the item's open token (label start)
+  for (let i = 0; i < childCount; i++) {
+    const dom = view.nodeDOM(childPos);
+    if (dom instanceof HTMLElement) {
+      rects.push(dom.getBoundingClientRect());
+    } else {
+      allPresent = false;
+      rects.push(itemRect);
+    }
+    childPos += item.child(i).nodeSize;
+  }
+
+  // Degrade to append-last if a rect is missing: legacy behaviour, anchored
+  // at the item's bottom edge.
+  const label = rects[0];
+  if (!allPresent || !label) return { childIndex: childCount, gapRect: appendGap };
+
+  // Empty children-zone (label only): first child is also the last, so the
+  // single reachable slot is index 1 == append, drawn at the label's bottom.
+  if (childCount === 1) {
+    return {
+      childIndex: 1,
+      gapRect: { top: label.bottom, bottom: label.bottom, left: label.left, width: label.width },
+    };
+  }
+
+  // Slot = 1 + number of block children whose mid-line is at/above the cursor.
+  let index = 1;
+  for (let i = 1; i < childCount; i++) {
+    const r = rects[i];
+    if (r && clientY >= (r.top + r.bottom) / 2) index = i + 1;
+  }
+  index = Math.min(Math.max(index, 1), childCount);
+
+  // Child-slot dead-band: keep the incumbent when the cursor is within `band`
+  // px of the boundary (the mid-line of the child shared by the two adjacent
+  // slots) between the incumbent and the freshly chosen index.
+  if (
+    band > 0 &&
+    incumbentChildIndex !== null &&
+    incumbentChildIndex >= 1 &&
+    incumbentChildIndex <= childCount &&
+    Math.abs(index - incumbentChildIndex) === 1
+  ) {
+    const r = rects[Math.min(index, incumbentChildIndex)];
+    if (r && Math.abs(clientY - (r.top + r.bottom) / 2) <= band) index = incumbentChildIndex;
+  }
+
+  const above = rects[index - 1];
+  const below = index < childCount ? rects[index] : undefined;
+  if (!above) return { childIndex: index, gapRect: appendGap };
+  if (!below) {
+    return {
+      childIndex: index,
+      gapRect: { top: above.bottom, bottom: above.bottom, left: above.left, width: above.width },
+    };
+  }
+  return {
+    childIndex: index,
+    gapRect: { top: above.bottom, bottom: below.top, left: below.left, width: below.width },
+  };
 }
 
 /**
@@ -745,6 +899,10 @@ export function createBlockHandlePlugin(
   let currentDropKey: string | null = null;
   let dragIncumbentPos: number | null = null;
   let dragNestLatched = false;
+  // Child slot latched on the previous nested dragover, so a tiny Y wobble
+  // near a child-gap boundary doesn't flip first/between/last. Reset whenever
+  // nested mode flips off (handled at the indicator resolve site).
+  let dragIncumbentChildIndex: number | null = null;
 
   const resetDropState = (): void => {
     if (dropRaf !== null) {
@@ -755,6 +913,7 @@ export function createBlockHandlePlugin(
     currentDropKey = null;
     dragIncumbentPos = null;
     dragNestLatched = false;
+    dragIncumbentChildIndex = null;
   };
 
   // Auto-scroll state machine (populated during an active drag, reset by
@@ -1119,6 +1278,7 @@ export function createBlockHandlePlugin(
     const placement = computeDropPlacement(view, clientX, clientY, nested, nestThreshold, {
       incumbentPos: dragIncumbentPos,
       nestLatched: dragNestLatched,
+      incumbentChildIndex: dragIncumbentChildIndex,
       hysteresis: true,
     });
     if (!placement) return false;
@@ -1129,14 +1289,31 @@ export function createBlockHandlePlugin(
       && placement.targetItemPos !== undefined
       && placement.wrapperPos !== undefined
     ) {
-      // Drop-indent path: append source as the last child of the target
-      // list item via `insertAsListItemChild`. On schema reject the
-      // helper leaves `tr` untouched and returns false; we fall back to
-      // the sibling-style move so the user's drag still produces a
-      // sensible result.
-      const ok = moveBlockAsNestedChild(tr, draggedFrom, placement.wrapperPos, placement.targetItemPos);
+      // Drop-indent path: insert the source at the resolved child slot of the
+      // target list item (first / between / last) via `insertAsListItemChild`.
+      // `placement.childIndex` is read off the SAME placement the indicator
+      // drew, so the block lands exactly where the line sat.
+      const ok = moveBlockAsNestedChild(
+        tr,
+        draggedFrom,
+        placement.wrapperPos,
+        placement.targetItemPos,
+        placement.childIndex,
+      );
       if (ok) {
         view.dispatch(tr.scrollIntoView());
+        return true;
+      }
+      // The helper returned false. Distinguish a self-drop no-op (the source
+      // is inside the target item, e.g. reordering a child to its own slot)
+      // from a genuine schema reject. For the no-op, do nothing and consume
+      // the event; only a true reject falls through to the sibling move so we
+      // don't surprise the user by ejecting the block out to a list sibling.
+      const targetItem = view.state.doc.nodeAt(placement.targetItemPos);
+      const targetItemEnd = targetItem
+        ? placement.targetItemPos + targetItem.nodeSize
+        : placement.targetItemPos;
+      if (draggedFrom >= placement.targetItemPos && draggedFrom < targetItemEnd) {
         return true;
       }
     }
@@ -1191,6 +1368,7 @@ export function createBlockHandlePlugin(
     const placement = computeDropPlacement(editor.view, clientX, clientY, nested, nestThreshold, {
       incumbentPos: dragIncumbentPos,
       nestLatched: dragNestLatched,
+      incumbentChildIndex: dragIncumbentChildIndex,
       hysteresis: true,
     });
     if (!placement) {
@@ -1203,6 +1381,9 @@ export function createBlockHandlePlugin(
     // updated, even when the repaint is gated below.
     dragIncumbentPos = placement.resolvedBlockPos ?? null;
     dragNestLatched = placement.mode === 'nested';
+    // Carry the child slot forward only while nested; reset when nest mode
+    // flips off so a stale slot from a prior nest episode can't glue the line.
+    dragIncumbentChildIndex = placement.mode === 'nested' ? placement.childIndex ?? null : null;
 
     const editorRect = editorEl.getBoundingClientRect();
 
@@ -1210,15 +1391,28 @@ export function createBlockHandlePlugin(
     let left: number;
     let width: number;
     if (placement.mode === 'nested') {
-      // Indicator sits AT the bottom of the target list item, indented
-      // to the children-zone start. `NESTED_INDICATOR_INDENT_PX` mirrors
-      // the default `--dm-block-children-indent` CSS variable (1.5rem ≈
-      // 24px); custom themes that override the variable can override
-      // the indicator indent through the same CSS hook (see theme).
+      // Indicator sits in the chosen child gap, indented to the children-zone
+      // start. `NESTED_INDICATOR_INDENT_PX` mirrors the default
+      // `--dm-block-children-indent` CSS variable (1.5rem ≈ 24px); custom
+      // themes that override the variable can override the indicator indent
+      // through the same CSS hook (see theme). `nestedGapRect` carries the
+      // first/between/last gap the cursor picked; fall back to the item's
+      // bottom edge (legacy append look) when it's absent.
       const indent = NESTED_INDICATOR_INDENT_PX;
-      lineY = placement.rect.bottom - editorRect.top;
-      left = placement.rect.left - editorRect.left + indent;
-      width = Math.max(0, placement.rect.width - indent);
+      const gap = placement.nestedGapRect ?? {
+        top: placement.rect.bottom,
+        bottom: placement.rect.bottom,
+        left: placement.rect.left,
+        width: placement.rect.width,
+      };
+      // The nested CSS applies `transform: translateY(-2px)`. For a REAL gap
+      // (top !== bottom) add 2px so the visible dashed line lands at the gap
+      // CENTER; for a thin edge band (append / flush children) keep the
+      // legacy -2px nudge that tucks the line just inside the edge.
+      const cssNudgeComp = gap.top === gap.bottom ? 0 : 2;
+      lineY = (gap.top + gap.bottom) / 2 + cssNudgeComp - editorRect.top;
+      left = gap.left - editorRect.left + indent;
+      width = Math.max(0, gap.width - indent);
     } else {
       // Sibling line: ABOVE rect when inserting before, BELOW when
       // inserting after. Spans the full resolved block width.
@@ -1232,7 +1426,10 @@ export function createBlockHandlePlugin(
     // gate. Gating on the DRAWN geometry (not just placement.pos) keeps the
     // indicator correct during auto-scroll, where the same logical slot
     // moves on screen and SHOULD repaint.
-    const key = `${placement.mode}|${String(Math.round(lineY))}|${String(Math.round(left))}|${String(Math.round(width))}`;
+    // Include the nested child slot in the key so two child gaps that round
+    // to the same pixel row still repaint when the slot changes.
+    const slotPart = placement.mode === 'nested' ? String(placement.childIndex ?? -1) : 's';
+    const key = `${placement.mode}|${slotPart}|${String(Math.round(lineY))}|${String(Math.round(left))}|${String(Math.round(width))}`;
     if (key === currentDropKey && indicator.hasAttribute('data-show')) return;
     currentDropKey = key;
 

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -550,17 +550,16 @@ export function computeDropPlacement(
       // (stateless unit callers) counts as "same item" to keep their contract.
       const inc = options.incumbentPos ?? null;
       const sameItem = inc === null || inc === resolved.pos;
-      // X-hysteresis: with the latch off, enter nested only past
-      // `nestThreshold + band`; once latched, stay nested until the cursor
-      // falls back below `nestThreshold - band`. The band is 0 unless the
-      // live plugin opts in, so the stateless contract (enter at exactly
-      // `nestThreshold`) is preserved for unit callers.
+      // X-hysteresis (asymmetric / sticky-exit): enter nested at the natural
+      // `nestThreshold` (so the entry point stays predictable), but once
+      // latched stay nested until the cursor falls back below
+      // `nestThreshold - band`. This kills sibling<->nested flicker around the
+      // threshold without moving where nesting begins. Band is 0 unless the
+      // live plugin opts in, so unit callers keep the exact-threshold contract.
       const xBand = options.hysteresis ? DROP_HYSTERESIS_X_PX : 0;
-      const enterZone = nestThreshold + xBand;
-      const leaveZone = nestThreshold - xBand;
       const isInNestZone = sameItem && options.nestLatched
-        ? xInTarget >= leaveZone
-        : xInTarget >= enterZone;
+        ? xInTarget >= nestThreshold - xBand
+        : xInTarget >= nestThreshold;
       const isInsideY = clientY >= targetRect.top && clientY <= targetRect.bottom;
       if (isInsideX && isInNestZone && isInsideY) {
         // Walk up to the wrapping list. `$resolved.before()` is the

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -455,6 +455,89 @@ function adjustDropTargetForListWrapper(
   return { pos: childPos, rect: childDom.getBoundingClientRect(), dom: childDom };
 }
 
+interface ResolvedBlock { pos: number; rect: DOMRect; dom: HTMLElement }
+
+/**
+ * Among the direct list-item children of the wrapper at `wrapperPos`, pick the
+ * one whose row the cursor is nearest (distance 0 when strictly contained).
+ */
+function nearestChildItem(
+  view: EditorView,
+  wrapperPos: number,
+  wrapper: Node,
+  clientY: number,
+): ResolvedBlock | null {
+  let childPos = wrapperPos + 1;
+  let best: { block: ResolvedBlock; dist: number } | null = null;
+  for (let i = 0; i < wrapper.childCount; i++) {
+    const child = wrapper.child(i);
+    if (LIST_ITEM_TYPES.has(child.type.name)) {
+      const dom = view.nodeDOM(childPos);
+      if (dom instanceof HTMLElement) {
+        const rect = dom.getBoundingClientRect();
+        const dist = clientY < rect.top ? rect.top - clientY : clientY > rect.bottom ? clientY - rect.bottom : 0;
+        if (best === null || dist < best.dist) best = { block: { pos: childPos, rect, dom }, dist };
+      }
+    }
+    childPos += child.nodeSize;
+  }
+  return best?.block ?? null;
+}
+
+/** The direct nested list-wrapper child of the item at `itemPos`, if any. */
+function findNestedListChild(
+  view: EditorView,
+  itemPos: number,
+  item: Node,
+): { pos: number; node: Node; rect: DOMRect } | null {
+  let childPos = itemPos + 1;
+  for (let i = 0; i < item.childCount; i++) {
+    const child = item.child(i);
+    if (LIST_WRAPPER_TYPE_NAMES.has(child.type.name)) {
+      const dom = view.nodeDOM(childPos);
+      if (dom instanceof HTMLElement) return { pos: childPos, node: child, rect: dom.getBoundingClientRect() };
+      return null;
+    }
+    childPos += child.nodeSize;
+  }
+  return null;
+}
+
+/**
+ * Hover-path refinement: anchor the handle on the list/task ITEM whose row the
+ * cursor is nearest, descending through nesting. `findDeepestBlockAtY` resolves
+ * to the containing ANCESTOR when the cursor sits in a gap between sibling items
+ * (no leaf strictly contains Y) - e.g. the gap between two nested task items, or
+ * the gap below a list - which parks the handle on the ancestor's top row far
+ * above the cursor. Walks down into the nearest child item so the handle tracks
+ * the actual row. Stays put when the cursor is on an item's own label row.
+ */
+function descendToNearestHoverItem(view: EditorView, resolved: ResolvedBlock, clientY: number): ResolvedBlock {
+  let current = resolved;
+  for (let guard = 0; guard < 20; guard++) {
+    const node = view.state.doc.nodeAt(current.pos);
+    if (!node) return current;
+    if (LIST_WRAPPER_TYPE_NAMES.has(node.type.name)) {
+      const next = nearestChildItem(view, current.pos, node, clientY);
+      if (!next || next.pos === current.pos) return current;
+      current = next;
+      continue;
+    }
+    if (LIST_ITEM_TYPES.has(node.type.name)) {
+      const nested = findNestedListChild(view, current.pos, node);
+      // No nested list, or the cursor is on this item's own label row (above
+      // the nested list): the item itself is the right anchor.
+      if (!nested || clientY < nested.rect.top) return current;
+      const next = nearestChildItem(view, nested.pos, nested.node, clientY);
+      if (!next || next.pos === current.pos) return current;
+      current = next;
+      continue;
+    }
+    return current;
+  }
+  return current;
+}
+
 /** Client-coord gap rect an indicator line draws into. */
 interface ChildGapRect {
   top: number;
@@ -952,11 +1035,16 @@ export function createBlockHandlePlugin(
       // Re-check the pin gate: a mousemove queued pre-open can fire
       // after `open()` and otherwise reposition the handle.
       if (editorEl.hasAttribute('data-block-context-menu-open')) return;
-      const resolved = resolveBlockAtCoords(editor.view, coords.x, coords.y, nested);
-      if (!resolved) {
+      const initial = resolveBlockAtCoords(editor.view, coords.x, coords.y, nested);
+      if (!initial) {
         scheduleHide();
         return;
       }
+      // When the cursor sits in a gap (below a list, or between nested items),
+      // resolution falls back to the containing wrapper/ancestor item. Descend
+      // to the nearest leaf item so the handle anchors on that row instead of
+      // jumping to the ancestor's top edge.
+      const resolved = descendToNearestHoverItem(editor.view, initial, coords.y);
       clearHideTimer();
       // `updateHoverState` is a no-op when PM plugin state already matches
       // - keep it unconditional so that if a prior docChanged transaction

--- a/packages/extension-block-menu/src/BlockHandle.ts
+++ b/packages/extension-block-menu/src/BlockHandle.ts
@@ -428,7 +428,7 @@ const LIST_WRAPPER_TYPE_NAMES = new Set(['bulletList', 'orderedList', 'taskList'
  *   that case; if we got the wrapper despite being inside, the caller's
  *   default targeting is already correct).
  */
-function adjustDropTargetForListWrapper(
+export function adjustDropTargetForListWrapper(
   view: EditorView,
   resolved: { pos: number; rect: DOMRect; dom: HTMLElement },
   clientY: number,
@@ -504,15 +504,14 @@ function findNestedListChild(
 }
 
 /**
- * Hover-path refinement: anchor the handle on the list/task ITEM whose row the
- * cursor is nearest, descending through nesting. `findDeepestBlockAtY` resolves
- * to the containing ANCESTOR when the cursor sits in a gap between sibling items
- * (no leaf strictly contains Y) - e.g. the gap between two nested task items, or
- * the gap below a list - which parks the handle on the ancestor's top row far
- * above the cursor. Walks down into the nearest child item so the handle tracks
- * the actual row. Stays put when the cursor is on an item's own label row.
+ * Anchor the handle on the list/task ITEM whose row the cursor is nearest,
+ * descending through nesting. `findDeepestBlockAtY` resolves to the containing
+ * ANCESTOR when the cursor sits in a gap between sibling items (no leaf
+ * strictly contains Y), parking the handle far above the cursor; this walks
+ * down to the nearest child so it tracks the actual row. Stays put when the
+ * cursor is on an item's own label row.
  */
-function descendToNearestHoverItem(view: EditorView, resolved: ResolvedBlock, clientY: number): ResolvedBlock {
+export function descendToNearestHoverItem(view: EditorView, resolved: ResolvedBlock, clientY: number): ResolvedBlock {
   let current = resolved;
   for (let guard = 0; guard < 20; guard++) {
     const node = view.state.doc.nodeAt(current.pos);
@@ -629,29 +628,23 @@ export function computeDropPlacement(
       const xInTarget = clientX - targetRect.left;
       const isInsideX = xInTarget >= 0 && xInTarget <= targetRect.width;
       // The X-latch and child-slot incumbent only apply while the cursor stays
-      // on the SAME item they were captured on, so moving to another list item
-      // re-requires crossing its own enter threshold. A null incumbentPos
-      // (stateless unit callers) counts as "same item" to keep their contract.
+      // on the same item; a null incumbentPos (stateless unit callers) counts
+      // as "same item" to keep their contract.
       const inc = options.incumbentPos ?? null;
       const sameItem = inc === null || inc === resolved.pos;
-      // X-hysteresis (asymmetric / sticky-exit): enter nested at the natural
-      // `nestThreshold` (so the entry point stays predictable), but once
-      // latched stay nested until the cursor falls back below
-      // `nestThreshold - band`. This kills sibling<->nested flicker around the
-      // threshold without moving where nesting begins. Band is 0 unless the
-      // live plugin opts in, so unit callers keep the exact-threshold contract.
+      // X-hysteresis (sticky-exit): enter nested at `nestThreshold`, but once
+      // latched stay nested until X falls below `nestThreshold - band`, killing
+      // sibling<->nested flicker. Band is 0 for unit callers (exact threshold).
       const xBand = options.hysteresis ? DROP_HYSTERESIS_X_PX : 0;
       const isInNestZone = sameItem && options.nestLatched
         ? xInTarget >= nestThreshold - xBand
         : xInTarget >= nestThreshold;
       const isInsideY = clientY >= targetRect.top && clientY <= targetRect.bottom;
       if (isInsideX && isInNestZone && isInsideY) {
-        // Walk up to the wrapping list. `$resolved.before()` is the
-        // position right before the parent at $resolved.depth, which for
-        // a position between siblings is the wrapper itself.
+        // Walk up to the wrapping list (`$resolved.before()` is the position
+        // before the parent, i.e. the wrapper itself).
         const $resolved = view.state.doc.resolve(resolved.pos);
         const wrapperPos = $resolved.before();
-        // Pick which child slot (first/between/last) the cursor's Y lands in.
         const childBand = options.hysteresis ? DROP_HYSTERESIS_Y_PX : 0;
         const slot = resolveChildSlot(
           view,
@@ -662,7 +655,6 @@ export function computeDropPlacement(
           sameItem ? options.incumbentChildIndex ?? null : null,
           childBand,
         );
-        // `insertAfter` kept Y-mid-meaningful though the nested drop ignores it.
         const midY = targetRect.top + targetRect.height / 2;
         return {
           pos: resolved.pos,
@@ -679,13 +671,10 @@ export function computeDropPlacement(
     }
   }
 
-  // Outdent ladder: when the cursor sits to the LEFT of a NESTED list item's
-  // content (and inside its row), X picks a shallower ancestor level, so the
-  // drop becomes a sibling AFTER that ancestor (drag left to outdent, Notion-
-  // style). This resolves to a plain sibling placement pointing at the
-  // ancestor: the existing sibling drop computes `ancestorPos + nodeSize`
-  // (== the position after the ancestor) and the indicator draws at the
-  // ancestor's bottom edge indented to its left, so indicator == drop.
+  // Outdent ladder: cursor LEFT of a nested item's content (inside its row)
+  // picks a shallower ancestor, so the drop becomes a sibling AFTER that
+  // ancestor (drag left to outdent, Notion-style). Resolves to a plain sibling
+  // placement at the ancestor, where the sibling drop already lands.
   if (nestThreshold > 0) {
     const targetNode = view.state.doc.nodeAt(resolved.pos);
     const inRowY = clientY >= resolved.rect.top && clientY <= resolved.rect.bottom;
@@ -759,13 +748,11 @@ interface ChildSlot {
 
 /**
  * Picks which child slot (first/between/last) of a list item the cursor's Y
- * lands in. `childIndex` is `1 + (block children whose mid-line is at/above
- * the cursor)`, clamped to `[1, childCount]` (index 0 is the label; mid-line
- * not gap-edge so flush children aren't ambiguous). `band > 0` keeps the
- * `incumbentChildIndex` sticky within `band` px of a boundary. Degrades to
- * append-last when a child rect is unavailable. All gaps share the item's
- * horizontal content column (only Y varies), so the indented line lands at a
- * consistent depth regardless of which child borders the gap.
+ * lands in. `childIndex` is `1 + (children whose mid-line is at/above the
+ * cursor)`, clamped to `[1, childCount]` (index 0 is the label). `band > 0`
+ * keeps `incumbentChildIndex` sticky within `band` px of a boundary. Degrades
+ * to append-last when a child rect is missing. All gaps share the item's
+ * content column so the indented line lands at a consistent depth.
  */
 function resolveChildSlot(
   view: EditorView,
@@ -899,11 +886,10 @@ export function createBlockHandlePlugin(
   // dragend, so it never lingers across drags.
   let pendingDraggedFrom: number | null = null;
 
-  // Drop-indicator drag-session state. The dragover->indicator path mirrors
-  // the hover path: rAF-coalesced, repainted only when the line moves
-  // (`currentDropKey`). `dragHyst` carries the previous resolution forward for
-  // Y/X/child-slot hysteresis; bundling the three axes makes every reset
-  // atomic so a stale incumbent can't glue a later resolution.
+  // Drop-indicator drag-session state. Like the hover path: rAF-coalesced,
+  // repainted only when the line moves (`currentDropKey`). `dragHyst` carries
+  // the previous resolution forward for Y/X/child-slot hysteresis, bundled so
+  // every reset is atomic.
   let dropRaf: number | null = null;
   let pendingDropCoords: { x: number; y: number } | null = null;
   let currentDropKey: string | null = null;
@@ -1040,10 +1026,7 @@ export function createBlockHandlePlugin(
         scheduleHide();
         return;
       }
-      // When the cursor sits in a gap (below a list, or between nested items),
-      // resolution falls back to the containing wrapper/ancestor item. Descend
-      // to the nearest leaf item so the handle anchors on that row instead of
-      // jumping to the ancestor's top edge.
+      // Gap hovers resolve to an ancestor; descend to the nearest leaf row.
       const resolved = descendToNearestHoverItem(editor.view, initial, coords.y);
       clearHideTimer();
       // `updateHoverState` is a no-op when PM plugin state already matches
@@ -1212,9 +1195,8 @@ export function createBlockHandlePlugin(
     if (inZone) event.preventDefault();
     if (!dropIndicator) return;
     if (!inZone) {
-      // Left the zone: hide, clear any queued repaint + identity gate, and
-      // drop the hysteresis incumbents so re-entry resolves fresh (a stale
-      // nest-latch must not survive a round-trip out of the editor).
+      // Left the zone: hide and drop the hysteresis incumbents so re-entry
+      // resolves fresh (no stale nest-latch across a round-trip out).
       if (dropRaf !== null) {
         cancelAnimationFrame(dropRaf);
         dropRaf = null;
@@ -1225,9 +1207,8 @@ export function createBlockHandlePlugin(
       indicator.removeAttribute('data-show');
       return;
     }
-    // Coalesce the indicator repaint to one rAF/frame (dragover fires far
-    // faster). preventDefault + auto-scroll Y above MUST stay synchronous;
-    // only the repaint defers.
+    // Coalesce the repaint to one rAF/frame; preventDefault + auto-scroll above
+    // stay synchronous.
     pendingDropCoords = { x: event.clientX, y: event.clientY };
     if (dropRaf !== null) return;
     dropRaf = requestAnimationFrame(() => {
@@ -1291,8 +1272,7 @@ export function createBlockHandlePlugin(
     if (draggedFrom === null) return false;
     const sourceNode = view.state.doc.nodeAt(draggedFrom);
     if (!sourceNode) return false;
-    // Resolve with the SAME hysteresis state the indicator last used, so the
-    // drop lands exactly where the (stabilized) line was drawn.
+    // Same hysteresis state the indicator last used, so the drop lands on the line.
     const placement = computeDropPlacement(view, clientX, clientY, nested, nestThreshold, {
       incumbentPos: dragHyst.incumbentPos,
       nestLatched: dragHyst.nestLatched,
@@ -1307,8 +1287,7 @@ export function createBlockHandlePlugin(
       && placement.targetItemPos !== undefined
       && placement.wrapperPos !== undefined
     ) {
-      // Drop-indent: insert at `placement.childIndex` (the slot the indicator
-      // drew, so the block lands where the line sat).
+      // Drop-indent into the slot the indicator drew.
       const ok = moveBlockAsNestedChild(
         tr,
         draggedFrom,
@@ -1320,11 +1299,9 @@ export function createBlockHandlePlugin(
         view.dispatch(tr.scrollIntoView());
         return true;
       }
-      // Helper bailed. Treat a SELF-drop (source and target overlap either
-      // way: source inside the target item, or the target sits inside the
-      // dragged source's subtree) as a no-op and consume the event, rather
-      // than ejecting the block to a sibling. A true schema reject (no
-      // overlap) falls through to the sibling move below.
+      // Helper bailed. A SELF-drop (source and target overlap either way) is a
+      // no-op: consume the event instead of ejecting the block to a sibling. A
+      // true schema reject (no overlap) falls through to the sibling move below.
       const targetItem = view.state.doc.nodeAt(placement.targetItemPos);
       const targetItemEnd = targetItem
         ? placement.targetItemPos + targetItem.nodeSize
@@ -1379,8 +1356,8 @@ export function createBlockHandlePlugin(
       currentDropKey = null;
       return;
     }
-    // Carry the resolution forward for next dragover's hysteresis (always,
-    // even when the repaint is gated below). Child slot only while nested.
+    // Carry forward for the next dragover's hysteresis, even if the repaint is
+    // gated below.
     dragHyst.incumbentPos = placement.resolvedBlockPos ?? null;
     dragHyst.nestLatched = placement.mode === 'nested';
     dragHyst.childIndex = placement.mode === 'nested' ? placement.childIndex ?? null : null;
@@ -1391,11 +1368,9 @@ export function createBlockHandlePlugin(
     let left: number;
     let width: number;
     if (placement.mode === 'nested') {
-      // Anchor on the gap's TOP edge, indented to the children zone, the same
-      // way the sibling line anchors on a rect edge. The theme's small
-      // `translateY` tuck (see `_block-handle.scss`) then applies uniformly,
-      // so JS owns no CSS-coupled pixel offset. Fall back to the item bottom
-      // (legacy append) when `nestedGapRect` is absent.
+      // Anchor on the gap's TOP edge, indented to the children zone (the
+      // theme's `translateY` tuck applies uniformly, so JS owns no CSS-coupled
+      // offset). Fall back to the item bottom when `nestedGapRect` is absent.
       const indent = NESTED_INDICATOR_INDENT_PX;
       const gap = placement.nestedGapRect ?? {
         top: placement.rect.bottom,
@@ -1406,15 +1381,13 @@ export function createBlockHandlePlugin(
       left = gap.left - editorRect.left + indent;
       width = Math.max(0, gap.width - indent);
     } else {
-      // Sibling line at the rect's top/bottom edge, full block width.
+      // Sibling line at the rect's top/bottom edge, full width.
       lineY = (placement.insertAfter ? placement.rect.bottom : placement.rect.top) - editorRect.top;
       left = placement.rect.left - editorRect.left;
       width = placement.rect.width;
     }
-    // Identity gate (drag-path equivalent of the hover `currentHoveredPos`):
-    // skip DOM writes when the drawn line is unchanged. Key on drawn geometry
-    // (so auto-scroll still repaints) + child slot (so two gaps rounding to
-    // the same row still repaint on slot change).
+    // Identity gate: skip DOM writes when the drawn line is unchanged. Keyed on
+    // geometry + child slot (so a slot change at the same row still repaints).
     const slotPart = placement.mode === 'nested' ? String(placement.childIndex ?? -1) : 's';
     const key = `${placement.mode}|${slotPart}|${String(Math.round(lineY))}|${String(Math.round(left))}|${String(Math.round(width))}`;
     if (key === currentDropKey && indicator.hasAttribute('data-show')) return;

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -706,3 +706,156 @@ describe('computeDropPlacement - hysteresis (drag-session stickiness)', () => {
     editor.destroy();
   });
 });
+
+describe('computeDropPlacement - position-aware nested child slot', () => {
+  // A single list item with a label + two block children: [L, A, B]. The
+  // item rect spans all three (100-220); each child gets its own band.
+  function multiChildView(editor: Editor): {
+    view: EditorView;
+    liPos: number;
+  } {
+    const ulPos = posOf(editor, (n) => n.type.name === 'bulletList');
+    const liPos = posOf(editor, (n) => n.type.name === 'listItem');
+    const pL = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'L');
+    const pA = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'A');
+    const pB = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'B');
+    const rects = new Map<number, HTMLElement>([
+      [ulPos, elWithRect({ top: 100, bottom: 220 })],
+      [liPos, elWithRect({ top: 100, bottom: 220 })],
+      [pL, elWithRect({ top: 100, bottom: 140 })],
+      [pA, elWithRect({ top: 140, bottom: 180 })], // mid = 160
+      [pB, elWithRect({ top: 180, bottom: 220 })], // mid = 200
+    ]);
+    return { view: viewStub(editor, rects), liPos };
+  }
+
+  it('cursor in the FIRST-child zone (below label, above first child mid) resolves childIndex 1', () => {
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+    const { view } = multiChildView(editor);
+    const r = computeDropPlacement(view, 50, 145, NESTED_LIST); // 145 < A.mid(160)
+    expect(r?.mode).toBe('nested');
+    expect(r?.childIndex).toBe(1);
+    expect(r?.nestedGapRect).toBeDefined();
+    editor.destroy();
+  });
+
+  it('cursor in a BETWEEN zone (past first child mid) resolves childIndex 2', () => {
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+    const { view } = multiChildView(editor);
+    const r = computeDropPlacement(view, 50, 170, NESTED_LIST); // A.mid(160) <= 170 < B.mid(200)
+    expect(r?.mode).toBe('nested');
+    expect(r?.childIndex).toBe(2);
+    editor.destroy();
+  });
+
+  it('cursor in the LAST zone (past last child mid) resolves childIndex === childCount (append)', () => {
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+    const { view } = multiChildView(editor);
+    const r = computeDropPlacement(view, 50, 210, NESTED_LIST); // >= B.mid(200)
+    expect(r?.mode).toBe('nested');
+    expect(r?.childIndex).toBe(3); // childCount of [L,A,B]
+    editor.destroy();
+  });
+
+  it('an empty-children item (label only) resolves childIndex 1', () => {
+    const editor = makeEditor('<ul><li><p>Solo</p></li></ul>');
+    const ulPos = posOf(editor, (n) => n.type.name === 'bulletList');
+    const liPos = posOf(editor, (n) => n.type.name === 'listItem');
+    const pSolo = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'Solo');
+    const rects = new Map<number, HTMLElement>([
+      [ulPos, elWithRect({ top: 100, bottom: 140 })],
+      [liPos, elWithRect({ top: 100, bottom: 140 })],
+      [pSolo, elWithRect({ top: 100, bottom: 140 })],
+    ]);
+    const r = computeDropPlacement(viewStub(editor, rects), 50, 120, NESTED_LIST);
+    expect(r?.mode).toBe('nested');
+    expect(r?.childIndex).toBe(1);
+    editor.destroy();
+  });
+
+  it('child-slot hysteresis: incumbentChildIndex sticks within the band, flips past it', () => {
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+    const { view } = multiChildView(editor);
+
+    // Y=163 is 3px past A.mid(160). Stateless -> index 2.
+    const stateless = computeDropPlacement(view, 50, 163, NESTED_LIST);
+    expect(stateless?.childIndex).toBe(2);
+
+    // With incumbent=1 + hysteresis, 3px (< 6px band) keeps index 1.
+    const sticky = computeDropPlacement(view, 50, 163, NESTED_LIST, 28, {
+      incumbentChildIndex: 1,
+      hysteresis: true,
+    });
+    expect(sticky?.childIndex).toBe(1);
+
+    // 10px past the boundary (> band) flips to 2 even with incumbent=1.
+    const flipped = computeDropPlacement(view, 50, 170, NESTED_LIST, 28, {
+      incumbentChildIndex: 1,
+      hysteresis: true,
+    });
+    expect(flipped?.childIndex).toBe(2);
+    editor.destroy();
+  });
+
+  it('sibling placements never carry childIndex / nestedGapRect', () => {
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p><p>B</p></li></ul>');
+    const { view } = multiChildView(editor);
+    // nestThreshold=0 forces sibling mode.
+    const r = computeDropPlacement(view, 50, 145, NESTED_LIST, 0);
+    expect(r?.mode).toBe('sibling');
+    expect(r?.childIndex).toBeUndefined();
+    expect(r?.nestedGapRect).toBeUndefined();
+    editor.destroy();
+  });
+
+  describe('flagship: outer item with a nested sublist', () => {
+    // taskItem "AI" whose children are [label, nested taskList]. The outer
+    // item is the deepest match ONLY in the label band (Y 100-145); the
+    // nested list rows resolve to the INNER item (deepest-match).
+    function flagshipView(editor: Editor): {
+      view: EditorView;
+      outerTI: number;
+      innerTI: number;
+    } {
+      const outerTL = posOf(editor, (n) => n.type.name === 'taskList');
+      const outerTI = posOf(editor, (n) => n.type.name === 'taskItem');
+      const pAI = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'AI');
+      const innerTI = posOf(editor, (n) => n.type.name === 'taskItem' && n.textContent === 'Wire');
+      const innerTL = editor.state.doc.resolve(innerTI).before();
+      const pWire = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'Wire');
+      const rects = new Map<number, HTMLElement>([
+        [outerTL, elWithRect({ top: 100, bottom: 300 })],
+        [outerTI, elWithRect({ top: 100, bottom: 300 })],
+        [pAI, elWithRect({ top: 100, bottom: 145 })],
+        [innerTL, elWithRect({ top: 150, bottom: 300 })],
+        [innerTI, elWithRect({ top: 150, bottom: 200 })],
+        [pWire, elWithRect({ top: 150, bottom: 200 })],
+      ]);
+      return { view: viewStub(editor, rects), outerTI, innerTI };
+    }
+
+    const FLAGSHIP_HTML =
+      '<ul data-type="taskList"><li data-type="taskItem"><p>AI</p>' +
+      '<ul data-type="taskList"><li data-type="taskItem"><p>Wire</p></li></ul>' +
+      '</li></ul>';
+
+    it('cursor in the outer label band resolves to the OUTER item at childIndex 1 (before the sublist)', () => {
+      const editor = makeEditor(FLAGSHIP_HTML);
+      const { view, outerTI } = flagshipView(editor);
+      const r = computeDropPlacement(view, 50, 130, NESTED_LIST); // label band
+      expect(r?.mode).toBe('nested');
+      expect(r?.targetItemPos).toBe(outerTI);
+      expect(r?.childIndex).toBe(1);
+      editor.destroy();
+    });
+
+    it('cursor on a nested-list row resolves to the INNER item (documented reachability limit)', () => {
+      const editor = makeEditor(FLAGSHIP_HTML);
+      const { view, innerTI } = flagshipView(editor);
+      const r = computeDropPlacement(view, 50, 170, NESTED_LIST); // inner row
+      expect(r?.mode).toBe('nested');
+      expect(r?.targetItemPos).toBe(innerTI);
+      editor.destroy();
+    });
+  });
+});

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -159,6 +159,24 @@ describe('computeDropPlacement - DropPlacement.mode contract', () => {
       editor.destroy();
     });
 
+    it('upper-half cursor whose previous sibling has no DOM keeps the resolved block (no canonicalisation)', () => {
+      // Same inter-block setup, but the FIRST paragraph has no rect, so the
+      // prev-sibling lookup bails and the placement stays on the lower block
+      // with insertAfter=false instead of canonicalising to the gap.
+      const editor = makeEditor('<p>First</p><p>Second</p>');
+      const secondPos = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'Second');
+      const rects = new Map<number, HTMLElement>([
+        // firstPos intentionally omitted -> nodeDOM(0) === null.
+        [secondPos, elWithRect({ top: 130, bottom: 160 })],
+      ]);
+
+      const result = computeDropPlacement(viewStub(editor, rects), 50, 135, NESTED_DISABLED); // upper half of "Second"
+      expect(result?.mode).toBe('sibling');
+      expect(result?.insertAfter).toBe(false);
+      expect(result?.pos).toBe(secondPos);
+      editor.destroy();
+    });
+
     it('cursor BELOW the last block falls back to closest-by-Y - mode kept "sibling"', () => {
       const editor = makeEditor('<p>Top</p><p>Bottom</p>');
       const firstPos = 0;

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -596,3 +596,113 @@ describe('computeDropPlacement - DropPlacement.mode contract', () => {
     });
   });
 });
+
+describe('computeDropPlacement - hysteresis (drag-session stickiness)', () => {
+  // li-inside-li fixture: the outer item rect (100-300) spans its label PLUS
+  // a nested sublist; the inner item is short (150-200). The boundary at
+  // inner.top=150 is where "smallest height wins" flips the resolver. Tests
+  // use nestThreshold=0 to stay on the sibling path so the assertion can
+  // target which ITEM the resolver locked onto (exposed via resolvedBlockPos).
+  function nestedView(editor: Editor, outerLi: number, innerLi: number): EditorView {
+    const rects = new Map<number, HTMLElement>([
+      [outerLi, elWithRect({ top: 100, bottom: 300 })],
+      [innerLi, elWithRect({ top: 150, bottom: 200 })],
+    ]);
+    return viewStub(editor, rects);
+  }
+
+  function listItemView(editor: Editor): EditorView {
+    const ulPos = posOf(editor, (n) => n.type.name === 'bulletList');
+    const liApple = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Apple');
+    const rects = new Map<number, HTMLElement>([
+      [ulPos, elWithRect({ top: 100, bottom: 150 })],
+      [liApple, elWithRect({ top: 100, bottom: 150 })],
+    ]);
+    return viewStub(editor, rects);
+  }
+
+  it('exposes resolvedBlockPos for incumbent tracking', () => {
+    const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
+    const liApple = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Apple');
+    const result = computeDropPlacement(listItemView(editor), 100, 125, NESTED_LIST, 0);
+    expect(result?.resolvedBlockPos).toBe(liApple);
+    editor.destroy();
+  });
+
+  it('Y-hysteresis: incumbent=inner keeps the resolver on the inner item through a sub-band wobble', () => {
+    const editor = makeEditor('<ul><li><p>Outer label</p><ul><li><p>Inner</p></li></ul></li></ul>');
+    const outerLi = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Outer'));
+    const innerLi = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Inner');
+    const view = nestedView(editor, outerLi, innerLi);
+
+    // Baseline: Y=147 (3px above inner.top=150) with no incumbent -> outer.
+    const baseline = computeDropPlacement(view, 100, 147, NESTED_LIST, 0);
+    expect(baseline?.resolvedBlockPos).toBe(outerLi);
+
+    // Same cursor, inner as incumbent + hysteresis on -> stays on inner.
+    const sticky = computeDropPlacement(view, 100, 147, NESTED_LIST, 0, {
+      incumbentPos: innerLi,
+      hysteresis: true,
+    });
+    expect(sticky?.resolvedBlockPos).toBe(innerLi);
+    editor.destroy();
+  });
+
+  it('Y-hysteresis: incumbent yields once the cursor crosses decisively (beyond the band)', () => {
+    const editor = makeEditor('<ul><li><p>Outer label</p><ul><li><p>Inner</p></li></ul></li></ul>');
+    const outerLi = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Outer'));
+    const innerLi = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Inner');
+    const view = nestedView(editor, outerLi, innerLi);
+
+    // Y=142 is 8px above inner.top, past the 6px band -> back to outer.
+    const result = computeDropPlacement(view, 100, 142, NESTED_LIST, 0, {
+      incumbentPos: innerLi,
+      hysteresis: true,
+    });
+    expect(result?.resolvedBlockPos).toBe(outerLi);
+    editor.destroy();
+  });
+
+  it('X-hysteresis: a latched nested mode stays nested in the band where an unlatched cursor would not enter', () => {
+    // Default threshold 28, band 8 -> enter at >=36, leave at <20. X=30 sits
+    // between, so the result depends purely on the latch.
+    const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
+    const view = listItemView(editor);
+
+    const fromSibling = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+      nestLatched: false,
+      hysteresis: true,
+    });
+    expect(fromSibling?.mode).toBe('sibling');
+
+    const fromNested = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+      nestLatched: true,
+      hysteresis: true,
+    });
+    expect(fromNested?.mode).toBe('nested');
+    editor.destroy();
+  });
+
+  it('X-hysteresis: a latched nested mode leaves only once X drops below threshold-band', () => {
+    const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
+    const view = listItemView(editor);
+
+    // X=18 (<20 leave threshold) drops nested even when latched.
+    const result = computeDropPlacement(view, 18, 125, NESTED_LIST, 28, {
+      nestLatched: true,
+      hysteresis: true,
+    });
+    expect(result?.mode).toBe('sibling');
+    editor.destroy();
+  });
+
+  it('without the hysteresis flag the nestThreshold stays a hard step regardless of latch', () => {
+    const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
+    const view = listItemView(editor);
+
+    // X=30 >= 28 and no hysteresis flag -> nested even though nestLatched is false.
+    const result = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, { nestLatched: false });
+    expect(result?.mode).toBe('nested');
+    editor.destroy();
+  });
+});

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -902,3 +902,82 @@ describe('computeDropPlacement - position-aware nested child slot', () => {
     editor.destroy();
   });
 });
+
+describe('computeDropPlacement - multi-level outdent (X left of a nested item)', () => {
+  // Groceries (L1, left 10) > Fruit (L2, left 30) > Apples (L3, left 50).
+  // Hovering the Apples row resolves to Apples; X left of Apples picks a
+  // shallower ancestor -> sibling AFTER that ancestor.
+  function outdentView(editor: Editor): { view: EditorView; groceries: number; fruit: number; apples: number } {
+    const groceries = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Groceries'));
+    const fruit = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Fruit'));
+    const apples = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Apples');
+    const rects = new Map<number, HTMLElement>([
+      [groceries, elWithRect({ top: 100, bottom: 200, left: 10, right: 510 })],
+      [fruit, elWithRect({ top: 100, bottom: 160, left: 30, right: 510 })],
+      [apples, elWithRect({ top: 100, bottom: 130, left: 50, right: 510 })],
+    ]);
+    return { view: viewStub(editor, rects), groceries, fruit, apples };
+  }
+
+  const HTML = '<ul><li><p>Groceries</p><ul><li><p>Fruit</p><ul><li><p>Apples</p></li></ul></li></ul></li></ul>';
+
+  function afterOf(editor: Editor, pos: number): number {
+    const n = editor.state.doc.nodeAt(pos);
+    if (!n) throw new Error('no node');
+    return pos + n.nodeSize;
+  }
+
+  it('X between the middle and deepest ancestor outdents one level (sibling after the middle ancestor)', () => {
+    const editor = makeEditor(HTML);
+    const { view, fruit } = outdentView(editor);
+    const r = computeDropPlacement(view, 35, 115, NESTED_LIST); // 30 <= X < 50, Y in Apples row
+    expect(r?.mode).toBe('sibling');
+    expect(r?.insertAfter).toBe(true);
+    expect(r?.pos).toBe(fruit);
+    editor.destroy();
+  });
+
+  it('X at the top-level indent outdents all the way (sibling after the outermost item)', () => {
+    const editor = makeEditor(HTML);
+    const { view, groceries } = outdentView(editor);
+    const r = computeDropPlacement(view, 20, 115, NESTED_LIST); // 10 <= X < 30
+    expect(r?.mode).toBe('sibling');
+    expect(r?.pos).toBe(groceries);
+    editor.destroy();
+  });
+
+  it('the outdent drop position is AFTER the chosen ancestor subtree', () => {
+    const editor = makeEditor(HTML);
+    const { view, fruit } = outdentView(editor);
+    const r = computeDropPlacement(view, 35, 115, NESTED_LIST);
+    // sibling + insertAfter => the live drop targets pos + nodeSize.
+    const targetNode = editor.state.doc.nodeAt(r?.pos ?? -1);
+    const dropPos = (r?.pos ?? 0) + (targetNode?.nodeSize ?? 0);
+    expect(dropPos).toBe(afterOf(editor, fruit));
+    editor.destroy();
+  });
+
+  it('X at/inside the resolved item is NOT outdent (falls through to the normal paths)', () => {
+    const editor = makeEditor(HTML);
+    const { view, apples } = outdentView(editor);
+    // X=55 >= Apples.left(50): not the outdent zone. nestThreshold default 28,
+    // 55 - 50 = 5 < 28 so not nested either -> a normal sibling at Apples level.
+    const r = computeDropPlacement(view, 55, 115, NESTED_LIST);
+    expect(r?.mode).toBe('sibling');
+    expect(r?.pos).not.toBe(apples + 99999); // sanity: resolved, not an ancestor outdent
+    editor.destroy();
+  });
+
+  it('a top-level item has no shallower ancestor, so X far left does NOT outdent', () => {
+    const editor = makeEditor('<ul><li><p>Solo</p></li></ul>');
+    const solo = posOf(editor, (n) => n.type.name === 'listItem');
+    const ul = posOf(editor, (n) => n.type.name === 'bulletList');
+    const rects = new Map<number, HTMLElement>([
+      [ul, elWithRect({ top: 100, bottom: 130, left: 10, right: 510 })],
+      [solo, elWithRect({ top: 100, bottom: 130, left: 10, right: 510 })],
+    ]);
+    const r = computeDropPlacement(viewStub(editor, rects), 2, 115, NESTED_LIST);
+    expect(r?.pos).toBe(solo); // resolved item itself, no ancestor outdent
+    editor.destroy();
+  });
+});

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -858,4 +858,47 @@ describe('computeDropPlacement - position-aware nested child slot', () => {
       editor.destroy();
     });
   });
+
+  it('the nested gap takes left/width from the ITEM, not the (indented) child', () => {
+    // Item rect left=10/width=500; child A is indented to left=40. The first-
+    // child gap must align to the item's content column (10), not A's 40, so
+    // the indented indicator lands where a child block actually renders.
+    const editor = makeEditor('<ul><li><p>L</p><p>A</p></li></ul>');
+    const ulPos = posOf(editor, (n) => n.type.name === 'bulletList');
+    const liPos = posOf(editor, (n) => n.type.name === 'listItem');
+    const pL = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'L');
+    const pA = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'A');
+    const rects = new Map<number, HTMLElement>([
+      [ulPos, elWithRect({ top: 100, bottom: 200, left: 10, right: 510 })],
+      [liPos, elWithRect({ top: 100, bottom: 200, left: 10, right: 510 })],
+      [pL, elWithRect({ top: 100, bottom: 150, left: 10, right: 510 })],
+      [pA, elWithRect({ top: 150, bottom: 200, left: 40, right: 510 })],
+    ]);
+    const r = computeDropPlacement(viewStub(editor, rects), 50, 130, NESTED_LIST); // first-child zone
+    expect(r?.childIndex).toBe(1);
+    expect(r?.nestedGapRect?.left).toBe(10);
+    expect(r?.nestedGapRect?.width).toBe(500);
+    editor.destroy();
+  });
+
+  it('the X-latch is scoped to the latched item: a different incumbentPos drops the latch', () => {
+    const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
+    const liApple = posOf(editor, (n) => n.type.name === 'listItem');
+    const ulPos = posOf(editor, (n) => n.type.name === 'bulletList');
+    const rects = new Map<number, HTMLElement>([
+      [ulPos, elWithRect({ top: 100, bottom: 150 })],
+      [liApple, elWithRect({ top: 100, bottom: 150 })],
+    ]);
+    const view = viewStub(editor, rects);
+    // X=30 sits in the band [20, 36): latched only when the incumbent matches.
+    const sameItem = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+      incumbentPos: liApple, nestLatched: true, hysteresis: true,
+    });
+    expect(sameItem?.mode).toBe('nested');
+    const otherItem = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+      incumbentPos: liApple + 9999, nestLatched: true, hysteresis: true,
+    });
+    expect(otherItem?.mode).toBe('sibling');
+    editor.destroy();
+  });
 });

--- a/packages/extension-block-menu/src/computeDropPlacement.test.ts
+++ b/packages/extension-block-menu/src/computeDropPlacement.test.ts
@@ -664,18 +664,18 @@ describe('computeDropPlacement - hysteresis (drag-session stickiness)', () => {
   });
 
   it('X-hysteresis: a latched nested mode stays nested in the band where an unlatched cursor would not enter', () => {
-    // Default threshold 28, band 8 -> enter at >=36, leave at <20. X=30 sits
-    // between, so the result depends purely on the latch.
+    // Asymmetric: enter at threshold 28, sticky-exit at 28-8=20. X=24 sits in
+    // [20, 28), so the result depends purely on the latch.
     const editor = makeEditor('<ul><li><p>Apple</p></li></ul>');
     const view = listItemView(editor);
 
-    const fromSibling = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+    const fromSibling = computeDropPlacement(view, 24, 125, NESTED_LIST, 28, {
       nestLatched: false,
       hysteresis: true,
     });
     expect(fromSibling?.mode).toBe('sibling');
 
-    const fromNested = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+    const fromNested = computeDropPlacement(view, 24, 125, NESTED_LIST, 28, {
       nestLatched: true,
       hysteresis: true,
     });
@@ -890,12 +890,12 @@ describe('computeDropPlacement - position-aware nested child slot', () => {
       [liApple, elWithRect({ top: 100, bottom: 150 })],
     ]);
     const view = viewStub(editor, rects);
-    // X=30 sits in the band [20, 36): latched only when the incumbent matches.
-    const sameItem = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+    // X=24 sits in the sticky band [20, 28): latched only when the incumbent matches.
+    const sameItem = computeDropPlacement(view, 24, 125, NESTED_LIST, 28, {
       incumbentPos: liApple, nestLatched: true, hysteresis: true,
     });
     expect(sameItem?.mode).toBe('nested');
-    const otherItem = computeDropPlacement(view, 30, 125, NESTED_LIST, 28, {
+    const otherItem = computeDropPlacement(view, 24, 125, NESTED_LIST, 28, {
       incumbentPos: liApple + 9999, nestLatched: true, hysteresis: true,
     });
     expect(otherItem?.mode).toBe('sibling');

--- a/packages/extension-block-menu/src/helpers/findTopLevelBlock.test.ts
+++ b/packages/extension-block-menu/src/helpers/findTopLevelBlock.test.ts
@@ -97,6 +97,15 @@ describe('findTopLevelBlock', () => {
     editor.destroy();
   });
 
+  it('returns null at the very end of the document (depth-0 boundary with no node starting there)', () => {
+    const editor = makeEditor('<p>Hi</p>');
+    // `content.size` resolves to depth 0 but `nodeAt` is null (nothing starts
+    // at the doc's end), so there is no top-level block to anchor on.
+    const result = findTopLevelBlock(editor.state.doc, editor.state.doc.content.size);
+    expect(result).toBeNull();
+    editor.destroy();
+  });
+
   it('provides `end` = pos + nodeSize for the resolved block', () => {
     const editor = makeEditor('<p>Hi</p><p>There</p>');
     const result = findTopLevelBlock(editor.state.doc, 5);

--- a/packages/extension-block-menu/src/helpers/findTopLevelBlock.test.ts
+++ b/packages/extension-block-menu/src/helpers/findTopLevelBlock.test.ts
@@ -502,3 +502,96 @@ describe('findDeepestBlockAtY', () => {
     editor.destroy();
   });
 });
+
+describe('findDeepestBlockAtY - Y-hysteresis (incumbent stickiness)', () => {
+  // Shared nested fixture: an outer list item whose rect (100-300) spans its
+  // own label PLUS a nested sublist, and an inner item with a short rect
+  // (150-200). The boundary at inner.top=150 is exactly where the
+  // "smallest-height wins" rule flips outer<->inner on a 1-2px wobble.
+  function nestedFixture(): {
+    editor: Editor;
+    view: EditorView;
+    outerPos: number;
+    innerPos: number;
+  } {
+    const editor = makeEditor('<ul><li><p>Outer</p><ul><li><p>Inner</p></li></ul></li></ul>');
+    const outerPos = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Outer'));
+    const innerPos = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Inner');
+    const rects = new Map<number, HTMLElement>([
+      [outerPos, elWithRect({ top: 100, bottom: 300 })],
+      [innerPos, elWithRect({ top: 150, bottom: 200 })],
+    ]);
+    return { editor, view: viewStub(editor, rects), outerPos, innerPos };
+  }
+
+  it('baseline (no incumbent): the winner flips outer<->inner across the boundary', () => {
+    // This is the bistability the hysteresis exists to tame: a 6px Y move
+    // across inner.top=150 swaps the resolved target with no stickiness.
+    const { editor, view, outerPos, innerPos } = nestedFixture();
+    expect(findDeepestBlockAtY(view, 147, ['listItem'])?.pos).toBe(outerPos); // just above inner
+    expect(findDeepestBlockAtY(view, 153, ['listItem'])?.pos).toBe(innerPos); // just inside inner
+    editor.destroy();
+  });
+
+  it('incumbent=inner keeps inner through a sub-band wobble above the boundary', () => {
+    // Cursor at 147 (3px above inner.top=150, within the 6px band). Without
+    // an incumbent this resolves to outer (baseline test above); with inner
+    // as the incumbent the sticky margin holds it on inner.
+    const { editor, view, innerPos } = nestedFixture();
+    const result = findDeepestBlockAtY(view, 147, ['listItem'], [], {
+      incumbentPos: innerPos,
+      hysteresisBand: 6,
+    });
+    expect(result?.pos).toBe(innerPos);
+    editor.destroy();
+  });
+
+  it('incumbent=inner yields to outer once the cursor crosses decisively (beyond the band)', () => {
+    // Cursor at 142 (8px above inner.top, past the 6px band) - the sticky
+    // margin no longer reaches, so the outer item takes over.
+    const { editor, view, outerPos, innerPos } = nestedFixture();
+    const result = findDeepestBlockAtY(view, 142, ['listItem'], [], {
+      incumbentPos: innerPos,
+      hysteresisBand: 6,
+    });
+    expect(result?.pos).toBe(outerPos);
+    editor.destroy();
+  });
+
+  it('incumbent=outer still lets the cursor enter the inner item (no margin on entry)', () => {
+    // Stickiness must not trap the cursor on the outer item: moving clearly
+    // into the inner row (152, inside 150-200) resolves to inner.
+    const { editor, view, outerPos, innerPos } = nestedFixture();
+    const result = findDeepestBlockAtY(view, 152, ['listItem'], [], {
+      incumbentPos: outerPos,
+      hysteresisBand: 6,
+    });
+    expect(result?.pos).toBe(innerPos);
+    editor.destroy();
+  });
+
+  it('hysteresisBand=0 disables stickiness even with an incumbent set', () => {
+    // Same 147 cursor + inner incumbent as the sticky test, but band 0 means
+    // the strict containment test runs and the result falls back to outer.
+    const { editor, view, outerPos, innerPos } = nestedFixture();
+    const result = findDeepestBlockAtY(view, 147, ['listItem'], [], {
+      incumbentPos: innerPos,
+      hysteresisBand: 0,
+    });
+    expect(result?.pos).toBe(outerPos);
+    editor.destroy();
+  });
+
+  it('a stale incumbent pos that no longer contains the cursor does not stick', () => {
+    // Incumbent points at inner, but the cursor is far below everything; the
+    // banded test still fails so resolution proceeds normally (here: null,
+    // nothing contains Y=500).
+    const { editor, view, innerPos } = nestedFixture();
+    const result = findDeepestBlockAtY(view, 500, ['listItem'], [], {
+      incumbentPos: innerPos,
+      hysteresisBand: 6,
+    });
+    expect(result).toBeNull();
+    editor.destroy();
+  });
+});

--- a/packages/extension-block-menu/src/helpers/findTopLevelBlock.ts
+++ b/packages/extension-block-menu/src/helpers/findTopLevelBlock.ts
@@ -105,6 +105,33 @@ export interface DeepestBlockMatch {
 }
 
 /**
+ * Hysteresis options for {@link findDeepestBlockAtY}. Used by the drag
+ * pipeline to keep the resolved target STABLE across the per-event
+ * re-resolution that would otherwise flip-flop near a nested-list boundary.
+ */
+export interface FindDeepestBlockOptions {
+  /**
+   * Position of the block resolved on the PREVIOUS dragover (the drag
+   * "incumbent"), or `null` for the first resolution of a drag.
+   *
+   * The problem this solves: an outer list item that contains a sublist has
+   * a TALL rect (it spans its own label plus every nested child), while the
+   * inner items have SHORT rects. Both vertically contain the cursor in the
+   * band just above the sublist, so the "smallest height wins" rule flips
+   * the winner outer<->inner on a 1-2px Y move - the drop indicator jumps.
+   *
+   * When set, the incumbent's vertical containment test is widened by
+   * `hysteresisBand` px on each edge, so the cursor must move DECISIVELY
+   * (more than the band) out of the current target before a different block
+   * can take over. The band never changes the height-based ranking, only
+   * which blocks are eligible to win.
+   */
+  incumbentPos?: number | null;
+  /** Sticky margin (px) applied to the incumbent's containment test. `0` disables. */
+  hysteresisBand?: number;
+}
+
+/**
  * Finds the **deepest (innermost)** block at a given client Y coordinate
  * by walking the doc tree and comparing each node's DOM rect against
  * `clientY`. Among all blocks whose vertical rect contains `clientY`
@@ -141,23 +168,35 @@ export function findDeepestBlockAtY(
   clientY: number,
   allowedTypes: string[],
   matchers: readonly BlockMatcher[] = [],
+  options: FindDeepestBlockOptions = {},
 ): DeepestBlockMatch | null {
   if (allowedTypes.length === 0) return null;
+  const incumbentPos = options.incumbentPos ?? null;
+  // Band only engages when there's an incumbent to be sticky about.
+  const band = incumbentPos !== null ? Math.max(0, options.hysteresisBand ?? 0) : 0;
   let best: DeepestBlockMatch | null = null;
   view.state.doc.descendants((node, pos, parent, index) => {
     const dom = view.nodeDOM(pos);
     if (!(dom instanceof HTMLElement)) return true;
     const rect = dom.getBoundingClientRect();
-    // Skip the entire subtree when the cursor isn't vertically inside this
-    // node - children of a non-containing parent can't contain the cursor
-    // either, so pruning here is what keeps the walk O(depth) instead of
-    // O(doc).
-    if (clientY < rect.top || clientY > rect.bottom) return false;
+    // Prune the subtree when the cursor isn't vertically inside this node -
+    // children of a non-containing parent can't contain the cursor either,
+    // so pruning keeps the walk O(depth) instead of O(doc). The prune test
+    // is widened by `band` so the incumbent's ancestor chain stays walkable
+    // when the cursor sits within the sticky margin just outside it.
+    if (clientY < rect.top - band || clientY > rect.bottom + band) return false;
     if (allowedTypes.includes(node.type.name)) {
       if (matchers.length > 0 && isRejectedByMatchers(view, node, pos, parent, index, matchers)) {
         return true;
       }
-      if (best === null || rect.height < best.rect.height) {
+      // Eligibility: a normal candidate must STRICTLY contain the cursor; the
+      // incumbent wins eligibility within the wider banded extent so a
+      // sub-band wobble can't promote a different block. Ranking still uses
+      // the REAL height, so the band never distorts which block is smallest.
+      const strictlyContains = clientY >= rect.top && clientY <= rect.bottom;
+      const incumbentContains =
+        pos === incumbentPos && clientY >= rect.top - band && clientY <= rect.bottom + band;
+      if ((strictlyContains || incumbentContains) && (best === null || rect.height < best.rect.height)) {
         best = { node, pos, dom, rect };
       }
     }

--- a/packages/extension-block-menu/src/helpers/findTopLevelBlock.ts
+++ b/packages/extension-block-menu/src/helpers/findTopLevelBlock.ts
@@ -105,63 +105,29 @@ export interface DeepestBlockMatch {
 }
 
 /**
- * Hysteresis options for {@link findDeepestBlockAtY}. Used by the drag
- * pipeline to keep the resolved target STABLE across the per-event
- * re-resolution that would otherwise flip-flop near a nested-list boundary.
+ * Hysteresis options for {@link findDeepestBlockAtY}, keeping the resolved
+ * target stable so it doesn't flip-flop near a nested-list boundary.
  */
 export interface FindDeepestBlockOptions {
   /**
-   * Position of the block resolved on the PREVIOUS dragover (the drag
-   * "incumbent"), or `null` for the first resolution of a drag.
-   *
-   * The problem this solves: an outer list item that contains a sublist has
-   * a TALL rect (it spans its own label plus every nested child), while the
-   * inner items have SHORT rects. Both vertically contain the cursor in the
-   * band just above the sublist, so the "smallest height wins" rule flips
-   * the winner outer<->inner on a 1-2px Y move - the drop indicator jumps.
-   *
-   * When set, the incumbent's vertical containment test is widened by
-   * `hysteresisBand` px on each edge, so the cursor must move DECISIVELY
-   * (more than the band) out of the current target before a different block
-   * can take over. The band never changes the height-based ranking, only
-   * which blocks are eligible to win.
+   * The previous dragover's resolved block. Its containment test is widened
+   * by `hysteresisBand`, so the cursor must move decisively out before a
+   * different block (e.g. outer<->inner list item) can take over. Ranking is
+   * unchanged; only eligibility widens.
    */
   incumbentPos?: number | null;
-  /** Sticky margin (px) applied to the incumbent's containment test. `0` disables. */
+  /** Sticky margin (px) for the incumbent's containment test. `0` disables. */
   hysteresisBand?: number;
 }
 
 /**
- * Finds the **deepest (innermost)** block at a given client Y coordinate
- * by walking the doc tree and comparing each node's DOM rect against
- * `clientY`. Among all blocks whose vertical rect contains `clientY`
- * AND whose type appears in `allowedTypes`, the one with the **smallest
- * height** wins (innermost in a vertical block layout).
- *
- * X is intentionally ignored - the gutter where the BlockHandle visually
- * lives sits to the left of `.ProseMirror`, so any X-based resolution
- * (`posAtCoords`, point-in-rect tests) would resolve to whatever happens
- * to be at the editor's left edge, which is the OUTER block when nested
- * lists are indented further right. This is the deepest-match behaviour:
- * the handle anchors on the row the cursor is actually in, regardless of
- * how far left the cursor strayed.
- *
- * The opposite policy - gutter bias (penalise depth near the left edge so
- * shallower ancestors win) - is exposed here as Mode C (`promoteOnEdge`)
- * and uses {@link ./resolveDragTarget resolveDragTarget} instead.
- *
- * `matchers` (default `[]`) shares the same `BlockMatcher[]` contract Mode C
- * applies; here only the `'reject'` verdict matters (a rejected candidate is
- * skipped, the walker continues). This keeps exclusion behaviour (e.g.
- * `firstChildOfListItem`) consistent between modes B and C: when a host
- * extends `allowedTypes` to include `paragraph`, the label paragraph of a
- * list item is automatically excluded so the handle still resolves to the
- * list item itself.
- *
- * Returns `null` when no allowed block contains `clientY` (e.g. cursor is
- * above the first block, below the last, or hovering a top-level node not
- * in `allowedTypes`). Callers should treat `null` as "fall through to
- * top-level resolution".
+ * Finds the deepest (smallest-height) `allowedTypes` block whose vertical
+ * rect contains `clientY`. X is ignored on purpose: the handle sits in the
+ * left gutter, so X-based resolution would pick the outer block; matching by
+ * Y anchors on the row the cursor is actually in. `matchers` can `'reject'`
+ * candidates (e.g. a list item's label paragraph). The gutter-bias
+ * alternative is Mode C ({@link ./resolveDragTarget resolveDragTarget}).
+ * Returns `null` (caller falls through to top-level) when nothing matches.
  */
 export function findDeepestBlockAtY(
   view: EditorView,
@@ -179,20 +145,15 @@ export function findDeepestBlockAtY(
     const dom = view.nodeDOM(pos);
     if (!(dom instanceof HTMLElement)) return true;
     const rect = dom.getBoundingClientRect();
-    // Prune the subtree when the cursor isn't vertically inside this node -
-    // children of a non-containing parent can't contain the cursor either,
-    // so pruning keeps the walk O(depth) instead of O(doc). The prune test
-    // is widened by `band` so the incumbent's ancestor chain stays walkable
-    // when the cursor sits within the sticky margin just outside it.
+    // Prune the subtree when the cursor is outside this node (keeps the walk
+    // O(depth)). Widened by `band` so the incumbent's ancestors stay walkable.
     if (clientY < rect.top - band || clientY > rect.bottom + band) return false;
     if (allowedTypes.includes(node.type.name)) {
       if (matchers.length > 0 && isRejectedByMatchers(view, node, pos, parent, index, matchers)) {
         return true;
       }
-      // Eligibility: a normal candidate must STRICTLY contain the cursor; the
-      // incumbent wins eligibility within the wider banded extent so a
-      // sub-band wobble can't promote a different block. Ranking still uses
-      // the REAL height, so the band never distorts which block is smallest.
+      // A normal candidate must strictly contain the cursor; the incumbent
+      // wins within the banded extent. Ranking still uses the real height.
       const strictlyContains = clientY >= rect.top && clientY <= rect.bottom;
       const incumbentContains =
         pos === incumbentPos && clientY >= rect.top - band && clientY <= rect.bottom + band;

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.test.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.test.ts
@@ -296,4 +296,56 @@ describe('moveBlockAsNestedChild', () => {
       expect(li?.lastChild?.textContent).toBe('Solo');
     });
   });
+
+  describe('childIndex (position-aware nested drop)', () => {
+    it('non-list source forwarded with childIndex=1 lands as the FIRST child (before existing block children)', () => {
+      editor = makeEditor('<p>Source</p><ul><li><p>Target</p><p>Existing</p></li></ul>');
+      const sourcePos = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'Source');
+      const wrapperPos = posOf(editor, (n) => n.type.name === 'bulletList');
+      const targetItemPos = posOf(editor, (n) => n.type.name === 'listItem');
+
+      const tr = editor.state.tr;
+      expect(moveBlockAsNestedChild(tr, sourcePos, wrapperPos, targetItemPos, 1)).toBe(true);
+      editor.view.dispatch(tr);
+
+      // Target item is now [Target(label), Source, Existing].
+      expect(dump(editor)).toContain(
+        'listItem(paragraph("Target"), paragraph("Source"), paragraph("Existing"))',
+      );
+    });
+
+    it('list-item source with childIndex=1 wraps in a fresh sublist placed BEFORE the existing block child', () => {
+      editor = makeEditor(
+        '<ul><li><p>Drag</p></li></ul><ul><li><p>Target</p><p>X</p></li></ul>',
+      );
+      const sourcePos = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Drag');
+      const targetItemPos = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Target'));
+      const wrapperPos = editor.state.doc.resolve(targetItemPos).before();
+
+      const tr = editor.state.tr;
+      expect(moveBlockAsNestedChild(tr, sourcePos, wrapperPos, targetItemPos, 1)).toBe(true);
+      editor.view.dispatch(tr);
+
+      // Target item: [label, nested bulletList(Drag), X]. The fresh sublist
+      // sits at index 1 (before X), not appended last.
+      const out = dump(editor);
+      expect(out).toContain('paragraph("Target"), bulletList(listItem(paragraph("Drag")))');
+      expect(out).toContain('bulletList(listItem(paragraph("Drag"))), paragraph("X")');
+    });
+
+    it('childIndex omitted still appends as last child (backward-compat)', () => {
+      editor = makeEditor('<p>Source</p><ul><li><p>Target</p><p>Existing</p></li></ul>');
+      const sourcePos = posOf(editor, (n) => n.type.name === 'paragraph' && n.textContent === 'Source');
+      const wrapperPos = posOf(editor, (n) => n.type.name === 'bulletList');
+      const targetItemPos = posOf(editor, (n) => n.type.name === 'listItem');
+
+      const tr = editor.state.tr;
+      expect(moveBlockAsNestedChild(tr, sourcePos, wrapperPos, targetItemPos)).toBe(true);
+      editor.view.dispatch(tr);
+
+      expect(dump(editor)).toContain(
+        'listItem(paragraph("Target"), paragraph("Existing"), paragraph("Source"))',
+      );
+    });
+  });
 });

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.test.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.test.ts
@@ -348,4 +348,66 @@ describe('moveBlockAsNestedChild', () => {
       );
     });
   });
+
+  describe('merge with adjacent same-type sublist', () => {
+    it('first-child slot merges into the existing sublist (one list, not two)', () => {
+      editor = makeEditor(
+        '<ul><li><p>AI</p><ul><li><p>Wire</p></li></ul></li></ul>' +
+        '<ul><li><p>Drag</p></li></ul>',
+      );
+      const aiItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('AI'));
+      const dragItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Drag');
+      const wrapperPos = editor.state.doc.resolve(aiItem).before();
+
+      const tr = editor.state.tr;
+      // childIndex 1 = first-child slot, before AI's existing nested sublist.
+      expect(moveBlockAsNestedChild(tr, dragItem, wrapperPos, aiItem, 1)).toBe(true);
+      editor.view.dispatch(tr);
+
+      // Dragged item joins the sublist as its first item; ONE bulletList.
+      expect(dump(editor)).toContain(
+        'listItem(paragraph("AI"), bulletList(listItem(paragraph("Drag")), listItem(paragraph("Wire"))))',
+      );
+    });
+
+    it('append slot merges into a trailing sublist as its last item', () => {
+      editor = makeEditor(
+        '<ul><li><p>AI</p><ul><li><p>Wire</p></li></ul></li></ul>' +
+        '<ul><li><p>Drag</p></li></ul>',
+      );
+      const aiItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('AI'));
+      const dragItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Drag');
+      const wrapperPos = editor.state.doc.resolve(aiItem).before();
+
+      const tr = editor.state.tr;
+      // No childIndex = append after the existing sublist, then join upward.
+      expect(moveBlockAsNestedChild(tr, dragItem, wrapperPos, aiItem)).toBe(true);
+      editor.view.dispatch(tr);
+
+      expect(dump(editor)).toContain(
+        'listItem(paragraph("AI"), bulletList(listItem(paragraph("Wire")), listItem(paragraph("Drag"))))',
+      );
+    });
+
+    it('does NOT merge across incompatible list types (canJoin gate)', () => {
+      // AI item lives in a bulletList but its sublist is a taskList. The
+      // dragged bullet item wraps as a bulletList, which cannot join the
+      // adjacent taskList, so two sibling sublists remain (schema-valid).
+      editor = makeEditor(
+        '<ul><li><p>AI</p><ul data-type="taskList"><li data-type="taskItem"><p>Wire</p></li></ul></li></ul>' +
+        '<ul><li><p>Drag</p></li></ul>',
+      );
+      const aiItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('AI'));
+      const dragItem = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Drag');
+      const wrapperPos = editor.state.doc.resolve(aiItem).before();
+
+      const tr = editor.state.tr;
+      expect(moveBlockAsNestedChild(tr, dragItem, wrapperPos, aiItem, 1)).toBe(true);
+      editor.view.dispatch(tr);
+
+      const out = dump(editor);
+      expect(out).toContain('bulletList(listItem(paragraph("Drag")))');
+      expect(out).toContain('taskList(taskItem(paragraph("Wire")))');
+    });
+  });
 });

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
@@ -8,10 +8,13 @@ import { convertListItemForParent } from './convertListItemForParent.js';
 const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
 
 /**
- * Moves a block from `sourcePos` and inserts it as the LAST child of
- * the list item at `targetItemPos` inside the wrapper at `wrapperPos`.
- * Shared drop-indent path used by `BlockHandle.performBlockDrop` when
- * `computeDropPlacement` returns `mode: 'nested'`.
+ * Moves a block from `sourcePos` and inserts it as a child of the list
+ * item at `targetItemPos` inside the wrapper at `wrapperPos`. Without
+ * `childIndex` it appends as the LAST child (legacy); pass `childIndex`
+ * (>= 1) to land it at a specific slot among the item's children, e.g.
+ * `1` for the first child after the label. Shared drop-indent path used by
+ * `BlockHandle.performBlockDrop` when `computeDropPlacement` returns
+ * `mode: 'nested'`.
  *
  * Behaviour matrix:
  *
@@ -42,6 +45,7 @@ export function moveBlockAsNestedChild(
   sourcePos: number,
   wrapperPos: number,
   targetItemPos: number,
+  childIndex?: number,
 ): boolean {
   if (sourcePos < 0 || sourcePos >= tr.doc.content.size) return false;
   const sourceNode = tr.doc.nodeAt(sourcePos);
@@ -84,6 +88,9 @@ export function moveBlockAsNestedChild(
     targetItemPos,
     blockNode,
     sourceRange: { from: expandedFrom, to: expandedTo },
+    // Conditional spread: `exactOptionalPropertyTypes` forbids passing an
+    // explicit `undefined` to the optional `childIndex` prop.
+    ...(childIndex !== undefined ? { childIndex } : {}),
   });
   return result.ok;
 }

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
@@ -10,17 +10,13 @@ const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
 
 /**
  * Moves the block at `sourcePos` into the list item at `targetItemPos`
- * (wrapper `wrapperPos`) at `childIndex` (default: append last). Drop-indent
- * path used by `performBlockDrop` for `mode: 'nested'`.
+ * (wrapper `wrapperPos`) at `childIndex` (default: append last). Used by
+ * `performBlockDrop` for `mode: 'nested'`.
  *
- * By source type: a non-list block goes in directly; a listItem/taskItem is
- * wrapped in a fresh target-type list (adapted via `convertListItemForParent`)
- * so it reads as a nested sublist, then joined with an adjacent same-type
- * sublist on either side so the dragged item MERGES into the existing list
- * instead of creating a second one. Position math + ordering is delegated to
- * `insertAsListItemChild`; the deletion range is widened via
- * `expandToEmptyWrappers`. Returns `false` (no mutation) on invalid source,
- * self-drop, or schema reject.
+ * A non-list block inserts directly; a listItem/taskItem is wrapped in a fresh
+ * target-type list (via `convertListItemForParent`) and joined with an adjacent
+ * same-type sublist so it MERGES rather than forming a second list. Returns
+ * `false` (no mutation) on invalid source, self-drop, or schema reject.
  */
 export function moveBlockAsNestedChild(
   tr: Transaction,
@@ -38,11 +34,10 @@ export function moveBlockAsNestedChild(
   if (targetItemPos >= sourcePos && targetItemPos < sourceEnd) return false;
   if (wrapperPos >= sourcePos && wrapperPos < sourceEnd) return false;
 
-  // Widen the deletion so a single-child wrapper around the source collapses
-  // with it instead of leaving an empty placeholder.
+  // Widen the deletion so a single-child wrapper collapses with the source.
   const { from: expandedFrom, to: expandedTo } = expandToEmptyWrappers(tr.doc, sourcePos, sourceEnd);
 
-  // A list-item source is wrapped in a fresh list (the item slot expects a
+  // A list-item source needs wrapping in a fresh list (the item slot expects a
   // block, not a bare listItem); other blocks insert as-is.
   let blockNode: PMNode;
   const wrapped = LIST_ITEM_TYPES.has(sourceNode.type.name);
@@ -71,10 +66,9 @@ export function moveBlockAsNestedChild(
   });
   if (!result.ok || result.insertedAt === undefined) return result.ok;
 
-  // Merge the freshly inserted list with an adjacent same-type sublist so the
-  // dragged item joins the existing list instead of forming a second one.
-  // Join the trailing boundary first (higher pos) so the leading one stays
-  // valid; `canJoin` no-ops across incompatible types (e.g. bullet vs task).
+  // Merge with an adjacent same-type sublist so the item joins it rather than
+  // forming a second list. Trailing boundary first (higher pos) so the leading
+  // one stays valid; `canJoin` no-ops across incompatible types.
   if (wrapped) {
     const after = result.insertedAt + blockNode.nodeSize;
     if (after < tr.doc.content.size && canJoin(tr.doc, after)) tr.join(after);

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
@@ -1,6 +1,7 @@
 import { Fragment } from '@domternal/pm/model';
 import type { Node as PMNode } from '@domternal/pm/model';
 import type { Transaction } from '@domternal/pm/state';
+import { canJoin } from '@domternal/pm/transform';
 import { insertAsListItemChild } from '@domternal/core';
 import { expandToEmptyWrappers } from './expandToEmptyWrappers.js';
 import { convertListItemForParent } from './convertListItemForParent.js';
@@ -14,7 +15,9 @@ const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
  *
  * By source type: a non-list block goes in directly; a listItem/taskItem is
  * wrapped in a fresh target-type list (adapted via `convertListItemForParent`)
- * so it reads as a nested sublist. Position math + ordering is delegated to
+ * so it reads as a nested sublist, then joined with an adjacent same-type
+ * sublist on either side so the dragged item MERGES into the existing list
+ * instead of creating a second one. Position math + ordering is delegated to
  * `insertAsListItemChild`; the deletion range is widened via
  * `expandToEmptyWrappers`. Returns `false` (no mutation) on invalid source,
  * self-drop, or schema reject.
@@ -42,7 +45,8 @@ export function moveBlockAsNestedChild(
   // A list-item source is wrapped in a fresh list (the item slot expects a
   // block, not a bare listItem); other blocks insert as-is.
   let blockNode: PMNode;
-  if (LIST_ITEM_TYPES.has(sourceNode.type.name)) {
+  const wrapped = LIST_ITEM_TYPES.has(sourceNode.type.name);
+  if (wrapped) {
     const wrapperNode = tr.doc.nodeAt(wrapperPos);
     if (!wrapperNode) return false;
     const adaptedFragment = convertListItemForParent(
@@ -65,5 +69,17 @@ export function moveBlockAsNestedChild(
     // Spread: exactOptionalPropertyTypes forbids passing `childIndex: undefined`.
     ...(childIndex !== undefined ? { childIndex } : {}),
   });
-  return result.ok;
+  if (!result.ok || result.insertedAt === undefined) return result.ok;
+
+  // Merge the freshly inserted list with an adjacent same-type sublist so the
+  // dragged item joins the existing list instead of forming a second one.
+  // Join the trailing boundary first (higher pos) so the leading one stays
+  // valid; `canJoin` no-ops across incompatible types (e.g. bullet vs task).
+  if (wrapped) {
+    const after = result.insertedAt + blockNode.nodeSize;
+    if (after < tr.doc.content.size && canJoin(tr.doc, after)) tr.join(after);
+    const before = result.insertedAt;
+    if (before > 0 && canJoin(tr.doc, before)) tr.join(before);
+  }
+  return true;
 }

--- a/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
+++ b/packages/extension-block-menu/src/helpers/moveBlockAsNestedChild.ts
@@ -8,37 +8,16 @@ import { convertListItemForParent } from './convertListItemForParent.js';
 const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
 
 /**
- * Moves a block from `sourcePos` and inserts it as a child of the list
- * item at `targetItemPos` inside the wrapper at `wrapperPos`. Without
- * `childIndex` it appends as the LAST child (legacy); pass `childIndex`
- * (>= 1) to land it at a specific slot among the item's children, e.g.
- * `1` for the first child after the label. Shared drop-indent path used by
- * `BlockHandle.performBlockDrop` when `computeDropPlacement` returns
- * `mode: 'nested'`.
+ * Moves the block at `sourcePos` into the list item at `targetItemPos`
+ * (wrapper `wrapperPos`) at `childIndex` (default: append last). Drop-indent
+ * path used by `performBlockDrop` for `mode: 'nested'`.
  *
- * Behaviour matrix:
- *
- *  - **Non-list source** (paragraph, heading, codeBlock, blockquote,
- *    horizontalRule, image, etc.) - inserted directly as last child of
- *    the target item. Schema (`paragraph block*`) accepts any block in
- *    the trailing slot.
- *  - **List item source** (listItem / taskItem) - wrapped in a fresh
- *    list wrapper of the SAME TYPE as the target's wrapper, with the
- *    source's item type adapted (via `convertListItemForParent`) so a
- *    bulletList listItem dropped into a taskList nested zone becomes a
- *    fresh taskList with a taskItem inside. Result: the dragged item
- *    appears as a nested sublist below the target item's label.
- *
- * Position math is delegated to `insertAsListItemChild` which handles
- * source-before-vs-after-target ordering automatically. Source range
- * is widened via `expandToEmptyWrappers` so single-child containers
- * don't leave empty placeholders behind (matches `moveBlock` semantics).
- *
- * Returns `false` (no mutation) when:
- *   - source position is invalid / no node
- *   - target position falls inside the source range (self-drop)
- *   - schema rejects the resulting structure (caller falls through to
- *     a sibling-style fallback or no-op)
+ * By source type: a non-list block goes in directly; a listItem/taskItem is
+ * wrapped in a fresh target-type list (adapted via `convertListItemForParent`)
+ * so it reads as a nested sublist. Position math + ordering is delegated to
+ * `insertAsListItemChild`; the deletion range is widened via
+ * `expandToEmptyWrappers`. Returns `false` (no mutation) on invalid source,
+ * self-drop, or schema reject.
  */
 export function moveBlockAsNestedChild(
   tr: Transaction,
@@ -52,21 +31,16 @@ export function moveBlockAsNestedChild(
   if (!sourceNode) return false;
   const sourceEnd = sourcePos + sourceNode.nodeSize;
 
-  // Self-drop guard: target item or its wrapper sits inside the source
-  // range. Prevents "move A into A's own subtree" - an invalid op that
-  // would otherwise corrupt the document.
+  // Self-drop guard: don't move A into its own subtree.
   if (targetItemPos >= sourcePos && targetItemPos < sourceEnd) return false;
   if (wrapperPos >= sourcePos && wrapperPos < sourceEnd) return false;
 
-  // Widen the deletion range so a single-child wrapper around the
-  // source (e.g., a nested ul whose only li is the source) collapses
-  // along with the source, instead of being left as an empty placeholder.
+  // Widen the deletion so a single-child wrapper around the source collapses
+  // with it instead of leaving an empty placeholder.
   const { from: expandedFrom, to: expandedTo } = expandToEmptyWrappers(tr.doc, sourcePos, sourceEnd);
 
-  // Pick the block to insert. For a list-item source we wrap it in a
-  // fresh list wrapper so the trailing block-slot of the target item
-  // (which expects a block, not a bare listItem) accepts the insertion
-  // and the result reads as a nested sublist below the target's label.
+  // A list-item source is wrapped in a fresh list (the item slot expects a
+  // block, not a bare listItem); other blocks insert as-is.
   let blockNode: PMNode;
   if (LIST_ITEM_TYPES.has(sourceNode.type.name)) {
     const wrapperNode = tr.doc.nodeAt(wrapperPos);
@@ -88,8 +62,7 @@ export function moveBlockAsNestedChild(
     targetItemPos,
     blockNode,
     sourceRange: { from: expandedFrom, to: expandedTo },
-    // Conditional spread: `exactOptionalPropertyTypes` forbids passing an
-    // explicit `undefined` to the optional `childIndex` prop.
+    // Spread: exactOptionalPropertyTypes forbids passing `childIndex: undefined`.
     ...(childIndex !== undefined ? { childIndex } : {}),
   });
   return result.ok;

--- a/packages/extension-block-menu/src/helpers/resolveDropDepth.test.ts
+++ b/packages/extension-block-menu/src/helpers/resolveDropDepth.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Document, Text, Paragraph, BulletList, OrderedList, ListItem, TaskList, TaskItem, Editor,
+} from '@domternal/core';
+import type { EditorView } from '@domternal/pm/view';
+import { resolveDropDepth } from './resolveDropDepth.js';
+
+const extensions = [Document, Text, Paragraph, BulletList, OrderedList, ListItem, TaskList, TaskItem];
+
+function makeEditor(html: string): Editor {
+  return new Editor({ extensions, content: html });
+}
+
+interface RectSpec { top?: number; bottom?: number; left: number; right?: number }
+
+function elWithRect(spec: RectSpec): HTMLElement {
+  const el = document.createElement('div');
+  const top = spec.top ?? 0;
+  const bottom = spec.bottom ?? 20;
+  const right = spec.right ?? spec.left + 500;
+  el.getBoundingClientRect = () => new DOMRect(spec.left, top, right - spec.left, bottom - top);
+  return el;
+}
+
+function viewStub(editor: Editor, rects: Map<number, HTMLElement>): EditorView {
+  return {
+    state: editor.state,
+    nodeDOM: (pos: number) => rects.get(pos) ?? null,
+  } as unknown as EditorView;
+}
+
+function posOf(editor: Editor, predicate: (n: { type: { name: string }; textContent: string }) => boolean): number {
+  let found = -1;
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== -1) return false;
+    if (predicate(node)) { found = pos; return false; }
+    return true;
+  });
+  if (found === -1) throw new Error('node not found');
+  return found;
+}
+
+/**
+ * Three-level nesting: Groceries (L1) > Fruit (L2) > Apples (L3). Ancestor
+ * lefts at 10 / 30 / 50; indentStep 24 => child boundary at Apples.left+24=74.
+ */
+function fixture(): {
+  editor: Editor; view: EditorView; groceries: number; fruit: number; apples: number;
+} {
+  const editor = makeEditor(
+    '<ul><li><p>Groceries</p><ul><li><p>Fruit</p><ul><li><p>Apples</p></li></ul></li></ul></li></ul>',
+  );
+  const groceries = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Groceries'));
+  const fruit = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent.startsWith('Fruit'));
+  const apples = posOf(editor, (n) => n.type.name === 'listItem' && n.textContent === 'Apples');
+  const rects = new Map<number, HTMLElement>([
+    [groceries, elWithRect({ left: 10 })],
+    [fruit, elWithRect({ left: 30 })],
+    [apples, elWithRect({ left: 50 })],
+  ]);
+  return { editor, view: viewStub(editor, rects), groceries, fruit, apples };
+}
+
+function afterOf(editor: Editor, itemPos: number): number {
+  const node = editor.state.doc.nodeAt(itemPos);
+  if (!node) throw new Error('no node');
+  return itemPos + node.nodeSize;
+}
+
+describe('resolveDropDepth', () => {
+  it('X past the resolved item indent nests as a CHILD (level L+1)', () => {
+    const { editor, view, apples } = fixture();
+    const r = resolveDropDepth({ view, itemPos: apples, clientX: 80, indentStep: 24 });
+    expect(r?.kind).toBe('child');
+    expect(r?.level).toBe(4); // Apples is L3 -> child L4
+    expect(r?.itemPos).toBe(apples);
+    editor.destroy();
+  });
+
+  it('X at the resolved item indent is a SIBLING at the deepest level', () => {
+    const { editor, view, apples } = fixture();
+    const r = resolveDropDepth({ view, itemPos: apples, clientX: 60, indentStep: 24 }); // [50,74)
+    expect(r?.kind).toBe('sibling');
+    expect(r?.level).toBe(3);
+    expect(r?.itemPos).toBe(apples);
+    expect(r?.afterPos).toBe(afterOf(editor, apples));
+    editor.destroy();
+  });
+
+  it('moving X left outdents one level (sibling after the middle ancestor)', () => {
+    const { editor, view, apples, fruit } = fixture();
+    const r = resolveDropDepth({ view, itemPos: apples, clientX: 40, indentStep: 24 }); // [30,50)
+    expect(r?.kind).toBe('sibling');
+    expect(r?.level).toBe(2);
+    expect(r?.itemPos).toBe(fruit);
+    expect(r?.afterPos).toBe(afterOf(editor, fruit));
+    editor.destroy();
+  });
+
+  it('moving X further left reaches the top-level list (level 1)', () => {
+    const { editor, view, apples, groceries } = fixture();
+    const r = resolveDropDepth({ view, itemPos: apples, clientX: 20, indentStep: 24 }); // [10,30)
+    expect(r?.kind).toBe('sibling');
+    expect(r?.level).toBe(1);
+    expect(r?.itemPos).toBe(groceries);
+    expect(r?.afterPos).toBe(afterOf(editor, groceries));
+    editor.destroy();
+  });
+
+  it('X left of the top-level indent floors at level 1', () => {
+    const { editor, view, apples, groceries } = fixture();
+    const r = resolveDropDepth({ view, itemPos: apples, clientX: 2, indentStep: 24 });
+    expect(r?.level).toBe(1);
+    expect(r?.itemPos).toBe(groceries);
+    editor.destroy();
+  });
+
+  it('a top-level item only offers sibling (L1) and child (L2)', () => {
+    const editor = makeEditor('<ul><li><p>Solo</p></li></ul>');
+    const solo = posOf(editor, (n) => n.type.name === 'listItem');
+    const rects = new Map<number, HTMLElement>([[solo, elWithRect({ left: 10 })]]);
+    const view = viewStub(editor, rects);
+    expect(resolveDropDepth({ view, itemPos: solo, clientX: 12, indentStep: 24 })?.level).toBe(1); // sibling
+    expect(resolveDropDepth({ view, itemPos: solo, clientX: 40, indentStep: 24 })?.kind).toBe('child'); // L2
+    editor.destroy();
+  });
+
+  it('level dead-band keeps the incumbent within band px of a boundary, flips past it', () => {
+    const { editor, view, apples } = fixture();
+    // Boundary into child = childBoundary = 74. X=71 is 3px below it.
+    const stateless = resolveDropDepth({ view, itemPos: apples, clientX: 71, indentStep: 24 });
+    expect(stateless?.level).toBe(3); // sibling, not child
+    const sticky = resolveDropDepth({ view, itemPos: apples, clientX: 71, indentStep: 24, incumbentLevel: 4, band: 6 });
+    expect(sticky?.level).toBe(4); // incumbent child held within band
+    const flipped = resolveDropDepth({ view, itemPos: apples, clientX: 60, indentStep: 24, incumbentLevel: 4, band: 6 });
+    expect(flipped?.level).toBe(3); // > band away -> flips to sibling
+    editor.destroy();
+  });
+
+  it('returns null when the resolved position has no list-item ancestor', () => {
+    const editor = makeEditor('<p>Plain</p>');
+    const p = posOf(editor, (n) => n.type.name === 'paragraph');
+    const view = viewStub(editor, new Map());
+    expect(resolveDropDepth({ view, itemPos: p, clientX: 50, indentStep: 24 })).toBeNull();
+    editor.destroy();
+  });
+});

--- a/packages/extension-block-menu/src/helpers/resolveDropDepth.test.ts
+++ b/packages/extension-block-menu/src/helpers/resolveDropDepth.test.ts
@@ -144,4 +144,28 @@ describe('resolveDropDepth', () => {
     expect(resolveDropDepth({ view, itemPos: p, clientX: 50, indentStep: 24 })).toBeNull();
     editor.destroy();
   });
+
+  it('returns null when a list-item ancestor lacks a DOM rect', () => {
+    // List ancestors exist, but `nodeDOM` yields nothing for them, so the
+    // ladder cannot be measured and resolution degrades to null.
+    const editor = makeEditor('<ul><li><p>Solo</p></li></ul>');
+    const solo = posOf(editor, (n) => n.type.name === 'listItem');
+    const view = viewStub(editor, new Map()); // nodeDOM -> null for every pos
+    expect(resolveDropDepth({ view, itemPos: solo, clientX: 40, indentStep: 24 })).toBeNull();
+    editor.destroy();
+  });
+
+  it('level dead-band holds the incumbent across a SIBLING-level boundary', () => {
+    // Boundary between L1 (Groceries, left 10) and L2 (Fruit, left 30) sits at
+    // X=30. Stateless X=32 picks L2; with incumbent L1 + band it stays L1,
+    // exercising the ancestor-boundary branch (upper level is not the child).
+    const { editor, view, apples, groceries } = fixture();
+    const stateless = resolveDropDepth({ view, itemPos: apples, clientX: 32, indentStep: 24 });
+    expect(stateless?.level).toBe(2);
+    const sticky = resolveDropDepth({ view, itemPos: apples, clientX: 32, indentStep: 24, incumbentLevel: 1, band: 6 });
+    expect(sticky?.level).toBe(1);
+    expect(sticky?.kind).toBe('sibling');
+    expect(sticky?.itemPos).toBe(groceries);
+    editor.destroy();
+  });
 });

--- a/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
+++ b/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
@@ -119,3 +119,14 @@ export function resolveDropDepth(args: ResolveDropDepthArgs): DropDepthRung | nu
   if (!rung) return null;
   return { level: rung.level, kind: 'sibling', itemPos: rung.itemPos, afterPos: rung.afterPos };
 }
+
+/** True when the item at `itemPos` has a shallower list-item ancestor (i.e. it can outdent). */
+export function hasShallowerListAncestor(doc: Node, itemPos: number): boolean {
+  const $inside = doc.resolve(itemPos + 1);
+  let count = 0;
+  for (let d = 1; d <= $inside.depth; d++) {
+    if (LIST_ITEM_TYPES.has($inside.node(d).type.name)) count += 1;
+    if (count >= 2) return true;
+  }
+  return false;
+}

--- a/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
+++ b/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
@@ -1,0 +1,121 @@
+import type { Node, ResolvedPos } from '@domternal/pm/model';
+import type { EditorView } from '@domternal/pm/view';
+
+const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
+
+/**
+ * One rung of the drop "depth ladder" for a vertical gap. The cursor's
+ * horizontal position picks a rung, Notion-style: drag right to nest deeper,
+ * left to outdent toward the top-level list.
+ */
+export interface DropDepthRung {
+  /** List-nesting level: 1 = top-level list, 2 = nested once, ... `L+1` = child of the resolved item. */
+  level: number;
+  /** `'child'` = nest inside the resolved item; `'sibling'` = insert after `afterPos` at this level. */
+  kind: 'child' | 'sibling';
+  /** The list item this rung targets (the resolved item for child; an ancestor for sibling). */
+  itemPos: number;
+  /** Position to insert AFTER for `'sibling'` (end of the ancestor item at this level). */
+  afterPos: number;
+}
+
+export interface ResolveDropDepthArgs {
+  view: EditorView;
+  /** Position right BEFORE the resolved deepest list item (nodeAt convention). */
+  itemPos: number;
+  /** Cursor client X. */
+  clientX: number;
+  /** Pixels of indent for the deepest (child) rung past the resolved item's left. */
+  indentStep: number;
+  /** Level chosen on the previous dragover, for the level dead-band. */
+  incumbentLevel?: number | null;
+  /** Dead-band (px) around a level boundary; `0` disables. */
+  band?: number;
+}
+
+interface AncestorRung {
+  level: number;
+  itemPos: number;
+  /** Position after the ancestor item's subtree (where a sibling at its level lands). */
+  afterPos: number;
+  /** Client-coord left edge of the ancestor item's box (the level's indent guide). */
+  left: number;
+}
+
+/**
+ * Build the list-item ancestor chain of the item at `itemPos`, innermost
+ * FIRST. Each entry's `level` is its list-nesting level (1 = top-level list
+ * item) and `afterPos` is the position just past that item. Returns `null`
+ * if any ancestor lacks a DOM rect (resolution then degrades to a fixed level).
+ */
+function listItemAncestors(view: EditorView, itemPos: number): AncestorRung[] | null {
+  const $inside: ResolvedPos = view.state.doc.resolve(itemPos + 1);
+  const rungs: AncestorRung[] = [];
+  let level = 0;
+  for (let d = 1; d <= $inside.depth; d++) {
+    const node: Node = $inside.node(d);
+    if (!LIST_ITEM_TYPES.has(node.type.name)) continue;
+    level += 1;
+    const pos = $inside.before(d);
+    const dom = view.nodeDOM(pos);
+    if (!(dom instanceof HTMLElement)) return null;
+    rungs.push({ level, itemPos: pos, afterPos: $inside.after(d), left: dom.getBoundingClientRect().left });
+  }
+  return rungs.reverse(); // innermost first
+}
+
+/**
+ * Resolve which depth rung the cursor's X picks for a drop in the gap at the
+ * resolved item. Levels span `1 .. L+1` where `L` is the resolved item's list
+ * level: `L+1` = child of the resolved item (drag fully right), descending
+ * levels = sibling at progressively shallower ancestors (drag left), floored
+ * at the top-level list. The mapping uses each ancestor's rendered left edge
+ * as its indent guide, so it tracks the real layout. `band > 0` keeps the
+ * `incumbentLevel` sticky within `band` px of a level boundary. Returns `null`
+ * when the chain has no list-item ancestor or a rect is missing.
+ */
+export function resolveDropDepth(args: ResolveDropDepthArgs): DropDepthRung | null {
+  const { view, itemPos, clientX, indentStep, incumbentLevel = null, band = 0 } = args;
+  const ancestors = listItemAncestors(view, itemPos);
+  if (!ancestors || ancestors.length === 0) return null;
+  const innermost = ancestors[0];
+  if (!innermost) return null;
+  const childLevel = innermost.level + 1;
+  const childBoundary = innermost.left + indentStep; // X at/after which we nest as a child
+
+  // Pick the level: child when X is at least one indent past the resolved
+  // item's left; otherwise the deepest ancestor whose indent guide the cursor
+  // has reached (ancestors are innermost-first => left edges decrease), floored
+  // at the top-level list.
+  let level: number;
+  if (clientX >= childBoundary) {
+    level = childLevel;
+  } else {
+    const reached = ancestors.find((a) => clientX >= a.left);
+    level = reached ? reached.level : 1;
+  }
+
+  // Level dead-band: keep the incumbent when the cursor sits within `band` px
+  // of the boundary X between the incumbent level and the freshly chosen one.
+  if (
+    band > 0 &&
+    incumbentLevel !== null &&
+    incumbentLevel >= 1 &&
+    incumbentLevel <= childLevel &&
+    Math.abs(level - incumbentLevel) === 1
+  ) {
+    const upper = Math.max(level, incumbentLevel);
+    // Boundary into `upper`: the deeper rung's left edge (child uses childBoundary).
+    const boundaryX = upper === childLevel
+      ? childBoundary
+      : ancestors.find((a) => a.level === upper)?.left ?? Number.NaN;
+    if (Number.isFinite(boundaryX) && Math.abs(clientX - boundaryX) <= band) level = incumbentLevel;
+  }
+
+  if (level >= childLevel) {
+    return { level: childLevel, kind: 'child', itemPos, afterPos: innermost.afterPos };
+  }
+  const rung = ancestors.find((a) => a.level === level) ?? ancestors[ancestors.length - 1];
+  if (!rung) return null;
+  return { level: rung.level, kind: 'sibling', itemPos: rung.itemPos, afterPos: rung.afterPos };
+}

--- a/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
+++ b/packages/extension-block-menu/src/helpers/resolveDropDepth.ts
@@ -65,14 +65,12 @@ function listItemAncestors(view: EditorView, itemPos: number): AncestorRung[] | 
 }
 
 /**
- * Resolve which depth rung the cursor's X picks for a drop in the gap at the
- * resolved item. Levels span `1 .. L+1` where `L` is the resolved item's list
- * level: `L+1` = child of the resolved item (drag fully right), descending
- * levels = sibling at progressively shallower ancestors (drag left), floored
- * at the top-level list. The mapping uses each ancestor's rendered left edge
- * as its indent guide, so it tracks the real layout. `band > 0` keeps the
- * `incumbentLevel` sticky within `band` px of a level boundary. Returns `null`
- * when the chain has no list-item ancestor or a rect is missing.
+ * Resolve which depth rung the cursor's X picks for a drop at the resolved
+ * item. Levels span `1 .. L+1` (`L` = the item's list level): `L+1` nests as a
+ * child (drag right); shallower levels are siblings at shallower ancestors
+ * (drag left), floored at the top-level list, using each ancestor's rendered
+ * left edge as its indent guide. `band > 0` keeps `incumbentLevel` sticky
+ * within `band` px of a boundary. Returns `null` with no ancestor or rect.
  */
 export function resolveDropDepth(args: ResolveDropDepthArgs): DropDepthRung | null {
   const { view, itemPos, clientX, indentStep, incumbentLevel = null, band = 0 } = args;
@@ -83,10 +81,9 @@ export function resolveDropDepth(args: ResolveDropDepthArgs): DropDepthRung | nu
   const childLevel = innermost.level + 1;
   const childBoundary = innermost.left + indentStep; // X at/after which we nest as a child
 
-  // Pick the level: child when X is at least one indent past the resolved
-  // item's left; otherwise the deepest ancestor whose indent guide the cursor
-  // has reached (ancestors are innermost-first => left edges decrease), floored
-  // at the top-level list.
+  // Child when X is one indent past the item's left; otherwise the deepest
+  // ancestor whose indent guide the cursor has reached (innermost-first, so
+  // left edges decrease), floored at the top-level list.
   let level: number;
   if (clientX >= childBoundary) {
     level = childLevel;

--- a/packages/theme/src/_block-handle.scss
+++ b/packages/theme/src/_block-handle.scss
@@ -76,7 +76,10 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.12s ease, visibility 0.12s;
+  // Soft fade in/out so the handle eases on/off a block instead of
+  // popping. Position stays instant (no transform) so it never lags the
+  // cursor between rows, and boundingBox reads in tests stay stable.
+  transition: opacity 0.15s ease, visibility 0.15s;
   z-index: var(--dm-z-handle, 25);
 
   &[data-show] {


### PR DESCRIPTION
## Summary

Extends block-menu drag-and-drop so a dragged block can be nested into list
items and re-leveled across the list hierarchy, and fixes the drop-indicator
jitter that appeared when dragging near nested lists.

## Features

- **Position-aware nested drop**: a dragged block can land as the first,
  between, or last child of a list item, not just as a flat sibling.
- **Multi-level depth ladder**: drag right to nest deeper, drag left to outdent
  a nested list item across ancestor levels, driven by the new `resolveDropDepth`
  helper.
- **Sublist merge**: a list item dropped next to an adjacent sublist merges into
  it instead of creating a separate list.

## Changes

- Stabilized the drop indicator near nested lists via drag-target hysteresis and
  rAF-coalesced repaint (no more jitter).
- Fixed nested-drop indicator indentation, a hysteresis zone-exit leak, and the
  self-drop no-op case; added sticky-exit X-hysteresis.
- Block handle now sticks to the nearest list item when hovering the gaps near
  nested lists, with a softened fade.
- New helpers with unit coverage: `resolveDropDepth`, `moveBlockAsNestedChild`,
  `computeDropPlacement`, `insertAsListItemChild`, `findTopLevelBlock`.
- Internal cleanup: `posAtIndex` reuse, drag-state bundling, trimmed verbose
  comments.
