### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.1 (2026-06-17)
+
+### Fixes
+
+- fix(core): outdenting a list item into a list of a different kind keeps its own kind and checked state (a to-do outdented next to bullets stays a to-do), instead of taking on the surrounding list's type. (#108)
+- fix(core): pressing Enter at the end of a list item that has nested children adds a new sibling and leaves the children under the original item; Enter on an empty item with children no longer spawns a stray empty item. (#108)
+- fix(core): the ordered-list `start` attribute is clamped to a valid positive integer, so malformed markup no longer writes `NaN` / `null` into the document. (#108)
+- fix(core): GitHub-style (`contains-task-list`) markdown task lists import as real to-do lists with their checked state preserved, and a single `<ul>` that mixes to-do and plain items no longer fabricates a leading empty placeholder item. (#108)
+- fix(theme): list indentation now scales with the editor font size, a colored task item keeps its checkbox aligned with its label, and list markers / checkboxes mirror correctly in RTL; a task list nested inside a bullet or ordered list no longer inherits an extra children-zone indent. (#108)
+
 ## 0.9.0 (2026-06-15)
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ pnpm typecheck  # Run type checker
 4. Update `CHANGELOG.md` and `domternal.dev` changelog
 5. Update all 16 READMEs (root + 15 packages)
 6. (skip) Verify: `pnpm test && pnpm build && pnpm typecheck && pnpm lint`
-7. Merge to main, tag `vX.Y.Z`, push with tags
+7. Open the release PR and merge to main (manual), then tag `vX.Y.Z` on main and push with tags
 8. Publish in order: pm, core, theme, angular, react, vue, vanilla, then extensions
-9. Create GitHub release from tag with title `vX.Y.Z` and changelog entry as body
+9. Create GitHub release from tag with title `vX.Y.Z` and changelog entry as body (manual)
 
 ### Publish notes
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Block-menu UX extensions for Domternal editor - FloatingMenu, BlockHandle (hover gutter + drag), SlashCommand, ContextMenu, and keyboard reorder",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release. Ships the list / task-list behavior, parsing, and layout fixes
from #108, which landed on `main` after v0.9.0 was tagged. No API changes, so
`peerDependencies` and the `prepublishOnly` hook stay at `>=0.9.0`.

## Changes

- Bump `version` 0.9.0 → 0.9.1 across all 15 packages
- Add the 0.9.1 entry to `CHANGELOG.md`
- Docs: note in `CONTRIBUTING.md` that the release PR-merge and GitHub release steps are done manually

## Released fixes (#108)

- **core:** outdenting a list item into a list of a different kind keeps its own kind and checked state (a to-do outdented next to bullets stays a to-do)
- **core:** Enter at the end of a list item with nested children adds a sibling and keeps the children under the original item; Enter on an empty item with children no longer spawns a stray item
- **core:** the ordered-list `start` attribute is clamped to a valid positive integer (no more `NaN` / `null`)
- **core:** GFM (`contains-task-list`) markdown task lists import as real to-do lists with checked state; a mixed `<ul>` no longer fabricates a leading empty placeholder item
- **theme:** list indentation scales with the editor font size, colored task items keep their checkbox aligned, list markers / checkboxes mirror in RTL, and a task list nested in a bullet/ordered list no longer inherits an extra indent

## Verified

API-surface check passes (12 packages match snapshots) and full build passes (23 projects). The shipped fixes were already covered by unit + e2e across all four framework demos in #108.