### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.9.0 (2026-06-15)
+
+### Features
+
+- feat(core): the floating menu plugin now lives in `@domternal/core`, and `@domternal/extension-block-menu` is no longer a peer dependency of the framework wrappers. The Angular/React/Vue/Vanilla wrappers need only `@domternal/core` + `@domternal/theme`; add `@domternal/extension-block-menu` explicitly when you want the block handle, slash menu, or drag-and-drop. (#104)
+- feat(react): `immediatelyRender` creates the editor synchronously on the first render instead of after mount. (#104)
+- feat(extension-block-menu): per-item "Turn into" for lists. The slash command and block menu convert one list item at a time via the new `turnIntoBulletList` / `turnIntoOrderedList` / `turnIntoTaskList` commands, while the toolbar and keyboard shortcut still convert the whole list. (#105)
+- feat(theme): Notion-style list spacing. In notion mode, adjacent lists of different type chunk together at the within-item gap instead of the wider container gap; in both modes a nested list sits tightly under its parent label. (#105)
+
+### Fixes
+
+- fix(core): the placeholder paints on the initial draw of an empty editor instead of waiting for the first transaction. (#104)
+- fix(extension-mention, extension-emoji): suggestion items select on `mousemove`, so a resting pointer no longer overrides arrow-key navigation. (#104)
+- fix(theme): content clips on the editor's inner wrapper so popups can escape short editors; added the `--dm-editor-padding-top` variable for two-value padding shorthands. (#104)
+- fix(core, extension-table): `positionFloating` gained a flip-boundary option so the table cell toolbar stays inside the editor. (#104)
+- fix(core, extension-block-menu): a list item keeps its kind (bullet / ordered / to-do) across drag, paste, and turn-into; split numbering restarts and container drags close both ways. (#105)
+- fix(extension-block-menu): no-op block drops are suppressed. The drop indicator hides and the drop is ignored when the release target is the block's own slot. (#105)
+- fix(core): Shift+Tab outdents only the targeted children-zone block, splitting the list and keeping the parent item intact (Notion parity). (#105)
+
 ## 0.8.0 (2026-06-09)
 
 ### Features

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -16,7 +16,7 @@
   "peerDependencies": {
     "@angular/core": ">=17.1.0",
     "@angular/forms": ">=17.1.0",
-    "@domternal/core": ">=0.8.0"
+    "@domternal/core": ">=0.9.0"
   },
   "files": [
     "dist"
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
     "lint": "eslint src",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Block-menu UX extensions for Domternal editor - FloatingMenu, BlockHandle (hover gutter + drag), SlashCommand, ContextMenu, and keyboard reorder",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,15 +34,15 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {
     "hast-util-to-html": "^9.0.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0",
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0",
     "lowlight": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0",
-    "@domternal/pm": ">=0.8.0"
+    "@domternal/core": ">=0.9.0",
+    "@domternal/pm": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "@domternal/core": ">=0.8.0"
+    "@domternal/core": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -37,7 +37,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=0.8.0"
+    "@domternal/core": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -31,7 +31,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -20,7 +20,7 @@
   ],
   "peerDependencies": {
     "vue": ">=3.3",
-    "@domternal/core": ">=0.8.0"
+    "@domternal/core": ">=0.9.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -33,7 +33,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.8.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.9.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Release v0.9.0. Bumps all 15 packages + the docs site from 0.8.0 to 0.9.0 and ships everything merged since v0.8.0 (#104 and #105).

Minor release. The framework wrappers (`@domternal/angular|react|vue|vanilla`) no longer take `@domternal/extension-block-menu` as a peer dependency; they need only `@domternal/core` + `@domternal/theme`. Add `@domternal/extension-block-menu` explicitly when you want the block handle, slash menu, or drag-and-drop.

## Features

- **core:** the floating menu plugin moved into `@domternal/core`, and the wrappers dropped the `@domternal/extension-block-menu` peer dependency. (#104)
- **react:** `immediatelyRender` creates the editor synchronously on the first render. (#104)
- **extension-block-menu:** per-item "Turn into" for lists via new `turnIntoBulletList` / `turnIntoOrderedList` / `turnIntoTaskList` commands. The slash command and block menu convert one item; the toolbar and keyboard shortcut still convert the whole list. (#105)
- **theme:** Notion-style list spacing. Adjacent lists of different type chunk tightly in notion mode, and a nested list chunks under its parent label in both modes. (#105)

## Changes (fixes)

- **core:** the placeholder paints on the initial draw of an empty editor. (#104)
- **extension-mention, extension-emoji:** suggestion items select on `mousemove` so a resting pointer no longer overrides arrow-key navigation. (#104)
- **theme:** content clips on the editor's inner wrapper so popups escape short editors; new `--dm-editor-padding-top` variable. (#104)
- **core, extension-table:** `positionFloating` flip-boundary keeps the table cell toolbar inside the editor. (#104)
- **core, extension-block-menu:** a list item keeps its kind across drag, paste, and turn-into; split numbering restarts; container drags close both ways. (#105)
- **extension-block-menu:** no-op block drops are suppressed (the indicator hides and the drop is ignored when the target is the block's own slot). (#105)
- **core:** Shift+Tab outdents only the targeted children-zone block, splitting the list and keeping the parent item intact (Notion parity). (#105)

## Release mechanics

- `version` bumped to `0.9.0` in all 15 `packages/*/package.json` + `domternal.dev/package.json`.
- `@domternal/*` `peerDependencies` and `prepublishOnly` workspace pins bumped to `>=0.9.0`.
- `CHANGELOG.md` + docs-site changelog updated.

## Verified

- Full CI green on `main` before the bump: lint, typecheck, build, unit + coverage, api-surface, css-vars, bundle-size, consumer-types, and publint/attw across all 15 packages.
- e2e for the list / drag-drop / spacing changes verified on all four demos (React, Vue, Vanilla, Angular).
- Version bumps are metadata only.
