### PR TITLE
fix(core,theme): list and task-list behavior, parsing, and layout bugs

### DIFF
--- a/apps/demo-angular/e2e/list-audit-fixes.spec.ts
+++ b/apps/demo-angular/e2e/list-audit-fixes.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E coverage for the June 2026 list-behavior audit fixes. Unlike the core
+ * unit tests (which invoke the keymap functions directly), these drive REAL
+ * keydown events through the full plugin keymap chain and assert against the
+ * real rendered DOM - so they also verify handler precedence and CSS layout.
+ *
+ *   #1 cross-type outdent preserves item type + checked (Shift+Tab, Backspace)
+ *   #2 Enter at end of a label keeps nested children under the original item
+ *   #3 Enter on an empty label with children does not spawn a stray item
+ *   #4 OrderedList start is validated (no NaN/null corruption)
+ *   #5 GFM / markdown task lists import with checkboxes
+ *   #6 mixed <ul> does not fabricate an empty placeholder item
+ *   #7 list indent stays consistent when the editor font is scaled
+ *   #8 colored task item keeps its checkbox aligned with the label
+ *   #9 list markers / checkbox mirror in RTL
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = 'domternal-editor .ProseMirror';
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    if (ed) { ed.setContent(h, false); ed.commands.focus(); }
+  }, html);
+  await page.waitForTimeout(150);
+}
+async function getHTML(page: Page): Promise<string> {
+  return page.locator(editorSelector).innerHTML();
+}
+async function getText(page: Page): Promise<string> {
+  return (await page.locator(editorSelector).textContent()) ?? '';
+}
+async function getJSONString(page: Page): Promise<string> {
+  return page.evaluate(() => JSON.stringify((window as any).__DEMO_EDITOR__.getJSON()));
+}
+/** Place the caret at the start/end of the first paragraph whose text matches,
+ *  then send a REAL keydown so the live keymap chain is exercised. (click+Home
+ *  is unreliable for offset 0 inside a nested task structure.) */
+async function caretAt(page: Page, text: string, where: 'start' | 'end' = 'start'): Promise<void> {
+  await page.evaluate(({ txt, w }) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    let pos = -1, size = 0;
+    ed.state.doc.descendants((node: any, p: number) => {
+      if (pos !== -1) return false;
+      if (node.type.name === 'paragraph' && node.textContent === txt) { pos = p; size = node.nodeSize; return false; }
+      return true;
+    });
+    if (pos === -1) return;
+    const TS = ed.state.selection.constructor;
+    const target = w === 'start' ? pos + 1 : pos + size - 1;
+    ed.view.dispatch(ed.state.tr.setSelection(TS.create(ed.state.doc, target)));
+    ed.view.dom.focus(); ed.view.focus();
+  }, { txt: text, w: where });
+  await page.waitForTimeout(30);
+}
+
+const TASK_IN_BULLET =
+  '<ul><li><p>Parent</p><ul data-type="taskList">' +
+  '<li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>Child</p></div></li>' +
+  '</ul></li></ul>';
+const BULLET_IN_TASK =
+  '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label>' +
+  '<div><p>Task parent</p><ul><li><p>Bullet child</p></li></ul></div></li></ul>';
+
+test.describe('#1 cross-type outdent preserves item type + checked', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Shift+Tab: checked task nested in a bullet survives as a taskList', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Backspace at start: checked task nested in a bullet survives', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Backspace');
+    expect(await getHTML(page)).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Shift+Tab: bullet nested in a task survives as a bulletList', async ({ page }) => {
+    await setContentAndFocus(page, BULLET_IN_TASK);
+    await caretAt(page, 'Bullet child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('Bullet child');
+    // bullet item survives (a plain <ul> still present, not dissolved to a bare <p>)
+    expect(html).toContain('<ul>');
+  });
+});
+
+test.describe('#2 / #3 Enter keeps nested children under the original item', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#2 Enter at end of a parent label drops a sibling, child stays nested', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Parent</p><ul><li><p>Child</p></li></ul></li></ul>');
+    await caretAt(page, 'Parent', 'end');
+    await page.keyboard.press('Enter');
+    // Child stays under the first top-level item; a new empty sibling exists.
+    const childUnderParent = await page.locator(`${editorSelector} > ul > li:first-child ul li p`).textContent();
+    expect(childUnderParent).toContain('Child');
+    const topItems = await page.locator(`${editorSelector} > ul > li`).count();
+    expect(topItems).toBe(2);
+  });
+
+  test('#3 Enter on an empty label with children spawns no stray empty item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Top</p><ul><li><p></p><ul><li><p>Grandchild</p></li></ul></li></ul></li></ul>');
+    const emptyBefore = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    await caretAt(page, '', 'start');
+    await page.keyboard.press('Enter');
+    const emptyAfter = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    expect(emptyAfter).toBe(emptyBefore); // no duplicate empty item
+    expect(await getText(page)).toContain('Grandchild');
+  });
+});
+
+test.describe('#4 OrderedList start is validated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('malformed start does not corrupt JSON or HTML', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="abc"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).not.toContain('"start":null');
+    expect(await getHTML(page)).not.toContain('NaN');
+  });
+  test('valid start is preserved', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="5"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).toContain('"start":5');
+  });
+});
+
+test.describe('#5 / #6 import / parse fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#5 GFM task list imports as a real task list with checked state', async ({ page }) => {
+    await setContentAndFocus(page, '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked> Done</li><li class="task-list-item"><input type="checkbox"> Todo</li></ul>');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskList"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Done');
+  });
+  test('#6 mixed ul does not fabricate a leading empty bullet item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>tasktext</p></div></li><li><p>plain</p></li></ul>');
+    const text = await getText(page);
+    expect(text).toContain('tasktext');
+    expect(text).toContain('plain');
+    // first top-level node is not an empty placeholder list
+    const firstEmpty = await page.locator(`${editorSelector} > *:first-child`).evaluate((el) => {
+      const li = el.querySelector('li');
+      return !!li && (li.textContent ?? '').trim() === '' && el.querySelectorAll('li').length === 1;
+    });
+    expect(firstEmpty).toBe(false);
+  });
+});
+
+test.describe('#7 / #8 / #9 layout fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#8 coloring a task item does not shift its checkbox out of alignment', async ({ page }) => {
+    await setContentAndFocus(page,
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>plain task</p></div></li></ul>' +
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false" data-bg-color="blue"><label contenteditable="false"><input type="checkbox"></label><div><p>colored task</p></div></li></ul>');
+    const dy = await page.evaluate((sel) => {
+      const lis = Array.from(document.querySelectorAll(`${sel} li[data-type="taskItem"]`));
+      const measure = (li: Element) => {
+        const cb = li.querySelector('input')!.getBoundingClientRect();
+        const p = li.querySelector('p')!.getBoundingClientRect();
+        return ((cb.top + cb.bottom) / 2) - ((p.top + p.bottom) / 2);
+      };
+      return Math.abs(measure(lis[0]) - measure(lis[1]));
+    }, editorSelector);
+    expect(dy).toBeLessThan(1.0); // colored vs uncolored checkbox alignment matches
+  });
+
+  test('#9 RTL: checkbox hangs on the reading-start (right) side', async ({ page }) => {
+    await setContentAndFocus(page, '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>rtl task</p></div></li></ul>');
+    await page.evaluate((sel) => { (document.querySelector(sel) as HTMLElement).setAttribute('dir', 'rtl'); }, editorSelector);
+    await page.waitForTimeout(100);
+    const checkboxRightOfText = await page.evaluate((sel) => {
+      const li = document.querySelector(`${sel} li[data-type="taskItem"]`)!;
+      const cb = li.querySelector('input')!.getBoundingClientRect();
+      const p = li.querySelector('p')!.getBoundingClientRect();
+      return cb.left > p.right;
+    }, editorSelector);
+    expect(checkboxRightOfText).toBe(true);
+  });
+
+  test('#7 nested list and children-zone note align at a scaled editor font', async ({ page }) => {
+    await page.evaluate((sel) => { (document.querySelector(sel.replace(' .ProseMirror', '')) as HTMLElement).style.setProperty('--dm-editor-font-size', '1.6rem'); }, editorSelector);
+    await setContentAndFocus(page, '<ul><li><p>Label</p><p>note</p><ul><li><p>sub</p></li></ul></li></ul>');
+    const spread = await page.evaluate((sel) => {
+      const item = document.querySelector(`${sel} > ul > li`)!;
+      const note = item.querySelectorAll(':scope > p')[1]!.getBoundingClientRect().left;
+      const sub = item.querySelector(':scope > ul li p')!.getBoundingClientRect().left;
+      return Math.abs(note - sub);
+    }, editorSelector);
+    expect(spread).toBeLessThan(1.0);
+  });
+});

--- a/apps/demo-react/e2e/list-audit-fixes.spec.ts
+++ b/apps/demo-react/e2e/list-audit-fixes.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E coverage for the June 2026 list-behavior audit fixes. Unlike the core
+ * unit tests (which invoke the keymap functions directly), these drive REAL
+ * keydown events through the full plugin keymap chain and assert against the
+ * real rendered DOM - so they also verify handler precedence and CSS layout.
+ *
+ *   #1 cross-type outdent preserves item type + checked (Shift+Tab, Backspace)
+ *   #2 Enter at end of a label keeps nested children under the original item
+ *   #3 Enter on an empty label with children does not spawn a stray item
+ *   #4 OrderedList start is validated (no NaN/null corruption)
+ *   #5 GFM / markdown task lists import with checkboxes
+ *   #6 mixed <ul> does not fabricate an empty placeholder item
+ *   #7 list indent stays consistent when the editor font is scaled
+ *   #8 colored task item keeps its checkbox aligned with the label
+ *   #9 list markers / checkbox mirror in RTL
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    if (ed) { ed.setContent(h, false); ed.commands.focus(); }
+  }, html);
+  await page.waitForTimeout(150);
+}
+async function getHTML(page: Page): Promise<string> {
+  return page.locator(editorSelector).innerHTML();
+}
+async function getText(page: Page): Promise<string> {
+  return (await page.locator(editorSelector).textContent()) ?? '';
+}
+async function getJSONString(page: Page): Promise<string> {
+  return page.evaluate(() => JSON.stringify((window as any).__DEMO_EDITOR__.getJSON()));
+}
+/** Place the caret at the start/end of the first paragraph whose text matches,
+ *  then send a REAL keydown so the live keymap chain is exercised. (click+Home
+ *  is unreliable for offset 0 inside a nested task structure.) */
+async function caretAt(page: Page, text: string, where: 'start' | 'end' = 'start'): Promise<void> {
+  await page.evaluate(({ txt, w }) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    let pos = -1, size = 0;
+    ed.state.doc.descendants((node: any, p: number) => {
+      if (pos !== -1) return false;
+      if (node.type.name === 'paragraph' && node.textContent === txt) { pos = p; size = node.nodeSize; return false; }
+      return true;
+    });
+    if (pos === -1) return;
+    const TS = ed.state.selection.constructor;
+    const target = w === 'start' ? pos + 1 : pos + size - 1;
+    ed.view.dispatch(ed.state.tr.setSelection(TS.create(ed.state.doc, target)));
+    ed.view.dom.focus(); ed.view.focus();
+  }, { txt: text, w: where });
+  await page.waitForTimeout(30);
+}
+
+const TASK_IN_BULLET =
+  '<ul><li><p>Parent</p><ul data-type="taskList">' +
+  '<li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>Child</p></div></li>' +
+  '</ul></li></ul>';
+const BULLET_IN_TASK =
+  '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label>' +
+  '<div><p>Task parent</p><ul><li><p>Bullet child</p></li></ul></div></li></ul>';
+
+test.describe('#1 cross-type outdent preserves item type + checked', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Shift+Tab: checked task nested in a bullet survives as a taskList', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Backspace at start: checked task nested in a bullet survives', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Backspace');
+    expect(await getHTML(page)).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Shift+Tab: bullet nested in a task survives as a bulletList', async ({ page }) => {
+    await setContentAndFocus(page, BULLET_IN_TASK);
+    await caretAt(page, 'Bullet child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('Bullet child');
+    // bullet item survives (a plain <ul> still present, not dissolved to a bare <p>)
+    expect(html).toContain('<ul>');
+  });
+});
+
+test.describe('#2 / #3 Enter keeps nested children under the original item', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#2 Enter at end of a parent label drops a sibling, child stays nested', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Parent</p><ul><li><p>Child</p></li></ul></li></ul>');
+    await caretAt(page, 'Parent', 'end');
+    await page.keyboard.press('Enter');
+    // Child stays under the first top-level item; a new empty sibling exists.
+    const childUnderParent = await page.locator(`${editorSelector} > ul > li:first-child ul li p`).textContent();
+    expect(childUnderParent).toContain('Child');
+    const topItems = await page.locator(`${editorSelector} > ul > li`).count();
+    expect(topItems).toBe(2);
+  });
+
+  test('#3 Enter on an empty label with children spawns no stray empty item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Top</p><ul><li><p></p><ul><li><p>Grandchild</p></li></ul></li></ul></li></ul>');
+    const emptyBefore = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    await caretAt(page, '', 'start');
+    await page.keyboard.press('Enter');
+    const emptyAfter = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    expect(emptyAfter).toBe(emptyBefore); // no duplicate empty item
+    expect(await getText(page)).toContain('Grandchild');
+  });
+});
+
+test.describe('#4 OrderedList start is validated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('malformed start does not corrupt JSON or HTML', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="abc"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).not.toContain('"start":null');
+    expect(await getHTML(page)).not.toContain('NaN');
+  });
+  test('valid start is preserved', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="5"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).toContain('"start":5');
+  });
+});
+
+test.describe('#5 / #6 import / parse fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#5 GFM task list imports as a real task list with checked state', async ({ page }) => {
+    await setContentAndFocus(page, '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked> Done</li><li class="task-list-item"><input type="checkbox"> Todo</li></ul>');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskList"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Done');
+  });
+  test('#6 mixed ul does not fabricate a leading empty bullet item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>tasktext</p></div></li><li><p>plain</p></li></ul>');
+    const text = await getText(page);
+    expect(text).toContain('tasktext');
+    expect(text).toContain('plain');
+    // first top-level node is not an empty placeholder list
+    const firstEmpty = await page.locator(`${editorSelector} > *:first-child`).evaluate((el) => {
+      const li = el.querySelector('li');
+      return !!li && (li.textContent ?? '').trim() === '' && el.querySelectorAll('li').length === 1;
+    });
+    expect(firstEmpty).toBe(false);
+  });
+});
+
+test.describe('#7 / #8 / #9 layout fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#8 coloring a task item does not shift its checkbox out of alignment', async ({ page }) => {
+    await setContentAndFocus(page,
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>plain task</p></div></li></ul>' +
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false" data-bg-color="blue"><label contenteditable="false"><input type="checkbox"></label><div><p>colored task</p></div></li></ul>');
+    const dy = await page.evaluate((sel) => {
+      const lis = Array.from(document.querySelectorAll(`${sel} li[data-type="taskItem"]`));
+      const measure = (li: Element) => {
+        const cb = li.querySelector('input')!.getBoundingClientRect();
+        const p = li.querySelector('p')!.getBoundingClientRect();
+        return ((cb.top + cb.bottom) / 2) - ((p.top + p.bottom) / 2);
+      };
+      return Math.abs(measure(lis[0]) - measure(lis[1]));
+    }, editorSelector);
+    expect(dy).toBeLessThan(1.0); // colored vs uncolored checkbox alignment matches
+  });
+
+  test('#9 RTL: checkbox hangs on the reading-start (right) side', async ({ page }) => {
+    await setContentAndFocus(page, '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>rtl task</p></div></li></ul>');
+    await page.evaluate((sel) => { (document.querySelector(sel) as HTMLElement).setAttribute('dir', 'rtl'); }, editorSelector);
+    await page.waitForTimeout(100);
+    const checkboxRightOfText = await page.evaluate((sel) => {
+      const li = document.querySelector(`${sel} li[data-type="taskItem"]`)!;
+      const cb = li.querySelector('input')!.getBoundingClientRect();
+      const p = li.querySelector('p')!.getBoundingClientRect();
+      return cb.left > p.right;
+    }, editorSelector);
+    expect(checkboxRightOfText).toBe(true);
+  });
+
+  test('#7 nested list and children-zone note align at a scaled editor font', async ({ page }) => {
+    await page.evaluate((sel) => { (document.querySelector(sel.replace(' .ProseMirror', '')) as HTMLElement).style.setProperty('--dm-editor-font-size', '1.6rem'); }, editorSelector);
+    await setContentAndFocus(page, '<ul><li><p>Label</p><p>note</p><ul><li><p>sub</p></li></ul></li></ul>');
+    const spread = await page.evaluate((sel) => {
+      const item = document.querySelector(`${sel} > ul > li`)!;
+      const note = item.querySelectorAll(':scope > p')[1]!.getBoundingClientRect().left;
+      const sub = item.querySelector(':scope > ul li p')!.getBoundingClientRect().left;
+      return Math.abs(note - sub);
+    }, editorSelector);
+    expect(spread).toBeLessThan(1.0);
+  });
+});

--- a/apps/demo-vanilla/e2e/list-audit-fixes.spec.ts
+++ b/apps/demo-vanilla/e2e/list-audit-fixes.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E coverage for the June 2026 list-behavior audit fixes. Unlike the core
+ * unit tests (which invoke the keymap functions directly), these drive REAL
+ * keydown events through the full plugin keymap chain and assert against the
+ * real rendered DOM - so they also verify handler precedence and CSS layout.
+ *
+ *   #1 cross-type outdent preserves item type + checked (Shift+Tab, Backspace)
+ *   #2 Enter at end of a label keeps nested children under the original item
+ *   #3 Enter on an empty label with children does not spawn a stray item
+ *   #4 OrderedList start is validated (no NaN/null corruption)
+ *   #5 GFM / markdown task lists import with checkboxes
+ *   #6 mixed <ul> does not fabricate an empty placeholder item
+ *   #7 list indent stays consistent when the editor font is scaled
+ *   #8 colored task item keeps its checkbox aligned with the label
+ *   #9 list markers / checkbox mirror in RTL
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    if (ed) { ed.setContent(h, false); ed.commands.focus(); }
+  }, html);
+  await page.waitForTimeout(150);
+}
+async function getHTML(page: Page): Promise<string> {
+  return page.locator(editorSelector).innerHTML();
+}
+async function getText(page: Page): Promise<string> {
+  return (await page.locator(editorSelector).textContent()) ?? '';
+}
+async function getJSONString(page: Page): Promise<string> {
+  return page.evaluate(() => JSON.stringify((window as any).__DEMO_EDITOR__.getJSON()));
+}
+/** Place the caret at the start/end of the first paragraph whose text matches,
+ *  then send a REAL keydown so the live keymap chain is exercised. (click+Home
+ *  is unreliable for offset 0 inside a nested task structure.) */
+async function caretAt(page: Page, text: string, where: 'start' | 'end' = 'start'): Promise<void> {
+  await page.evaluate(({ txt, w }) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    let pos = -1, size = 0;
+    ed.state.doc.descendants((node: any, p: number) => {
+      if (pos !== -1) return false;
+      if (node.type.name === 'paragraph' && node.textContent === txt) { pos = p; size = node.nodeSize; return false; }
+      return true;
+    });
+    if (pos === -1) return;
+    const TS = ed.state.selection.constructor;
+    const target = w === 'start' ? pos + 1 : pos + size - 1;
+    ed.view.dispatch(ed.state.tr.setSelection(TS.create(ed.state.doc, target)));
+    ed.view.dom.focus(); ed.view.focus();
+  }, { txt: text, w: where });
+  await page.waitForTimeout(30);
+}
+
+const TASK_IN_BULLET =
+  '<ul><li><p>Parent</p><ul data-type="taskList">' +
+  '<li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>Child</p></div></li>' +
+  '</ul></li></ul>';
+const BULLET_IN_TASK =
+  '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label>' +
+  '<div><p>Task parent</p><ul><li><p>Bullet child</p></li></ul></div></li></ul>';
+
+test.describe('#1 cross-type outdent preserves item type + checked', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Shift+Tab: checked task nested in a bullet survives as a taskList', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Backspace at start: checked task nested in a bullet survives', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Backspace');
+    expect(await getHTML(page)).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Shift+Tab: bullet nested in a task survives as a bulletList', async ({ page }) => {
+    await setContentAndFocus(page, BULLET_IN_TASK);
+    await caretAt(page, 'Bullet child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('Bullet child');
+    // bullet item survives (a plain <ul> still present, not dissolved to a bare <p>)
+    expect(html).toContain('<ul>');
+  });
+});
+
+test.describe('#2 / #3 Enter keeps nested children under the original item', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#2 Enter at end of a parent label drops a sibling, child stays nested', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Parent</p><ul><li><p>Child</p></li></ul></li></ul>');
+    await caretAt(page, 'Parent', 'end');
+    await page.keyboard.press('Enter');
+    // Child stays under the first top-level item; a new empty sibling exists.
+    const childUnderParent = await page.locator(`${editorSelector} > ul > li:first-child ul li p`).textContent();
+    expect(childUnderParent).toContain('Child');
+    const topItems = await page.locator(`${editorSelector} > ul > li`).count();
+    expect(topItems).toBe(2);
+  });
+
+  test('#3 Enter on an empty label with children spawns no stray empty item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Top</p><ul><li><p></p><ul><li><p>Grandchild</p></li></ul></li></ul></li></ul>');
+    const emptyBefore = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    await caretAt(page, '', 'start');
+    await page.keyboard.press('Enter');
+    const emptyAfter = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    expect(emptyAfter).toBe(emptyBefore); // no duplicate empty item
+    expect(await getText(page)).toContain('Grandchild');
+  });
+});
+
+test.describe('#4 OrderedList start is validated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('malformed start does not corrupt JSON or HTML', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="abc"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).not.toContain('"start":null');
+    expect(await getHTML(page)).not.toContain('NaN');
+  });
+  test('valid start is preserved', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="5"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).toContain('"start":5');
+  });
+});
+
+test.describe('#5 / #6 import / parse fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#5 GFM task list imports as a real task list with checked state', async ({ page }) => {
+    await setContentAndFocus(page, '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked> Done</li><li class="task-list-item"><input type="checkbox"> Todo</li></ul>');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskList"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Done');
+  });
+  test('#6 mixed ul does not fabricate a leading empty bullet item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>tasktext</p></div></li><li><p>plain</p></li></ul>');
+    const text = await getText(page);
+    expect(text).toContain('tasktext');
+    expect(text).toContain('plain');
+    // first top-level node is not an empty placeholder list
+    const firstEmpty = await page.locator(`${editorSelector} > *:first-child`).evaluate((el) => {
+      const li = el.querySelector('li');
+      return !!li && (li.textContent ?? '').trim() === '' && el.querySelectorAll('li').length === 1;
+    });
+    expect(firstEmpty).toBe(false);
+  });
+});
+
+test.describe('#7 / #8 / #9 layout fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#8 coloring a task item does not shift its checkbox out of alignment', async ({ page }) => {
+    await setContentAndFocus(page,
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>plain task</p></div></li></ul>' +
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false" data-bg-color="blue"><label contenteditable="false"><input type="checkbox"></label><div><p>colored task</p></div></li></ul>');
+    const dy = await page.evaluate((sel) => {
+      const lis = Array.from(document.querySelectorAll(`${sel} li[data-type="taskItem"]`));
+      const measure = (li: Element) => {
+        const cb = li.querySelector('input')!.getBoundingClientRect();
+        const p = li.querySelector('p')!.getBoundingClientRect();
+        return ((cb.top + cb.bottom) / 2) - ((p.top + p.bottom) / 2);
+      };
+      return Math.abs(measure(lis[0]) - measure(lis[1]));
+    }, editorSelector);
+    expect(dy).toBeLessThan(1.0); // colored vs uncolored checkbox alignment matches
+  });
+
+  test('#9 RTL: checkbox hangs on the reading-start (right) side', async ({ page }) => {
+    await setContentAndFocus(page, '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>rtl task</p></div></li></ul>');
+    await page.evaluate((sel) => { (document.querySelector(sel) as HTMLElement).setAttribute('dir', 'rtl'); }, editorSelector);
+    await page.waitForTimeout(100);
+    const checkboxRightOfText = await page.evaluate((sel) => {
+      const li = document.querySelector(`${sel} li[data-type="taskItem"]`)!;
+      const cb = li.querySelector('input')!.getBoundingClientRect();
+      const p = li.querySelector('p')!.getBoundingClientRect();
+      return cb.left > p.right;
+    }, editorSelector);
+    expect(checkboxRightOfText).toBe(true);
+  });
+
+  test('#7 nested list and children-zone note align at a scaled editor font', async ({ page }) => {
+    await page.evaluate((sel) => { (document.querySelector(sel.replace(' .ProseMirror', '')) as HTMLElement).style.setProperty('--dm-editor-font-size', '1.6rem'); }, editorSelector);
+    await setContentAndFocus(page, '<ul><li><p>Label</p><p>note</p><ul><li><p>sub</p></li></ul></li></ul>');
+    const spread = await page.evaluate((sel) => {
+      const item = document.querySelector(`${sel} > ul > li`)!;
+      const note = item.querySelectorAll(':scope > p')[1]!.getBoundingClientRect().left;
+      const sub = item.querySelector(':scope > ul li p')!.getBoundingClientRect().left;
+      return Math.abs(note - sub);
+    }, editorSelector);
+    expect(spread).toBeLessThan(1.0);
+  });
+});

--- a/apps/demo-vue/e2e/list-audit-fixes.spec.ts
+++ b/apps/demo-vue/e2e/list-audit-fixes.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E coverage for the June 2026 list-behavior audit fixes. Unlike the core
+ * unit tests (which invoke the keymap functions directly), these drive REAL
+ * keydown events through the full plugin keymap chain and assert against the
+ * real rendered DOM - so they also verify handler precedence and CSS layout.
+ *
+ *   #1 cross-type outdent preserves item type + checked (Shift+Tab, Backspace)
+ *   #2 Enter at end of a label keeps nested children under the original item
+ *   #3 Enter on an empty label with children does not spawn a stray item
+ *   #4 OrderedList start is validated (no NaN/null corruption)
+ *   #5 GFM / markdown task lists import with checkboxes
+ *   #6 mixed <ul> does not fabricate an empty placeholder item
+ *   #7 list indent stays consistent when the editor font is scaled
+ *   #8 colored task item keeps its checkbox aligned with the label
+ *   #9 list markers / checkbox mirror in RTL
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+
+const editorSelector = '.dm-editor .ProseMirror';
+
+async function setContentAndFocus(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    if (ed) { ed.setContent(h, false); ed.commands.focus(); }
+  }, html);
+  await page.waitForTimeout(150);
+}
+async function getHTML(page: Page): Promise<string> {
+  return page.locator(editorSelector).innerHTML();
+}
+async function getText(page: Page): Promise<string> {
+  return (await page.locator(editorSelector).textContent()) ?? '';
+}
+async function getJSONString(page: Page): Promise<string> {
+  return page.evaluate(() => JSON.stringify((window as any).__DEMO_EDITOR__.getJSON()));
+}
+/** Place the caret at the start/end of the first paragraph whose text matches,
+ *  then send a REAL keydown so the live keymap chain is exercised. (click+Home
+ *  is unreliable for offset 0 inside a nested task structure.) */
+async function caretAt(page: Page, text: string, where: 'start' | 'end' = 'start'): Promise<void> {
+  await page.evaluate(({ txt, w }) => {
+    const ed = (window as any).__DEMO_EDITOR__;
+    let pos = -1, size = 0;
+    ed.state.doc.descendants((node: any, p: number) => {
+      if (pos !== -1) return false;
+      if (node.type.name === 'paragraph' && node.textContent === txt) { pos = p; size = node.nodeSize; return false; }
+      return true;
+    });
+    if (pos === -1) return;
+    const TS = ed.state.selection.constructor;
+    const target = w === 'start' ? pos + 1 : pos + size - 1;
+    ed.view.dispatch(ed.state.tr.setSelection(TS.create(ed.state.doc, target)));
+    ed.view.dom.focus(); ed.view.focus();
+  }, { txt: text, w: where });
+  await page.waitForTimeout(30);
+}
+
+const TASK_IN_BULLET =
+  '<ul><li><p>Parent</p><ul data-type="taskList">' +
+  '<li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>Child</p></div></li>' +
+  '</ul></li></ul>';
+const BULLET_IN_TASK =
+  '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label>' +
+  '<div><p>Task parent</p><ul><li><p>Bullet child</p></li></ul></div></li></ul>';
+
+test.describe('#1 cross-type outdent preserves item type + checked', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('Shift+Tab: checked task nested in a bullet survives as a taskList', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Backspace at start: checked task nested in a bullet survives', async ({ page }) => {
+    await setContentAndFocus(page, TASK_IN_BULLET);
+    await caretAt(page, 'Child', 'start');
+    await page.keyboard.press('Backspace');
+    expect(await getHTML(page)).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Child');
+  });
+
+  test('Shift+Tab: bullet nested in a task survives as a bulletList', async ({ page }) => {
+    await setContentAndFocus(page, BULLET_IN_TASK);
+    await caretAt(page, 'Bullet child', 'start');
+    await page.keyboard.press('Shift+Tab');
+    const html = await getHTML(page);
+    expect(html).toContain('Bullet child');
+    // bullet item survives (a plain <ul> still present, not dissolved to a bare <p>)
+    expect(html).toContain('<ul>');
+  });
+});
+
+test.describe('#2 / #3 Enter keeps nested children under the original item', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#2 Enter at end of a parent label drops a sibling, child stays nested', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Parent</p><ul><li><p>Child</p></li></ul></li></ul>');
+    await caretAt(page, 'Parent', 'end');
+    await page.keyboard.press('Enter');
+    // Child stays under the first top-level item; a new empty sibling exists.
+    const childUnderParent = await page.locator(`${editorSelector} > ul > li:first-child ul li p`).textContent();
+    expect(childUnderParent).toContain('Child');
+    const topItems = await page.locator(`${editorSelector} > ul > li`).count();
+    expect(topItems).toBe(2);
+  });
+
+  test('#3 Enter on an empty label with children spawns no stray empty item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li><p>Top</p><ul><li><p></p><ul><li><p>Grandchild</p></li></ul></li></ul></li></ul>');
+    const emptyBefore = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    await caretAt(page, '', 'start');
+    await page.keyboard.press('Enter');
+    const emptyAfter = await page.locator(`${editorSelector} p`).evaluateAll((ps) => ps.filter((p) => !p.textContent).length);
+    expect(emptyAfter).toBe(emptyBefore); // no duplicate empty item
+    expect(await getText(page)).toContain('Grandchild');
+  });
+});
+
+test.describe('#4 OrderedList start is validated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('malformed start does not corrupt JSON or HTML', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="abc"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).not.toContain('"start":null');
+    expect(await getHTML(page)).not.toContain('NaN');
+  });
+  test('valid start is preserved', async ({ page }) => {
+    await setContentAndFocus(page, '<ol start="5"><li><p>x</p></li></ol>');
+    expect(await getJSONString(page)).toContain('"start":5');
+  });
+});
+
+test.describe('#5 / #6 import / parse fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#5 GFM task list imports as a real task list with checked state', async ({ page }) => {
+    await setContentAndFocus(page, '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked> Done</li><li class="task-list-item"><input type="checkbox"> Todo</li></ul>');
+    const html = await getHTML(page);
+    expect(html).toContain('data-type="taskList"');
+    expect(html).toContain('data-checked="true"');
+    expect(await getText(page)).toContain('Done');
+  });
+  test('#6 mixed ul does not fabricate a leading empty bullet item', async ({ page }) => {
+    await setContentAndFocus(page, '<ul><li data-type="taskItem" data-checked="true"><label contenteditable="false"><input type="checkbox" checked></label><div><p>tasktext</p></div></li><li><p>plain</p></li></ul>');
+    const text = await getText(page);
+    expect(text).toContain('tasktext');
+    expect(text).toContain('plain');
+    // first top-level node is not an empty placeholder list
+    const firstEmpty = await page.locator(`${editorSelector} > *:first-child`).evaluate((el) => {
+      const li = el.querySelector('li');
+      return !!li && (li.textContent ?? '').trim() === '' && el.querySelectorAll('li').length === 1;
+    });
+    expect(firstEmpty).toBe(false);
+  });
+});
+
+test.describe('#7 / #8 / #9 layout fixes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector(editorSelector);
+  });
+
+  test('#8 coloring a task item does not shift its checkbox out of alignment', async ({ page }) => {
+    await setContentAndFocus(page,
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>plain task</p></div></li></ul>' +
+      '<ul data-type="taskList"><li data-type="taskItem" data-checked="false" data-bg-color="blue"><label contenteditable="false"><input type="checkbox"></label><div><p>colored task</p></div></li></ul>');
+    const dy = await page.evaluate((sel) => {
+      const lis = Array.from(document.querySelectorAll(`${sel} li[data-type="taskItem"]`));
+      const measure = (li: Element) => {
+        const cb = li.querySelector('input')!.getBoundingClientRect();
+        const p = li.querySelector('p')!.getBoundingClientRect();
+        return ((cb.top + cb.bottom) / 2) - ((p.top + p.bottom) / 2);
+      };
+      return Math.abs(measure(lis[0]) - measure(lis[1]));
+    }, editorSelector);
+    expect(dy).toBeLessThan(1.0); // colored vs uncolored checkbox alignment matches
+  });
+
+  test('#9 RTL: checkbox hangs on the reading-start (right) side', async ({ page }) => {
+    await setContentAndFocus(page, '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label contenteditable="false"><input type="checkbox"></label><div><p>rtl task</p></div></li></ul>');
+    await page.evaluate((sel) => { (document.querySelector(sel) as HTMLElement).setAttribute('dir', 'rtl'); }, editorSelector);
+    await page.waitForTimeout(100);
+    const checkboxRightOfText = await page.evaluate((sel) => {
+      const li = document.querySelector(`${sel} li[data-type="taskItem"]`)!;
+      const cb = li.querySelector('input')!.getBoundingClientRect();
+      const p = li.querySelector('p')!.getBoundingClientRect();
+      return cb.left > p.right;
+    }, editorSelector);
+    expect(checkboxRightOfText).toBe(true);
+  });
+
+  test('#7 nested list and children-zone note align at a scaled editor font', async ({ page }) => {
+    await page.evaluate((sel) => { (document.querySelector(sel.replace(' .ProseMirror', '')) as HTMLElement).style.setProperty('--dm-editor-font-size', '1.6rem'); }, editorSelector);
+    await setContentAndFocus(page, '<ul><li><p>Label</p><p>note</p><ul><li><p>sub</p></li></ul></li></ul>');
+    const spread = await page.evaluate((sel) => {
+      const item = document.querySelector(`${sel} > ul > li`)!;
+      const note = item.querySelectorAll(':scope > p')[1]!.getBoundingClientRect().left;
+      const sub = item.querySelector(':scope > ul li p')!.getBoundingClientRect().left;
+      return Math.abs(note - sub);
+    }, editorSelector);
+    expect(spread).toBeLessThan(1.0);
+  });
+});

--- a/packages/core/src/extensions/ListKeymap.ts
+++ b/packages/core/src/extensions/ListKeymap.ts
@@ -22,6 +22,7 @@ import type { EditorState } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
 import { Extension } from '../Extension.js';
 import type { ExtensionEditorInterface } from '../Extension.js';
+import { liftCrossTypeListItem } from '../utils/liftCrossTypeListItem.js';
 
 const LIST_GROUP_TYPES = new Set(['bulletList', 'orderedList', 'taskList']);
 
@@ -86,6 +87,10 @@ export const ListKeymap = Extension.create<ListKeymapOptions>({
         if (!this.editor) return false;
         const ctx = getListItemContext(this.editor, this.options.listItem);
         if (!ctx) return false;
+        // Cross-type nesting (e.g. a bullet item inside a task item):
+        // liftListItem would dissolve the item into a bare paragraph; preserve
+        // its type instead.
+        if (liftCrossTypeListItem(ctx.state, ctx.view.dispatch)) return true;
         return liftListItem(ctx.listItemType)(ctx.state, ctx.view.dispatch);
       },
 
@@ -180,6 +185,9 @@ export const ListKeymap = Extension.create<ListKeymapOptions>({
           // Check if the textblock is empty or cursor is at its start
           const posInListItem = $from.pos - $from.start(listItemDepth);
           if (posInListItem <= 1) {
+            // Cross-type nesting: preserve the item's type instead of
+            // dissolving it to a paragraph.
+            if (liftCrossTypeListItem(state, view.dispatch)) return true;
             return liftListItem(listItemType)(state, view.dispatch);
           }
         }

--- a/packages/core/src/helpers/createDocument.ts
+++ b/packages/core/src/helpers/createDocument.ts
@@ -5,8 +5,56 @@
  * Plain text is NOT supported - use HTML or JSON explicitly.
  */
 import type { Schema} from '@domternal/pm/model';
-import { Node as PMNode, DOMParser } from '@domternal/pm/model';
+import { Node as PMNode, DOMParser, Fragment } from '@domternal/pm/model';
 import type { Content, JSONContent } from '../types/index.js';
+
+const LIST_WRAPPER_TYPES = new Set(['bulletList', 'orderedList', 'taskList']);
+
+/**
+ * True for the content-fitter artifact: a list whose only content is one item
+ * holding a single empty paragraph. When HTML mixes item types in one `<ul>`
+ * (e.g. a `data-type="taskItem"` first), the parser opens a bulletList, finds
+ * it cannot hold the taskItem, and closes the bulletList - filling its required
+ * `listItem > paragraph` with an empty placeholder the author never wrote.
+ */
+function isEmptyPlaceholderList(node: PMNode): boolean {
+  if (!LIST_WRAPPER_TYPES.has(node.type.name) || node.childCount !== 1) return false;
+  const item = node.child(0);
+  return item.childCount === 1
+    && item.child(0).type.name === 'paragraph'
+    && item.child(0).content.size === 0;
+}
+
+/**
+ * Drops the fitter artifact above: an empty single-item placeholder list that
+ * sits immediately before a DIFFERENT-type list (the list it was split from).
+ * Scoped tightly to that signature so authored empty lists are left alone.
+ * Recurses so the artifact is removed at whatever depth the mixed list parsed.
+ */
+function stripFitterArtifacts(node: PMNode): PMNode {
+  if (!node.isBlock || node.isLeaf) return node;
+
+  const children: PMNode[] = [];
+  node.forEach((child) => children.push(stripFitterArtifacts(child)));
+
+  const kept: PMNode[] = [];
+  children.forEach((cur, i) => {
+    const next: PMNode | undefined = children[i + 1];
+    if (
+      isEmptyPlaceholderList(cur)
+      && next
+      && LIST_WRAPPER_TYPES.has(next.type.name)
+      && next.type !== cur.type
+    ) {
+      return; // drop the content-fitter artifact
+    }
+    kept.push(cur);
+  });
+
+  // Reconstruct only when filtering dropped a node or recursion replaced one.
+  const unchanged = kept.length === node.childCount && kept.every((c, i) => c === node.child(i));
+  return unchanged ? node : node.copy(Fragment.fromArray(kept));
+}
 
 /**
  * Options for createDocument
@@ -76,7 +124,7 @@ function parseHTMLContent(
   element.innerHTML = html;
 
   const parser = DOMParser.fromSchema(schema);
-  return parser.parse(element, options?.parseOptions);
+  return stripFitterArtifacts(parser.parse(element, options?.parseOptions));
 }
 
 /**

--- a/packages/core/src/nodes/ListItem.ts
+++ b/packages/core/src/nodes/ListItem.ts
@@ -73,7 +73,34 @@ export const ListItem = Node.create<ListItemOptions>({
           }
         }
 
-        if (splitListItem(this.nodeType)(state, view.dispatch)) return true;
+        // Label slot of an item that already has nested children. PM's
+        // splitListItem assigns everything after the caret (the whole nested
+        // sub-list) to the new sibling, emptying the original item. Notion
+        // keeps children under the original parent, so handle these here:
+        const item = $from.node(-1);
+        const hasChildren = item.childCount > 1;
+        const atEnd = $from.parentOffset === $from.parent.content.size;
+        const labelEmpty = $from.parent.content.size === 0;
+        if (!ctx?.isInChildrenZone && hasChildren && atEnd && !labelEmpty) {
+          // Non-empty label, caret at end: a fresh empty sibling drops below,
+          // children stay nested under the original item.
+          const newItem = this.nodeType.createAndFill();
+          if (newItem) {
+            const insertAt = $from.after($from.depth - 1);
+            const tr = state.tr.insert(insertAt, newItem);
+            tr.setSelection(Selection.near(tr.doc.resolve(insertAt + 2)));
+            view.dispatch(tr.scrollIntoView());
+            return true;
+          }
+        }
+
+        // Empty label with children: skip splitListItem (it would migrate the
+        // children to a stray sibling) and fall through to the lift below,
+        // which outdents the whole item one level (Notion: empty Enter
+        // outdents). Childless empty labels still split (splitListItem no-ops
+        // on them, then liftListItem runs).
+        const skipSplit = !ctx?.isInChildrenZone && labelEmpty && hasChildren;
+        if (!skipSplit && splitListItem(this.nodeType)(state, view.dispatch)) return true;
 
         // Empty listItem inside a list that's inside a taskItem: liftListItem would
         // place a bare paragraph in the taskItem (loses bullet marker). Instead,

--- a/packages/core/src/nodes/OrderedList.ts
+++ b/packages/core/src/nodes/OrderedList.ts
@@ -40,16 +40,22 @@ export const OrderedList = Node.create<OrderedListOptions>({
     return {
       start: {
         default: 1,
+        // Clamp to a finite integer >= 1. Without this, a malformed
+        // `start="abc"` parses to NaN; `JSON.stringify(NaN)` is `null`, so
+        // getJSON() serializes `start: null` and a save/load cycle
+        // permanently dirties the document (reloads as `<ol start="null">`).
         parseHTML: (element: HTMLElement) => {
-          const start = element.getAttribute('start');
-          return start ? parseInt(start, 10) : 1;
+          const n = parseInt(element.getAttribute('start') ?? '', 10);
+          return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
         },
         renderHTML: (attributes: Record<string, unknown>) => {
           const start = attributes['start'] as number;
-          if (start === 1) {
+          // Only emit a non-default, valid start. Guards against a stray
+          // NaN/non-finite reaching the DOM as `start="NaN"`.
+          if (!Number.isFinite(start) || start <= 1) {
             return {};
           }
-          return { start: String(start) };
+          return { start: String(Math.floor(start)) };
         },
       },
     };
@@ -142,8 +148,8 @@ export const OrderedList = Node.create<OrderedListOptions>({
         guard: notInsideList,
         joinForward: true,
         getAttributes: (match) => {
-          const num = match[1];
-          return { start: num ? parseInt(num, 10) : 1 };
+          const n = parseInt(match[1] ?? '', 10);
+          return { start: Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1 };
         },
       }),
     ];

--- a/packages/core/src/nodes/TaskItem.test.ts
+++ b/packages/core/src/nodes/TaskItem.test.ts
@@ -110,6 +110,10 @@ describe('TaskItem', () => {
           tag: 'li[data-type="taskItem"]',
           priority: 51,
         },
+        {
+          tag: 'li.task-list-item',
+          priority: 51,
+        },
       ]);
     });
   });

--- a/packages/core/src/nodes/TaskItem.ts
+++ b/packages/core/src/nodes/TaskItem.ts
@@ -24,6 +24,7 @@ import type { CommandSpec } from '../types/Commands.js';
 import { getListItemCursorContext } from '../utils/listItemCursorContext.js';
 import { insertChildrenZoneSibling } from '../utils/insertChildrenZoneSibling.js';
 import { liftEmptyChildrenZoneParagraph } from '../utils/liftEmptyChildrenZoneParagraph.js';
+import { liftCrossTypeListItem } from '../utils/liftCrossTypeListItem.js';
 import { TaskItemNodeView } from './TaskItemNodeView.js';
 
 declare module '@domternal/core' {
@@ -60,7 +61,13 @@ export const TaskItem = Node.create<TaskItemOptions>({
         keepOnSplit: false,
         parseHTML: (element: HTMLElement) => {
           const dataChecked = element.getAttribute('data-checked');
-          return dataChecked === 'true' || dataChecked === '';
+          if (dataChecked !== null) {
+            // Case-insensitive ("TRUE"/"True") + the empty-string form.
+            return dataChecked.toLowerCase() === 'true' || dataChecked === '';
+          }
+          // No data-checked (GFM / markdown task lists): derive from the
+          // rendered checkbox input so imported checked state survives.
+          return element.querySelector('input[type="checkbox"]')?.hasAttribute('checked') ?? false;
         },
         renderHTML: (attributes: Record<string, unknown>) => ({
           'data-checked': attributes['checked'] ? 'true' : 'false',
@@ -73,6 +80,14 @@ export const TaskItem = Node.create<TaskItemOptions>({
     return [
       {
         tag: `li[data-type="${this.name}"]`,
+        priority: 51,
+      },
+      // GFM / markdown task lists: `<li class="task-list-item">` carries no
+      // data-type. Priority 51 keeps it ahead of the generic `li` (listItem,
+      // 50); class-scoped so it never swallows ordinary bullet items. The
+      // `checked` attribute is derived from the descendant `<input>` above.
+      {
+        tag: 'li.task-list-item',
         priority: 51,
       },
     ];
@@ -187,13 +202,39 @@ export const TaskItem = Node.create<TaskItemOptions>({
           }
         }
 
+        // Label slot of a taskItem that already has nested children. PM's
+        // splitListItem assigns everything after the caret (the whole nested
+        // sub-list) to the new sibling, emptying the original item. Notion
+        // keeps children under the original parent, so handle these here.
+        const item = $from.node(-1);
+        const hasChildren = item.childCount > 1;
+        const labelEmpty = $from.parent.content.size === 0;
+        const atEnd = $from.parentOffset === $from.parent.content.size;
+        if (!ctx?.isInChildrenZone && hasChildren && atEnd && !labelEmpty) {
+          // Non-empty label, caret at end: a fresh unchecked sibling drops
+          // below; children stay nested under the original item.
+          const newItem = this.nodeType.createAndFill({ checked: false });
+          if (newItem) {
+            const insertAt = $from.after($from.depth - 1);
+            const tr = state.tr.insert(insertAt, newItem);
+            tr.setSelection(Selection.near(tr.doc.resolve(insertAt + 2)));
+            view.dispatch(tr.scrollIntoView());
+            return true;
+          }
+        }
+
         // Standard split for non-empty items. Pass `{ checked: false }` so
         // a freshly-spawned task item always starts unchecked - splitting
         // off a checked task otherwise inherits checked: true (Notion
         // semantics: each new task is fresh work). Other attrs assigned
         // by sibling extensions (UniqueID's `id`, etc.) are intentionally
         // NOT forwarded so those extensions can regenerate them.
-        if (splitListItem(this.nodeType, { checked: false })(state, view.dispatch)) return true;
+        //
+        // Skip the split for an empty label that has children: splitting would
+        // migrate the children to a stray sibling. Fall through to the
+        // empty-item lift/promotion below (Notion: empty Enter outdents).
+        const skipSplit = !ctx?.isInChildrenZone && labelEmpty && hasChildren;
+        if (!skipSplit && splitListItem(this.nodeType, { checked: false })(state, view.dispatch)) return true;
 
         // For empty taskItem nested inside a parent list item (e.g. orderedList > listItem > taskList > taskItem),
         // delete the taskItem, clean up the taskList if empty, and create a new parent listItem.
@@ -257,9 +298,14 @@ export const TaskItem = Node.create<TaskItemOptions>({
       },
       'Shift-Tab': () => {
         if (!this.editor || !this.nodeType) return false;
-        const { $from } = this.editor.state.selection;
+        const { state, view } = this.editor;
+        const { $from } = state.selection;
         if ($from.depth < 1 || $from.node(-1).type !== this.nodeType) return false;
-        return liftListItem(this.nodeType)(this.editor.state, this.editor.view.dispatch);
+        // Cross-type nesting (taskItem inside a bullet/ordered list item):
+        // liftListItem would dissolve the task into a bare paragraph, dropping
+        // the checkbox + checked state. Preserve it instead.
+        if (liftCrossTypeListItem(state, view.dispatch)) return true;
+        return liftListItem(this.nodeType)(state, view.dispatch);
       },
       Backspace: () => {
         if (!this.editor || !this.nodeType) return false;
@@ -290,6 +336,9 @@ export const TaskItem = Node.create<TaskItemOptions>({
         // Only lift when cursor is in the first child of the taskItem
         if ($from.index(taskItemDepth) !== 0) return false;
 
+        // Cross-type nesting: preserve the task (type + checked) instead of
+        // dissolving it to a paragraph.
+        if (liftCrossTypeListItem(state, view.dispatch)) return true;
         return liftListItem(this.nodeType)(state, view.dispatch);
       },
       'Mod-Enter': () => {

--- a/packages/core/src/nodes/TaskList.test.ts
+++ b/packages/core/src/nodes/TaskList.test.ts
@@ -49,6 +49,10 @@ describe('TaskList', () => {
           tag: 'ul[data-type="taskList"]',
           priority: 51,
         },
+        {
+          tag: 'ul.contains-task-list',
+          priority: 51,
+        },
       ]);
     });
   });

--- a/packages/core/src/nodes/TaskList.ts
+++ b/packages/core/src/nodes/TaskList.ts
@@ -42,6 +42,13 @@ export const TaskList = Node.create<TaskListOptions>({
         tag: `ul[data-type="${this.name}"]`,
         priority: 51, // Higher priority than regular bulletList
       },
+      // GFM / markdown task lists: `<ul class="contains-task-list">`. Priority
+      // 51 keeps it ahead of the generic `ul` (bulletList, 50); class-scoped so
+      // it only matches real GFM task-list containers, not ordinary bullets.
+      {
+        tag: 'ul.contains-task-list',
+        priority: 51,
+      },
     ];
   },
 

--- a/packages/core/src/nodes/listBehaviorFixes.test.ts
+++ b/packages/core/src/nodes/listBehaviorFixes.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression tests for list/task behavior bugs found in the June 2026 list
+ * audit. Each describe block maps to one fixed defect; together they guard the
+ * cross-cutting fixes that span ListItem / TaskItem / ListKeymap / OrderedList /
+ * createDocument so a future refactor cannot silently reintroduce them.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { TextSelection } from '@domternal/pm/state';
+import { TaskItem } from './TaskItem.js';
+import { TaskList } from './TaskList.js';
+import { BulletList } from './BulletList.js';
+import { OrderedList } from './OrderedList.js';
+import { ListItem } from './ListItem.js';
+import { Document } from './Document.js';
+import { Text } from './Text.js';
+import { Paragraph } from './Paragraph.js';
+import { Editor } from '../Editor.js';
+import { ListKeymap } from '../extensions/ListKeymap.js';
+
+let editor: Editor | undefined;
+afterEach(() => { if (editor && !editor.isDestroyed) editor.destroy(); });
+const base = [Document, Text, Paragraph, BulletList, OrderedList, ListItem, TaskList, TaskItem];
+
+function caretAt(text: string, where: 'end' | 'start'): void {
+  const ed = editor!;
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.type.name === 'paragraph' && node.textContent === text) {
+      pos = where === 'end' ? p + 1 + node.content.size : p + 1;
+    }
+  });
+  ed.view.dispatch(ed.state.tr.setSelection(TextSelection.create(ed.state.doc, pos)));
+}
+function fire(itemExt: any, key: string): boolean | undefined {
+  const ed = editor!;
+  const nodeType = ed.state.schema.nodes[itemExt.name];
+  const sc = itemExt.config.addKeyboardShortcuts?.call({ ...itemExt, editor: ed, nodeType, options: itemExt.options });
+  return sc?.[key]?.();
+}
+function fireListKeymap(key: string): boolean | undefined {
+  const ed = editor!;
+  const sc: any = ListKeymap.config.addKeyboardShortcuts?.call({ ...ListKeymap, editor: ed, options: { listItem: 'listItem' } } as any);
+  return sc?.[key]?.();
+}
+function countEmptyParas(): number {
+  const ed = editor!;
+  let n = 0;
+  ed.state.doc.descendants((node) => { if (node.type.name === 'paragraph' && node.content.size === 0) n++; });
+  return n;
+}
+function docValid(): boolean {
+  try { editor!.state.doc.check(); return true; } catch { return false; }
+}
+
+describe('OrderedList start is validated (no NaN/null corruption)', () => {
+  it('malformed start falls back to 1 and never serializes as null/NaN', () => {
+    editor = new Editor({ extensions: base, content: '<ol start="abc"><li><p>x</p></li></ol>' });
+    expect(editor.state.doc.firstChild!.attrs['start']).toBe(1);
+    expect(editor.getHTML()).not.toContain('NaN');
+    expect(JSON.stringify(editor.getJSON())).not.toContain('"start":null');
+  });
+  it('valid start is preserved; values < 1 clamp to 1', () => {
+    editor = new Editor({ extensions: base, content: '<ol start="5"><li><p>x</p></li></ol>' });
+    expect(editor.state.doc.firstChild!.attrs['start']).toBe(5);
+    expect(editor.getHTML()).toContain('start="5"');
+    editor.destroy();
+    editor = new Editor({ extensions: base, content: '<ol start="-4"><li><p>x</p></li></ol>' });
+    expect(editor.state.doc.firstChild!.attrs['start']).toBe(1);
+  });
+});
+
+describe('GFM / markdown task lists import with checkbox + checked state', () => {
+  it('contains-task-list maps to taskList; per-item checked derived from input', () => {
+    editor = new Editor({
+      extensions: base,
+      content: '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked> Done</li><li class="task-list-item"><input type="checkbox"> Todo</li></ul>',
+    });
+    const list = editor.state.doc.firstChild!;
+    expect(list.type.name).toBe('taskList');
+    expect(list.child(0).attrs['checked']).toBe(true);
+    expect(list.child(1).attrs['checked']).toBe(false);
+    expect(editor.getText()).toContain('Done');
+  });
+  it('data-checked parsing is case-insensitive', () => {
+    editor = new Editor({
+      extensions: base,
+      content: '<ul data-type="taskList"><li data-type="taskItem" data-checked="TRUE"><div><p>x</p></div></li></ul>',
+    });
+    expect(editor.state.doc.firstChild!.child(0).attrs['checked']).toBe(true);
+  });
+  it('an ordinary bullet list is NOT swallowed by the task-list fallback', () => {
+    editor = new Editor({ extensions: base, content: '<ul><li><p>plain</p></li></ul>' });
+    expect(editor.state.doc.firstChild!.type.name).toBe('bulletList');
+  });
+});
+
+describe('Enter on a label with nested children keeps children under the original item', () => {
+  it('bullet: caret at end of label -> fresh empty sibling, child stays nested', () => {
+    editor = new Editor({ extensions: base, content: '<ul><li><p>Parent</p><ul><li><p>Child</p></li></ul></li></ul>' });
+    caretAt('Parent', 'end');
+    expect(fire(ListItem, 'Enter')).toBe(true);
+    const outer = editor.state.doc.firstChild!;
+    expect(outer.childCount).toBe(2);
+    expect(outer.child(0).textContent).toContain('Child');
+    expect(outer.child(1).textContent).toBe('');
+  });
+  it('task: caret at end of label -> fresh empty sibling, child stays nested', () => {
+    editor = new Editor({ extensions: base, content: '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><div><p>Parent</p><ul data-type="taskList"><li data-type="taskItem" data-checked="false"><div><p>Child</p></div></li></ul></div></li></ul>' });
+    caretAt('Parent', 'end');
+    expect(fire(TaskItem, 'Enter')).toBe(true);
+    const outer = editor.state.doc.firstChild!;
+    expect(outer.childCount).toBe(2);
+    expect(outer.child(0).textContent).toContain('Child');
+    expect(outer.child(1).textContent).toBe('');
+  });
+  it('empty label with children does not spawn a stray empty item', () => {
+    editor = new Editor({ extensions: base, content: '<ul><li><p>Top</p><ul><li><p></p><ul><li><p>Grandchild</p></li></ul></li></ul></li></ul>' });
+    const before = countEmptyParas();
+    caretAt('', 'start');
+    fire(ListItem, 'Enter');
+    expect(countEmptyParas()).toBe(before);
+    expect(editor.getText()).toContain('Grandchild');
+  });
+});
+
+describe('Cross-type outdent preserves item type + checked state (no data loss)', () => {
+  const taskInBullet = '<ul><li><p>Parent</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>Child</p></div></li></ul></li></ul>';
+
+  it('Shift-Tab: a checked task nested in a bullet item survives as a taskList', () => {
+    editor = new Editor({ extensions: base, content: taskInBullet });
+    caretAt('Child', 'start');
+    expect(fire(TaskItem, 'Shift-Tab')).toBe(true);
+    const doc = editor.state.doc;
+    expect(doc.childCount).toBe(2);
+    expect(doc.child(1).type.name).toBe('taskList');
+    expect(doc.child(1).child(0).attrs['checked']).toBe(true);
+    expect(editor.getText()).toContain('Child');
+  });
+  it('Backspace at start: a checked task nested in a bullet item survives', () => {
+    editor = new Editor({ extensions: base, content: taskInBullet });
+    caretAt('Child', 'start');
+    expect(fire(TaskItem, 'Backspace')).toBe(true);
+    expect(editor.getHTML()).toContain('data-checked="true"');
+    expect(editor.state.doc.child(1).type.name).toBe('taskList');
+  });
+  it('Shift-Tab: a bullet item nested in a task survives as a bulletList', () => {
+    editor = new Editor({ extensions: base, content: '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><div><p>Task parent</p><ul><li><p>Bullet child</p></li></ul></div></li></ul>' });
+    caretAt('Bullet child', 'start');
+    expect(fireListKeymap('Shift-Tab')).toBe(true);
+    expect(editor.state.doc.child(1).type.name).toBe('bulletList');
+    expect(editor.getText()).toContain('Bullet child');
+  });
+  it('split case: a task in a NON-last bullet item splits the list, preserves all', () => {
+    editor = new Editor({ extensions: base, content: '<ul><li><p>First</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>Child</p></div></li></ul></li><li><p>Second</p></li></ul>' });
+    caretAt('Child', 'start');
+    expect(fire(TaskItem, 'Shift-Tab')).toBe(true);
+    const text = editor.getText();
+    expect(text).toContain('First');
+    expect(text).toContain('Second');
+    expect(text).toContain('Child');
+    expect(editor.getHTML()).toContain('data-checked="true"');
+    let hasTopTaskList = false;
+    editor.state.doc.forEach((n) => { if (n.type.name === 'taskList') hasTopTaskList = true; });
+    expect(hasTopTaskList).toBe(true);
+  });
+  it('inner wrapper with multiple items: only the target moves, all preserved, doc valid', () => {
+    editor = new Editor({ extensions: base, content: '<ul><li><p>Parent</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>A</p></div></li><li data-type="taskItem" data-checked="false"><div><p>B</p></div></li></ul></li></ul>' });
+    caretAt('A', 'start');
+    expect(fire(TaskItem, 'Shift-Tab')).toBe(true);
+    expect(docValid()).toBe(true);
+    expect(editor.getText()).toContain('A');
+    expect(editor.getText()).toContain('B');
+    expect(editor.getHTML()).toContain('data-checked="true"');
+  });
+  it('three levels deep and ordered/nested-grandparent variants stay schema-valid + checked', () => {
+    const cases = [
+      '<ul><li><p>L1</p><ul><li><p>L2</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>Deep</p></div></li></ul></li></ul></li></ul>',
+      '<ol start="3"><li><p>Num</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>Deep</p></div></li></ul></li></ol>',
+      '<ul><li><p>Outer</p><ul><li><p>Mid</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>Deep</p></div></li></ul></li></ul></li></ul>',
+    ];
+    for (const content of cases) {
+      editor?.destroy();
+      editor = new Editor({ extensions: base, content });
+      caretAt('Deep', 'start');
+      expect(fire(TaskItem, 'Shift-Tab')).toBe(true);
+      expect(docValid()).toBe(true);
+      expect(editor.getText()).toContain('Deep');
+      expect(editor.getHTML()).toContain('data-checked="true"');
+    }
+  });
+  it('regression: same-type (task in task) still outdents one level, keeps checked', () => {
+    editor = new Editor({ extensions: base, content: '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><div><p>P</p><ul data-type="taskList"><li data-type="taskItem" data-checked="true"><div><p>C</p></div></li></ul></div></li></ul>' });
+    caretAt('C', 'start');
+    expect(fire(TaskItem, 'Shift-Tab')).toBe(true);
+    const doc = editor.state.doc;
+    expect(doc.childCount).toBe(1);
+    expect(doc.child(0).type.name).toBe('taskList');
+    expect(doc.child(0).childCount).toBe(2);
+    expect(editor.getHTML()).toContain('data-checked="true"');
+  });
+});
+
+describe('setContent of a mixed <ul> drops the content-fitter placeholder item', () => {
+  it('task-first mixed ul: no leading empty bullet item; both items preserved', () => {
+    editor = new Editor({
+      extensions: base,
+      content: '<ul><li data-type="taskItem" data-checked="true"><div><p>tasktext</p></div></li><li><p>plain</p></li></ul>',
+    });
+    const first = editor.state.doc.firstChild!;
+    const firstIsEmptyPlaceholder = first.childCount === 1
+      && first.child(0).childCount === 1
+      && first.child(0).child(0).content.size === 0;
+    expect(firstIsEmptyPlaceholder).toBe(false);
+    expect(editor.getText()).toContain('tasktext');
+    expect(editor.getText()).toContain('plain');
+  });
+  it('control: a normal single-item task list is left untouched', () => {
+    editor = new Editor({
+      extensions: base,
+      content: '<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><div><p>only</p></div></li></ul>',
+    });
+    expect(editor.state.doc.firstChild!.type.name).toBe('taskList');
+    expect(editor.getText()).toContain('only');
+  });
+});

--- a/packages/core/src/utils/liftCrossTypeListItem.ts
+++ b/packages/core/src/utils/liftCrossTypeListItem.ts
@@ -1,0 +1,84 @@
+/**
+ * Outdent a list/task item that is nested inside a DIFFERENT-type parent list
+ * item (e.g. a checked `taskItem` inside a bullet `listItem`, or a bullet
+ * `listItem` inside a `taskItem`) WITHOUT dissolving it.
+ *
+ * ProseMirror's `liftListItem` can only keep an item's wrapper when the
+ * surrounding list accepts that item type. Across a type boundary the
+ * surrounding list rejects the item, so `liftListItem` falls back to
+ * `liftOutOfList`, which unwraps the item into a bare paragraph - silently
+ * dropping the marker and (for tasks) the `checked` state. This transform
+ * instead lifts the whole item, re-wrapped in a fresh list of its OWN type,
+ * out to the parent list's level (splitting that list when the containing
+ * item is not its last child), preserving the item's type and attributes.
+ *
+ * It is a no-op (returns false) for the same-type and top-level cases so the
+ * caller can fall back to the standard `liftListItem`.
+ */
+import { Selection } from '@domternal/pm/state';
+import type { EditorState, Transaction } from '@domternal/pm/state';
+
+const LIST_ITEM_TYPES = new Set(['listItem', 'taskItem']);
+
+export function liftCrossTypeListItem(
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void,
+): boolean {
+  const { $from } = state.selection;
+  if (!state.selection.empty) return false;
+
+  // Nearest enclosing list/task item.
+  let itemDepth = -1;
+  for (let d = $from.depth; d > 0; d--) {
+    if (LIST_ITEM_TYPES.has($from.node(d).type.name)) {
+      itemDepth = d;
+      break;
+    }
+  }
+  // A cross-type NESTED case needs at least doc > outerList > outerItem >
+  // innerList > item (depth 4). Shallower means a top-level item, which is
+  // `liftListItem`'s job (un-listing to a paragraph is expected there).
+  if (itemDepth < 4) return false;
+
+  const item = $from.node(itemDepth);
+  const wrapper = $from.node(itemDepth - 1); // the item's own list
+  const parentItem = $from.node(itemDepth - 2);
+  if (!LIST_ITEM_TYPES.has(parentItem.type.name)) return false; // not nested in an item
+  // Same item type: the surrounding list accepts it, so liftListItem preserves
+  // it cleanly. Only a type boundary triggers the dissolving fallback.
+  if (parentItem.type === item.type) return false;
+
+  const parentWrapper = $from.node(itemDepth - 3); // outer list (rejects item's type)
+  const grandParent = $from.node(itemDepth - 4); // doc, or an enclosing list item
+  const gpIndex = $from.index(itemDepth - 4); // parentWrapper's index in grandParent
+  // The destination must accept a list of the item's own type as a sibling.
+  if (!grandParent.canReplaceWith(gpIndex + 1, gpIndex + 1, wrapper.type)) return false;
+
+  if (!dispatch) return true;
+
+  const onlyChild = wrapper.childCount === 1;
+  const removeFrom = onlyChild ? $from.before(itemDepth - 1) : $from.before(itemDepth);
+  const removeTo = onlyChild ? $from.after(itemDepth - 1) : $from.after(itemDepth);
+  const parentIsLast = $from.index(itemDepth - 3) === parentWrapper.childCount - 1;
+
+  const tr = state.tr;
+  // Remove the item (or its now-empty wrapper) from the parent item.
+  tr.delete(removeFrom, removeTo);
+  // Re-wrap the item in a fresh list of its own type at the outer list's level.
+  const newList = wrapper.type.create(wrapper.attrs, item);
+  if (parentIsLast) {
+    // Lands right after the outer list.
+    const insertAt = tr.mapping.map($from.after(itemDepth - 3));
+    tr.insert(insertAt, newList);
+    tr.setSelection(Selection.near(tr.doc.resolve(insertAt + 2)));
+  } else {
+    // Split the outer list after the parent item so the rest stays intact,
+    // and drop the new list between the two halves.
+    const splitAt = tr.mapping.map($from.after(itemDepth - 2));
+    tr.split(splitAt, 1);
+    tr.insert(splitAt + 1, newList);
+    tr.setSelection(Selection.near(tr.doc.resolve(splitAt + 2)));
+  }
+  dispatch(tr.scrollIntoView());
+  return true;
+}

--- a/packages/theme/src/_block-colors.scss
+++ b/packages/theme/src/_block-colors.scss
@@ -35,6 +35,15 @@
     border-radius: 0.25rem;
   }
 
+  // Task items keep zero vertical padding when colored: their checkbox is
+  // absolutely positioned against the li's padding box, so growing the box
+  // would shift the label text down while the checkbox stays put (~2px
+  // misalignment). Bullet/ordered markers ride the line box and are unaffected,
+  // so this restores symmetry. The tint still reads as a band around the label.
+  li[data-type="taskItem"][data-bg-color] {
+    padding-block: 0;
+  }
+
   [data-text-color="gray"]   { color: var(--dm-block-text-gray); }
   [data-text-color="brown"]  { color: var(--dm-block-text-brown); }
   [data-text-color="orange"] { color: var(--dm-block-text-orange); }

--- a/packages/theme/src/_content.scss
+++ b/packages/theme/src/_content.scss
@@ -129,7 +129,9 @@
   // inner `<div>` instead.
   ul:not([data-type="taskList"]),
   ol {
-    li {
+    // `> li` (child, not descendant): a descendant `li` would match taskItems
+    // nested inside this list and shift them right via the rule below.
+    > li {
       margin: 0.25em 0;
 
       > p {

--- a/packages/theme/src/_content.scss
+++ b/packages/theme/src/_content.scss
@@ -105,10 +105,10 @@
   ul,
   ol {
     margin: 0.75em 0;
-    padding-left: 1.5em;
-    // Right padding so colored lists get breathing room on the right edge,
-    // matching the inline padding paragraphs and headings get above.
-    padding-right: var(--dm-block-inline-padding);
+    // Logical inline padding so the marker gutter sits on the reading-start
+    // side and mirrors under `dir="rtl"`. End padding gives colored lists
+    // breathing room on the reading-end edge, matching paragraphs/headings.
+    padding-inline: 1.5em var(--dm-block-inline-padding);
   }
 
   // A nested list chunks tightly under its parent label (the within-item gap)

--- a/packages/theme/src/_notion-mode.scss
+++ b/packages/theme/src/_notion-mode.scss
@@ -34,11 +34,6 @@
   --dm-block-handle-gutter: 0;
   --dm-block-handle-left: -3.5rem;
 
-  // The `top` checkbox tuning in `_task-list.scss` is for the default
-  // 1.6 line-height. Notion mode lifts line-height to 1.7, so nudge the
-  // checkbox down to keep it on the x-height of the first label line.
-  --dm-task-checkbox-top: 0.45em;
-
   .ProseMirror {
     min-height: 60vh;
     outline: none;

--- a/packages/theme/src/_task-list.scss
+++ b/packages/theme/src/_task-list.scss
@@ -14,7 +14,9 @@
 .dm-editor .ProseMirror {
   ul[data-type="taskList"] {
     list-style: none;
-    padding-left: 1.5em;
+    // Logical so the checkbox gutter mirrors under `dir="rtl"`, matching
+    // the bullet/ordered marker gutter in `_content.scss`.
+    padding-inline-start: 1.5em;
 
     li[data-type="taskItem"] {
       position: relative;
@@ -23,15 +25,16 @@
       > label {
         position: absolute;
         // Position is driven by tokens (defined in `_variables.scss`):
-        //  - `left` hangs the checkbox in the bullet column (paired with
-        //    the wrapper's `padding-left: 1.5em` and the checkbox's
-        //    1em width, the right edge of the checkbox sits at
-        //    `li.left - 0.25em` and text starts at `li.left`).
+        //  - `inset-inline-start` hangs the checkbox in the marker column on
+        //    the reading-start side (so it mirrors under `dir="rtl"`). Paired
+        //    with the wrapper's `padding-inline-start: 1.5em` and the
+        //    checkbox's 1em width, its reading-end edge sits ~0.25em before
+        //    the text column and text starts at the item's content edge.
         //  - `top` aligns with the first text line's x-height, so the
         //    checkbox visually rests next to lower-case glyphs the way
         //    a bullet glyph does. Override the token alongside
         //    `--dm-editor-line-height` to keep alignment.
-        left: var(--dm-task-checkbox-left, -1.15em);
+        inset-inline-start: var(--dm-task-checkbox-left, -1.15em);
         top: var(--dm-task-checkbox-top, 0.45em);
         display: flex;
         align-items: center;

--- a/packages/theme/src/_variables.scss
+++ b/packages/theme/src/_variables.scss
@@ -62,13 +62,18 @@
   // (heading, codeBlock, blockquote, etc.) render indented one level
   // below it.
   //
-  // `rem` (not `em`): we want every children-zone block to land in the
-  // SAME visual column regardless of its own font-size, so the indent
-  // stays decoupled from the child element's typography (a heading's
-  // larger font would otherwise produce a wider em-based indent than
-  // a sibling paragraph). Override per-editor for tighter/looser
-  // hierarchy.
-  --dm-block-children-indent: 1.5rem;
+  // `calc(1.5 * --dm-editor-font-size)` rather than a bare `1.5rem` or `1.5em`,
+  // to satisfy two competing constraints at once:
+  //  - it must match the marker gutter (`padding-inline-start: 1.5em` on the
+  //    list, whose `em` resolves against the editor font), so the indent
+  //    tracks `--dm-editor-font-size` instead of drifting from a fixed `rem`
+  //    when a consumer scales the editor font;
+  //  - it must stay decoupled from the CHILD block's own typography (a bare
+  //    `1.5em` on a heading note resolves against the heading's larger font
+  //    and over-indents it past a sibling paragraph note).
+  // Multiplying the editor-font token gives both. At the 1rem default this is
+  // 1.5rem (unchanged). Override per-editor for tighter/looser hierarchy.
+  --dm-block-children-indent: calc(1.5 * var(--dm-editor-font-size, 1rem));
 
   // Shared drop shadow for popover surfaces (floating menu, slash command,
   // context menu). Override in dark theme for visibility on dark bg.


### PR DESCRIPTION
## Summary

A focused audit of list behavior (bullet / ordered / task lists and how they nest) surfaced a cluster of bugs spanning editing logic, HTML parsing, and CSS layout. This PR fixes all of them. The headline issue is silent data loss when outdenting a task nested inside a different list type.

Each fix has a regression test (or, for CSS, was verified by measuring the rendered box model in headless Chromium). The full core suite passes, typecheck and lint are clean, and the public API surface is unchanged.

## Editing behavior

- **Cross-type outdent no longer destroys the item.** Shift+Tab or Backspace-at-start on a task nested inside a bullet/ordered list item used to dissolve it into a bare paragraph, silently dropping the checkbox and its checked state (and vice-versa for a bullet nested in a task). It now re-wraps the item in a fresh list of its own type at the outer level, preserving type and attributes. New `liftCrossTypeListItem` util, wired into `TaskItem` and `ListKeymap`.
- **Enter on a parent label keeps its children.** Pressing Enter at the end of a list/task label that has nested children used to move the whole sub-list into a new empty sibling. It now drops a fresh empty sibling below and leaves the children nested under the original item. Enter on an *empty* label with children no longer spawns a stray duplicate item.

## Parsing / schema

- **OrderedList `start` is validated.** A malformed `start` (e.g. `"abc"`) became `NaN`, which `getJSON()` serialized as `start: null`, so a save/reload cycle permanently corrupted the document. It now clamps to a finite integer >= 1 in parse, render, and the input rule.
- **GFM / markdown task lists import correctly.** Pasting a GitHub-style checklist used to drop to a plain bullet list (checkboxes and checked state lost). Class-scoped fallback parse rules (`li.task-list-item`, `ul.contains-task-list`) now map them to real task items, with checked state derived from the `<input>`. Scoped so ordinary bullet lists are never swallowed; internal round-trips are unchanged.
- **Mixed `<ul>` no longer fabricates an empty item.** Loading HTML that mixes a task `<li>` and a plain `<li>` in one `<ul>` produced a phantom empty bullet item (a content-fitter artifact). A narrow post-parse pass drops that exact signature.

## Theme / layout

- **List indent is consistent across editor font sizes.** Nested-list indent (`em`) and children-zone indent (fixed `rem`) drifted apart when `--dm-editor-font-size` was overridden. The children-zone indent now uses `calc(1.5 * var(--dm-editor-font-size))`, which tracks the marker gutter while staying decoupled from a child block's own font (so heading notes still align with paragraph notes). No change at the default font size.
- **Colored task items keep their checkbox aligned.** Applying a block background color added vertical padding that shifted the label text but not the absolutely-positioned checkbox. Colored task items now keep zero block padding, restoring symmetry with bullet/ordered markers.
- **List markers and checkboxes mirror in RTL.** Switched the list padding and checkbox offset from physical to logical properties (`padding-inline`, `inset-inline-start`), so markers and the children-zone indent sit consistently on the reading-start side. No-op in LTR.

## Deliberately not changed

- Decimal numbering at every depth (vs Notion's 1/a/i), backspace de-listing a root item in place, and the colored-block "pill" padding are intentional / Notion-faithful, not bugs.
- The UTF-8 BOM in the compressed stylesheet is a legitimate encoding marker for the non-ASCII glyphs it contains, so it is left in place.

## Testing

- New regression suite for the core fixes, including schema-validity (`doc.check()`) assertions and edge cases (multi-item wrappers, 3-level nesting, ordered parents, enclosing-list-item grandparents, the same-type delegation path).
- CSS fixes verified by measuring the rendered box model in headless Chromium across classic/notion modes, font sizes, and RTL.
- Full core test suite passes; typecheck, lint, and API-surface snapshot all clean.
