### PR TITLE
extension-math: CI wiring, editing fixes, full e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
             ./packages/extension-details/coverage/lcov.info,
             ./packages/extension-emoji/coverage/lcov.info,
             ./packages/extension-image/coverage/lcov.info,
+            ./packages/extension-math/coverage/lcov.info,
             ./packages/extension-mention/coverage/lcov.info,
             ./packages/extension-table/coverage/lcov.info,
             ./packages/extension-toc/coverage/lcov.info
@@ -107,7 +108,7 @@ jobs:
           # fflate 0.8.x Gunzip fires its callback multiple times (last chunk
           # empty), which makes attw 0.14.0+ crash with
           # "Cannot read properties of undefined (reading 'filename')".
-          for pkg in packages/pm packages/core packages/theme packages/angular packages/react packages/vue packages/vanilla packages/extension-block-controls packages/extension-block-menu packages/extension-table packages/extension-image packages/extension-emoji packages/extension-mention packages/extension-details packages/extension-code-block-lowlight packages/extension-toc; do
+          for pkg in packages/pm packages/core packages/theme packages/angular packages/react packages/vue packages/vanilla packages/extension-block-controls packages/extension-block-menu packages/extension-table packages/extension-image packages/extension-math packages/extension-emoji packages/extension-mention packages/extension-details packages/extension-code-block-lowlight packages/extension-toc; do
             echo "--- Validating $pkg ---"
             cd "$pkg"
             pnpm exec publint --strict

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Import only what you need for full control and zero bloat. Use `StarterKit` for 
 | [`@domternal/extension-block-controls`](https://www.npmjs.com/package/@domternal/extension-block-controls) | Notion-style block UX: block handle, context menu, drag-to-reorder, keyboard reorder, slash command, smart paste (formerly `@domternal/extension-block-menu`) |
 | [`@domternal/extension-toc`](https://www.npmjs.com/package/@domternal/extension-toc) | Notion-style Table of Contents: floating outline, inline `/toc` block, `scrollToHeading` command |
 | [`@domternal/extension-table`](https://www.npmjs.com/package/@domternal/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
+| [`@domternal/extension-math`](https://www.npmjs.com/package/@domternal/extension-math) | LaTeX math: inline and block equations with a pluggable renderer (KaTeX) |
 | [`@domternal/extension-image`](https://www.npmjs.com/package/@domternal/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
 | [`@domternal/extension-emoji`](https://www.npmjs.com/package/@domternal/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
 | [`@domternal/extension-mention`](https://www.npmjs.com/package/@domternal/extension-mention) | `@mention` autocomplete with multi-trigger and async support |

--- a/apps/demo-angular/e2e/math.spec.ts
+++ b/apps/demo-angular/e2e/math.spec.ts
@@ -189,4 +189,30 @@ test.describe('Math extension', () => {
     await inline.click();
     await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
+
+  test('typing $$ inserts a block equation and opens the editor', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$$');
+
+    await expect(page.locator('app-notion-demo .dm-math-block')).toBeVisible();
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    // Finishing the equation in the popover renders it.
+    await input.fill('a^2');
+    await input.press('Enter');
+    await expect(page.locator('.dm-math-popover')).toBeHidden();
+    await expect(page.locator('app-notion-demo .dm-math-block .katex')).toBeVisible();
+  });
+
+  test('typing $x^2$ inserts an inline equation', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$x^2$');
+
+    const inline = page.locator('app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    await expect(inline.locator('.katex')).toBeVisible();
+  });
 });

--- a/apps/demo-angular/e2e/math.spec.ts
+++ b/apps/demo-angular/e2e/math.spec.ts
@@ -6,7 +6,9 @@
 import { test } from './fixtures.js';
 import { expect, type Page } from '@playwright/test';
 
-const editorSelector = '.app-notion-demo .ProseMirror';
+// `app-notion-demo` is the Angular component tag (no leading dot); the other
+// notion-* angular specs use the same selector.
+const editorSelector = 'app-notion-demo .ProseMirror';
 const modeToggleNotion = '.toolbar-mode-toggle button:has-text("Notion style")';
 
 async function goNotion(page: Page): Promise<void> {
@@ -14,6 +16,10 @@ async function goNotion(page: Page): Promise<void> {
   await page.waitForSelector(modeToggleNotion);
   await page.click(modeToggleNotion);
   await page.waitForSelector(editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
 }
 
 async function setContent(page: Page, html: string): Promise<void> {
@@ -44,6 +50,17 @@ async function insertInline(page: Page, latex: string): Promise<void> {
   }, latex);
 }
 
+async function topLevelTypes(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { state: { doc: { forEach: (f: (n: { type: { name: string } }) => void) => void } } }
+      | undefined;
+    const names: string[] = [];
+    ed?.state.doc.forEach((n) => names.push(n.type.name));
+    return names;
+  });
+}
+
 test.describe('Math extension', () => {
   test.beforeEach(async ({ page }) => {
     await goNotion(page);
@@ -52,7 +69,7 @@ test.describe('Math extension', () => {
   test('renders a block equation as KaTeX', async ({ page }) => {
     await setContent(page, '<p>x</p>');
     await insertBlock(page, 'x^2 + y^2');
-    const block = page.locator('.app-notion-demo .dm-math-block');
+    const block = page.locator('app-notion-demo .dm-math-block');
     await expect(block).toBeVisible();
     await expect(block.locator('.katex')).toBeVisible();
   });
@@ -61,7 +78,7 @@ test.describe('Math extension', () => {
     await setContent(page, '<p>before </p>');
     await insertInline(page, 'a_1');
 
-    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    const inline = page.locator('app-notion-demo .dm-math-inline');
     await expect(inline).toBeVisible();
     await expect(inline.locator('.katex')).toBeVisible();
 
@@ -91,5 +108,85 @@ test.describe('Math extension', () => {
     await page.keyboard.type('a^2');
     await expect(input).toHaveValue('a^2');
     await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
+
+  test('inserting a block equation on an empty line replaces it (no dangling paragraph)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p></p>');
+    await insertBlock(page, 'x^2');
+    await expect(page.locator('app-notion-demo .dm-math-block')).toBeVisible();
+    // The empty paragraph is replaced by the block, not left dangling beside it.
+    expect(await topLevelTypes(page)).toEqual(['mathBlock']);
+  });
+
+  test('the block equation edit popover is centered under the block', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const block = page.locator('app-notion-demo .dm-math-block');
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(block).toBeVisible();
+
+    const bb = await block.boundingBox();
+    const pb = await popover.boundingBox();
+    expect(bb).not.toBeNull();
+    expect(pb).not.toBeNull();
+    const blockCenter = bb!.x + bb!.width / 2;
+    const popCenter = pb!.x + pb!.width / 2;
+    // The popover hugs the block's center (Notion-style), not its far-left edge.
+    expect(Math.abs(blockCenter - popCenter)).toBeLessThan(16);
+  });
+
+  test('Escape on a freshly inserted empty equation removes it', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(page.locator('app-notion-demo .dm-math-block')).toHaveCount(1);
+
+    await page.locator('.dm-math-popover textarea').press('Escape');
+    await expect(popover).toBeHidden();
+    await expect(page.locator('app-notion-demo .dm-math-block')).toHaveCount(0);
+  });
+
+  test('a node-selected block equation opens the edit popover on Enter (keyboard a11y)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, 'a^2');
+    await page.locator(editorSelector).click();
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+        | { commands: { focus: (pos?: string) => boolean } }
+        | undefined;
+      ed?.commands.focus('start');
+    });
+    // Arrow down out of the paragraph to node-select the block atom, then Enter
+    // opens the same popover a click would (WCAG 2.1.1 keyboard access).
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('textarea')).toHaveValue('a^2');
+  });
+
+  test('the text bubble menu turns a selection into inline math', async ({ page }) => {
+    await setContent(page, '<p>x^2</p>');
+    await page.locator(`${editorSelector} p`).first().click({ clickCount: 3 });
+    await page.waitForSelector('.dm-bubble-menu[data-show]');
+
+    const inlineBtn = page.locator('.dm-bubble-menu button[title="Inline equation"]');
+    await expect(inlineBtn).toBeVisible();
+    await inlineBtn.click();
+
+    const inline = page.locator('app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    // The selected text became the equation source.
+    await inline.click();
+    await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
 });

--- a/apps/demo-angular/e2e/math.spec.ts
+++ b/apps/demo-angular/e2e/math.spec.ts
@@ -77,4 +77,19 @@ test.describe('Math extension', () => {
     await expect(popover).toBeHidden();
     await expect(inline.locator('.katex')).toContainText('b');
   });
+
+  test('inserting an empty equation focuses the LaTeX field, not the document', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('/inline equation');
+    await page.waitForSelector('.dm-slash-command-menu');
+    await page.keyboard.press('Enter');
+
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    await page.keyboard.type('a^2');
+    await expect(input).toHaveValue('a^2');
+    await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
 });

--- a/apps/demo-react/e2e/math.spec.ts
+++ b/apps/demo-react/e2e/math.spec.ts
@@ -14,6 +14,10 @@ async function goNotion(page: Page): Promise<void> {
   await page.waitForSelector(modeToggleNotion);
   await page.click(modeToggleNotion);
   await page.waitForSelector(editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
 }
 
 async function setContent(page: Page, html: string): Promise<void> {

--- a/apps/demo-react/e2e/math.spec.ts
+++ b/apps/demo-react/e2e/math.spec.ts
@@ -44,6 +44,17 @@ async function insertInline(page: Page, latex: string): Promise<void> {
   }, latex);
 }
 
+async function topLevelTypes(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { state: { doc: { forEach: (f: (n: { type: { name: string } }) => void) => void } } }
+      | undefined;
+    const names: string[] = [];
+    ed?.state.doc.forEach((n) => names.push(n.type.name));
+    return names;
+  });
+}
+
 test.describe('Math extension', () => {
   test.beforeEach(async ({ page }) => {
     await goNotion(page);
@@ -92,5 +103,85 @@ test.describe('Math extension', () => {
     await page.keyboard.type('a^2');
     await expect(input).toHaveValue('a^2');
     await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
+
+  test('inserting a block equation on an empty line replaces it (no dangling paragraph)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p></p>');
+    await insertBlock(page, 'x^2');
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    // The empty paragraph is replaced by the block, not left dangling beside it.
+    expect(await topLevelTypes(page)).toEqual(['mathBlock']);
+  });
+
+  test('the block equation edit popover is centered under the block', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const block = page.locator('.app-notion-demo .dm-math-block');
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(block).toBeVisible();
+
+    const bb = await block.boundingBox();
+    const pb = await popover.boundingBox();
+    expect(bb).not.toBeNull();
+    expect(pb).not.toBeNull();
+    const blockCenter = bb!.x + bb!.width / 2;
+    const popCenter = pb!.x + pb!.width / 2;
+    // The popover hugs the block's center (Notion-style), not its far-left edge.
+    expect(Math.abs(blockCenter - popCenter)).toBeLessThan(16);
+  });
+
+  test('Escape on a freshly inserted empty equation removes it', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(1);
+
+    await page.locator('.dm-math-popover textarea').press('Escape');
+    await expect(popover).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(0);
+  });
+
+  test('a node-selected block equation opens the edit popover on Enter (keyboard a11y)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, 'a^2');
+    await page.locator(editorSelector).click();
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+        | { commands: { focus: (pos?: string) => boolean } }
+        | undefined;
+      ed?.commands.focus('start');
+    });
+    // Arrow down out of the paragraph to node-select the block atom, then Enter
+    // opens the same popover a click would (WCAG 2.1.1 keyboard access).
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('textarea')).toHaveValue('a^2');
+  });
+
+  test('the text bubble menu turns a selection into inline math', async ({ page }) => {
+    await setContent(page, '<p>x^2</p>');
+    await page.locator(`${editorSelector} p`).first().click({ clickCount: 3 });
+    await page.waitForSelector('.dm-bubble-menu[data-show]');
+
+    const inlineBtn = page.locator('.dm-bubble-menu button[title="Inline equation"]');
+    await expect(inlineBtn).toBeVisible();
+    await inlineBtn.click();
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    // The selected text became the equation source.
+    await inline.click();
+    await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
 });

--- a/apps/demo-react/e2e/math.spec.ts
+++ b/apps/demo-react/e2e/math.spec.ts
@@ -184,4 +184,30 @@ test.describe('Math extension', () => {
     await inline.click();
     await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
+
+  test('typing $$ inserts a block equation and opens the editor', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$$');
+
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    // Finishing the equation in the popover renders it.
+    await input.fill('a^2');
+    await input.press('Enter');
+    await expect(page.locator('.dm-math-popover')).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block .katex')).toBeVisible();
+  });
+
+  test('typing $x^2$ inserts an inline equation', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$x^2$');
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    await expect(inline.locator('.katex')).toBeVisible();
+  });
 });

--- a/apps/demo-react/e2e/math.spec.ts
+++ b/apps/demo-react/e2e/math.spec.ts
@@ -77,4 +77,20 @@ test.describe('Math extension', () => {
     await expect(popover).toBeHidden();
     await expect(inline.locator('.katex')).toContainText('b');
   });
+
+  test('inserting an empty equation focuses the LaTeX field, not the document', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('/inline equation');
+    await page.waitForSelector('.dm-slash-command-menu');
+    await page.keyboard.press('Enter');
+
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    // Typing lands in the equation field, not back in the document.
+    await page.keyboard.type('a^2');
+    await expect(input).toHaveValue('a^2');
+    await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
 });

--- a/apps/demo-vanilla/e2e/math.spec.ts
+++ b/apps/demo-vanilla/e2e/math.spec.ts
@@ -14,6 +14,10 @@ async function goNotion(page: Page): Promise<void> {
   await page.waitForSelector(modeToggleNotion);
   await page.click(modeToggleNotion);
   await page.waitForSelector(editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
 }
 
 async function setContent(page: Page, html: string): Promise<void> {

--- a/apps/demo-vanilla/e2e/math.spec.ts
+++ b/apps/demo-vanilla/e2e/math.spec.ts
@@ -183,4 +183,30 @@ test.describe('Math extension', () => {
     await inline.click();
     await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
+
+  test('typing $$ inserts a block equation and opens the editor', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$$');
+
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    // Finishing the equation in the popover renders it.
+    await input.fill('a^2');
+    await input.press('Enter');
+    await expect(page.locator('.dm-math-popover')).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block .katex')).toBeVisible();
+  });
+
+  test('typing $x^2$ inserts an inline equation', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$x^2$');
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    await expect(inline.locator('.katex')).toBeVisible();
+  });
 });

--- a/apps/demo-vanilla/e2e/math.spec.ts
+++ b/apps/demo-vanilla/e2e/math.spec.ts
@@ -77,4 +77,19 @@ test.describe('Math extension', () => {
     await expect(popover).toBeHidden();
     await expect(inline.locator('.katex')).toContainText('b');
   });
+
+  test('inserting an empty equation focuses the LaTeX field, not the document', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('/inline equation');
+    await page.waitForSelector('.dm-slash-command-menu');
+    await page.keyboard.press('Enter');
+
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    await page.keyboard.type('a^2');
+    await expect(input).toHaveValue('a^2');
+    await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
 });

--- a/apps/demo-vanilla/e2e/math.spec.ts
+++ b/apps/demo-vanilla/e2e/math.spec.ts
@@ -44,6 +44,17 @@ async function insertInline(page: Page, latex: string): Promise<void> {
   }, latex);
 }
 
+async function topLevelTypes(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { state: { doc: { forEach: (f: (n: { type: { name: string } }) => void) => void } } }
+      | undefined;
+    const names: string[] = [];
+    ed?.state.doc.forEach((n) => names.push(n.type.name));
+    return names;
+  });
+}
+
 test.describe('Math extension', () => {
   test.beforeEach(async ({ page }) => {
     await goNotion(page);
@@ -91,5 +102,85 @@ test.describe('Math extension', () => {
     await page.keyboard.type('a^2');
     await expect(input).toHaveValue('a^2');
     await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
+
+  test('inserting a block equation on an empty line replaces it (no dangling paragraph)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p></p>');
+    await insertBlock(page, 'x^2');
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    // The empty paragraph is replaced by the block, not left dangling beside it.
+    expect(await topLevelTypes(page)).toEqual(['mathBlock']);
+  });
+
+  test('the block equation edit popover is centered under the block', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const block = page.locator('.app-notion-demo .dm-math-block');
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(block).toBeVisible();
+
+    const bb = await block.boundingBox();
+    const pb = await popover.boundingBox();
+    expect(bb).not.toBeNull();
+    expect(pb).not.toBeNull();
+    const blockCenter = bb!.x + bb!.width / 2;
+    const popCenter = pb!.x + pb!.width / 2;
+    // The popover hugs the block's center (Notion-style), not its far-left edge.
+    expect(Math.abs(blockCenter - popCenter)).toBeLessThan(16);
+  });
+
+  test('Escape on a freshly inserted empty equation removes it', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(1);
+
+    await page.locator('.dm-math-popover textarea').press('Escape');
+    await expect(popover).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(0);
+  });
+
+  test('a node-selected block equation opens the edit popover on Enter (keyboard a11y)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, 'a^2');
+    await page.locator(editorSelector).click();
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+        | { commands: { focus: (pos?: string) => boolean } }
+        | undefined;
+      ed?.commands.focus('start');
+    });
+    // Arrow down out of the paragraph to node-select the block atom, then Enter
+    // opens the same popover a click would (WCAG 2.1.1 keyboard access).
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('textarea')).toHaveValue('a^2');
+  });
+
+  test('the text bubble menu turns a selection into inline math', async ({ page }) => {
+    await setContent(page, '<p>x^2</p>');
+    await page.locator(`${editorSelector} p`).first().click({ clickCount: 3 });
+    await page.waitForSelector('.dm-bubble-menu[data-show]');
+
+    const inlineBtn = page.locator('.dm-bubble-menu button[title="Inline equation"]');
+    await expect(inlineBtn).toBeVisible();
+    await inlineBtn.click();
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    // The selected text became the equation source.
+    await inline.click();
+    await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
 });

--- a/apps/demo-vue/e2e/math.spec.ts
+++ b/apps/demo-vue/e2e/math.spec.ts
@@ -14,6 +14,10 @@ async function goNotion(page: Page): Promise<void> {
   await page.waitForSelector(modeToggleNotion);
   await page.click(modeToggleNotion);
   await page.waitForSelector(editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
 }
 
 async function setContent(page: Page, html: string): Promise<void> {

--- a/apps/demo-vue/e2e/math.spec.ts
+++ b/apps/demo-vue/e2e/math.spec.ts
@@ -183,4 +183,30 @@ test.describe('Math extension', () => {
     await inline.click();
     await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
+
+  test('typing $$ inserts a block equation and opens the editor', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$$');
+
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    // Finishing the equation in the popover renders it.
+    await input.fill('a^2');
+    await input.press('Enter');
+    await expect(page.locator('.dm-math-popover')).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block .katex')).toBeVisible();
+  });
+
+  test('typing $x^2$ inserts an inline equation', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('$x^2$');
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    await expect(inline.locator('.katex')).toBeVisible();
+  });
 });

--- a/apps/demo-vue/e2e/math.spec.ts
+++ b/apps/demo-vue/e2e/math.spec.ts
@@ -77,4 +77,19 @@ test.describe('Math extension', () => {
     await expect(popover).toBeHidden();
     await expect(inline.locator('.katex')).toContainText('b');
   });
+
+  test('inserting an empty equation focuses the LaTeX field, not the document', async ({ page }) => {
+    await setContent(page, '<p></p>');
+    await page.locator(editorSelector).click();
+    await page.keyboard.type('/inline equation');
+    await page.waitForSelector('.dm-slash-command-menu');
+    await page.keyboard.press('Enter');
+
+    const input = page.locator('.dm-math-popover textarea');
+    await expect(input).toBeFocused();
+
+    await page.keyboard.type('a^2');
+    await expect(input).toHaveValue('a^2');
+    await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
 });

--- a/apps/demo-vue/e2e/math.spec.ts
+++ b/apps/demo-vue/e2e/math.spec.ts
@@ -44,6 +44,17 @@ async function insertInline(page: Page, latex: string): Promise<void> {
   }, latex);
 }
 
+async function topLevelTypes(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { state: { doc: { forEach: (f: (n: { type: { name: string } }) => void) => void } } }
+      | undefined;
+    const names: string[] = [];
+    ed?.state.doc.forEach((n) => names.push(n.type.name));
+    return names;
+  });
+}
+
 test.describe('Math extension', () => {
   test.beforeEach(async ({ page }) => {
     await goNotion(page);
@@ -91,5 +102,85 @@ test.describe('Math extension', () => {
     await page.keyboard.type('a^2');
     await expect(input).toHaveValue('a^2');
     await expect(page.locator(editorSelector)).not.toContainText('a^2');
+  });
+
+  test('inserting a block equation on an empty line replaces it (no dangling paragraph)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p></p>');
+    await insertBlock(page, 'x^2');
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toBeVisible();
+    // The empty paragraph is replaced by the block, not left dangling beside it.
+    expect(await topLevelTypes(page)).toEqual(['mathBlock']);
+  });
+
+  test('the block equation edit popover is centered under the block', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const block = page.locator('.app-notion-demo .dm-math-block');
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(block).toBeVisible();
+
+    const bb = await block.boundingBox();
+    const pb = await popover.boundingBox();
+    expect(bb).not.toBeNull();
+    expect(pb).not.toBeNull();
+    const blockCenter = bb!.x + bb!.width / 2;
+    const popCenter = pb!.x + pb!.width / 2;
+    // The popover hugs the block's center (Notion-style), not its far-left edge.
+    expect(Math.abs(blockCenter - popCenter)).toBeLessThan(16);
+  });
+
+  test('Escape on a freshly inserted empty equation removes it', async ({ page }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, '');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(1);
+
+    await page.locator('.dm-math-popover textarea').press('Escape');
+    await expect(popover).toBeHidden();
+    await expect(page.locator('.app-notion-demo .dm-math-block')).toHaveCount(0);
+  });
+
+  test('a node-selected block equation opens the edit popover on Enter (keyboard a11y)', async ({
+    page,
+  }) => {
+    await setContent(page, '<p>x</p>');
+    await insertBlock(page, 'a^2');
+    await page.locator(editorSelector).click();
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+        | { commands: { focus: (pos?: string) => boolean } }
+        | undefined;
+      ed?.commands.focus('start');
+    });
+    // Arrow down out of the paragraph to node-select the block atom, then Enter
+    // opens the same popover a click would (WCAG 2.1.1 keyboard access).
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const popover = page.locator('.dm-math-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('textarea')).toHaveValue('a^2');
+  });
+
+  test('the text bubble menu turns a selection into inline math', async ({ page }) => {
+    await setContent(page, '<p>x^2</p>');
+    await page.locator(`${editorSelector} p`).first().click({ clickCount: 3 });
+    await page.waitForSelector('.dm-bubble-menu[data-show]');
+
+    const inlineBtn = page.locator('.dm-bubble-menu button[title="Inline equation"]');
+    await expect(inlineBtn).toBeVisible();
+    await inlineBtn.click();
+
+    const inline = page.locator('.app-notion-demo .dm-math-inline');
+    await expect(inline).toBeVisible();
+    // The selected text became the equation source.
+    await inline.click();
+    await expect(page.locator('.dm-math-popover textarea')).toHaveValue('x^2');
   });
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,6 +37,9 @@ flag_management:
     - name: extension-image
       paths:
         - packages/extension-image/src/
+    - name: extension-math
+      paths:
+        - packages/extension-math/src/
     - name: extension-mention
       paths:
         - packages/extension-mention/src/

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -20,6 +20,7 @@ import {
   defaultBubbleContexts,
   defaultIcons,
   positionFloatingOnce,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type { BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown ,
   Editor} from '@domternal/core';
@@ -759,7 +760,7 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
   onDropdownItemClick(item: ToolbarButton): void {
     this.cleanupDropdown();
     ToolbarController.executeItem(this.editor() as never, item);
-    requestAnimationFrame(() => { this.editor().view.focus(); });
+    refocusEditorAfterCommand(this.editor().view);
   }
 
   private cleanupDropdown(): void {

--- a/packages/angular/src/lib/floating-menu.component.ts
+++ b/packages/angular/src/lib/floating-menu.component.ts
@@ -18,6 +18,7 @@ import {
   FloatingMenuController,
   createFloatingMenuPlugin,
   defaultIcons,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type {
   Editor,
@@ -231,7 +232,7 @@ export class DomternalFloatingMenuComponent implements OnDestroy {
     const ctl = this.controller;
     if (!ctl) return;
     ctl.execute(item);
-    requestAnimationFrame(() => { editor.view.focus(); });
+    refocusEditorAfterCommand(editor.view);
   }
 
   onKeyDown(e: KeyboardEvent): void {

--- a/packages/angular/src/lib/toolbar.component.ts
+++ b/packages/angular/src/lib/toolbar.component.ts
@@ -17,6 +17,7 @@ import {
   ToolbarController,
   defaultIcons,
   positionFloatingOnce,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type {
   ToolbarItem,
@@ -368,7 +369,7 @@ export class DomternalToolbarComponent implements OnDestroy {
     // Always refocus editor after executing a command via toolbar button.
     // Mouse clicks already keep focus via mousedown.preventDefault();
     // keyboard activations (Enter/Space) need explicit refocus.
-    requestAnimationFrame(() => { this.editor().view.focus(); });
+    refocusEditorAfterCommand(this.editor().view);
   }
 
   onDropdownToggle(dropdown: ToolbarDropdown): void {
@@ -415,7 +416,7 @@ export class DomternalToolbarComponent implements OnDestroy {
     }
 
     // Refocus editor so ::selection highlight stays visible
-    requestAnimationFrame(() => { this.editor().view.focus(); });
+    refocusEditorAfterCommand(this.editor().view);
   }
 
   onButtonFocus(name: string): void {

--- a/packages/core/src/icons/phosphor.ts
+++ b/packages/core/src/icons/phosphor.ts
@@ -32,6 +32,9 @@ export const defaultIcons: IconSet = {
   sigma:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none" stroke="currentColor" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"><path d="M196 56H64l64 72-64 72h132"/></svg>',
 
+  radical:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none" stroke="currentColor" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"><path d="M24 150 L66 200 L118 56 L236 56 M150 98 L204 156 M204 98 L150 156"/></svg>',
+
   link:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor"><path d="M240,88.23a54.43,54.43,0,0,1-16,37L189.25,160a54.27,54.27,0,0,1-38.63,16h-.05A54.63,54.63,0,0,1,96,119.84a8,8,0,0,1,16,.45A38.62,38.62,0,0,0,150.58,160h0a38.39,38.39,0,0,0,27.31-11.31l34.75-34.75a38.63,38.63,0,0,0-54.63-54.63l-11,11A8,8,0,0,1,135.7,59l11-11A54.65,54.65,0,0,1,224,48,54.86,54.86,0,0,1,240,88.23ZM109,185.66l-11,11A38.41,38.41,0,0,1,70.6,208h0a38.63,38.63,0,0,1-27.29-65.94L78,107.31A38.63,38.63,0,0,1,144,135.71a8,8,0,0,0,16,.45A54.86,54.86,0,0,0,144,96a54.65,54.65,0,0,0-77.27,0L32,130.75A54.62,54.62,0,0,0,70.56,224h0a54.28,54.28,0,0,0,38.64-16l11-11A8,8,0,0,0,109,185.66Z"/></svg>',
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,9 @@ export { writeToClipboard } from './utils/clipboard.js';
 // === Theme cascade for portaled elements ===
 export { copyThemeClass } from './utils/copyThemeClass.js';
 
+// === Post-command editor refocus (yields to popover inputs) ===
+export { refocusEditorAfterCommand } from './utils/refocusEditorAfterCommand.js';
+
 // === Bubble menu defaults ===
 export { defaultBubbleContexts } from './utils/defaultBubbleContexts.js';
 

--- a/packages/core/src/utils/defaultBubbleContexts.ts
+++ b/packages/core/src/utils/defaultBubbleContexts.ts
@@ -2,14 +2,18 @@ import type { Editor } from '../Editor.js';
 
 const NOTION_MODE_CLASS = 'dm-notion-mode';
 
+// `mathInline` is the inline-equation button from @domternal/extension-math.
+// It is listed here so a text selection can be turned into inline math (Notion's
+// selection-context equation), and is silently skipped when the extension is not
+// loaded (the bubble menu resolves names against the editor's actual items).
 const NOTION_TEXT_CONTEXT: readonly string[] = Object.freeze([
-  'bold', 'italic', 'underline', 'strike', 'code',
+  'bold', 'italic', 'underline', 'strike', 'code', 'mathInline',
   '|', 'link',
   '|', 'textAlign',
 ]);
 
 const STANDARD_TEXT_CONTEXT: readonly string[] = Object.freeze([
-  'bold', 'italic', 'underline', 'strike', 'code',
+  'bold', 'italic', 'underline', 'strike', 'code', 'mathInline',
   '|', 'link',
 ]);
 

--- a/packages/core/src/utils/refocusEditorAfterCommand.test.ts
+++ b/packages/core/src/utils/refocusEditorAfterCommand.test.ts
@@ -73,4 +73,11 @@ describe('refocusEditorAfterCommand', () => {
     refocusEditorAfterCommand(view);
     expect(focusCount).toBe(1);
   });
+
+  it('refocuses when there is no active element', () => {
+    const spy = vi.spyOn(document, 'activeElement', 'get').mockReturnValue(null);
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+    spy.mockRestore();
+  });
 });

--- a/packages/core/src/utils/refocusEditorAfterCommand.test.ts
+++ b/packages/core/src/utils/refocusEditorAfterCommand.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { refocusEditorAfterCommand } from './refocusEditorAfterCommand.js';
+
+describe('refocusEditorAfterCommand', () => {
+  let focusCount: number;
+  let viewDom: HTMLElement;
+  let view: { dom: Element; focus: () => void };
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // Run the scheduled frame synchronously so assertions are deterministic.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      cb(0);
+      return 0;
+    });
+    focusCount = 0;
+    viewDom = document.createElement('div');
+    viewDom.setAttribute('contenteditable', 'true');
+    viewDom.tabIndex = -1;
+    document.body.appendChild(viewDom);
+    view = {
+      dom: viewDom,
+      focus: () => {
+        focusCount += 1;
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  function focusInside(html: string, selector: string): void {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    document.body.appendChild(host);
+    host.querySelector<HTMLElement>(selector)!.focus();
+  }
+
+  it('does NOT refocus when focus is in a popover surface (math popover)', () => {
+    focusInside('<div class="dm-math-popover" data-dm-editor-ui><textarea></textarea></div>', 'textarea');
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(0);
+  });
+
+  it('refocuses when a toolbar button is focused (keyboard activation)', () => {
+    focusInside('<div class="dm-toolbar" data-dm-editor-ui><button>B</button></div>', 'button');
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+  });
+
+  it('refocuses when focus is in the bubble menu', () => {
+    focusInside('<div class="dm-bubble-menu" data-dm-editor-ui><button>B</button></div>', 'button');
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+  });
+
+  it('refocuses when focus is in the floating menu', () => {
+    focusInside('<div class="dm-floating-menu" data-dm-editor-ui><button>B</button></div>', 'button');
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+  });
+
+  it('refocuses when focus is already inside the editor', () => {
+    viewDom.focus();
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+  });
+
+  it('refocuses when focus is on the body / nowhere relevant', () => {
+    // beforeEach clears the DOM, so nothing is focused (activeElement is body).
+    refocusEditorAfterCommand(view);
+    expect(focusCount).toBe(1);
+  });
+});

--- a/packages/core/src/utils/refocusEditorAfterCommand.ts
+++ b/packages/core/src/utils/refocusEditorAfterCommand.ts
@@ -1,0 +1,45 @@
+/**
+ * Return focus to the editor on the next frame after a toolbar / menu command,
+ * UNLESS the command opened a popover the user is meant to type into (e.g. the
+ * math LaTeX field, a link or image input).
+ *
+ * The post-command refocus exists so that keyboard (Enter / Space) activation of a
+ * plain command button returns the caret to the document and keeps the native
+ * `::selection` highlight. Mouse clicks already keep editor focus via the buttons'
+ * `mousedown.preventDefault()`. But some commands legitimately move focus into a
+ * popover input; for those the refocus must NOT steal it back.
+ *
+ * A focused element counts as a "popover to leave alone" when it sits inside a
+ * `[data-dm-editor-ui]` element that is NOT the toolbar, bubble-menu, or floating-
+ * menu chrome (those carry the same marker, but their commands should return focus
+ * to the document), and is not inside the editor's own contenteditable. This reuses
+ * the `data-dm-editor-ui` + `.dm-*` discriminator already used by the bubble menu
+ * and selection decoration, so it introduces no new convention.
+ *
+ * Contract for popovers that rely on this (math edit popover, link/image inputs):
+ *  (a) render OUTSIDE the contenteditable and outside `.dm-toolbar` /
+ *      `.dm-bubble-menu` / `.dm-floating-menu`;
+ *  (b) carry the `data-dm-editor-ui` attribute;
+ *  (c) focus themselves SYNCHRONOUSLY while the opening command's transaction is
+ *      dispatched, so `document.activeElement` reflects them before this frame runs.
+ */
+export function refocusEditorAfterCommand(view: { dom: Element; focus: () => void }): void {
+  requestAnimationFrame(() => {
+    const ae = document.activeElement;
+    if (!ae) {
+      view.focus();
+      return;
+    }
+    if (
+      ae.closest('[data-dm-editor-ui]') &&
+      !ae.closest('.dm-toolbar') &&
+      !ae.closest('.dm-bubble-menu') &&
+      !ae.closest('.dm-floating-menu') &&
+      !view.dom.contains(ae)
+    ) {
+      // Focus moved into a popover input; leave it there.
+      return;
+    }
+    view.focus();
+  });
+}

--- a/packages/core/src/utils/refocusEditorAfterCommand.ts
+++ b/packages/core/src/utils/refocusEditorAfterCommand.ts
@@ -1,27 +1,18 @@
 /**
  * Return focus to the editor on the next frame after a toolbar / menu command,
- * UNLESS the command opened a popover the user is meant to type into (e.g. the
- * math LaTeX field, a link or image input).
+ * UNLESS the command moved focus into a popover input the user is meant to type
+ * into (currently the math LaTeX field).
  *
- * The post-command refocus exists so that keyboard (Enter / Space) activation of a
- * plain command button returns the caret to the document and keeps the native
- * `::selection` highlight. Mouse clicks already keep editor focus via the buttons'
- * `mousedown.preventDefault()`. But some commands legitimately move focus into a
- * popover input; for those the refocus must NOT steal it back.
+ * The refocus exists so keyboard (Enter / Space) activation of a plain command
+ * button returns the caret to the document and keeps the native `::selection`
+ * highlight. Mouse clicks already keep focus via `mousedown.preventDefault()`.
  *
- * A focused element counts as a "popover to leave alone" when it sits inside a
- * `[data-dm-editor-ui]` element that is NOT the toolbar, bubble-menu, or floating-
- * menu chrome (those carry the same marker, but their commands should return focus
- * to the document), and is not inside the editor's own contenteditable. This reuses
- * the `data-dm-editor-ui` + `.dm-*` discriminator already used by the bubble menu
- * and selection decoration, so it introduces no new convention.
- *
- * Contract for popovers that rely on this (math edit popover, link/image inputs):
- *  (a) render OUTSIDE the contenteditable and outside `.dm-toolbar` /
- *      `.dm-bubble-menu` / `.dm-floating-menu`;
- *  (b) carry the `data-dm-editor-ui` attribute;
- *  (c) focus themselves SYNCHRONOUSLY while the opening command's transaction is
- *      dispatched, so `document.activeElement` reflects them before this frame runs.
+ * A focused element is treated as such a popover when it sits inside a
+ * `[data-dm-editor-ui]` element that is NOT the toolbar / bubble-menu / floating-
+ * menu chrome and is not inside the contenteditable. To opt in, a popover must
+ * render outside those surfaces, carry `data-dm-editor-ui`, and focus itself
+ * synchronously while the opening command dispatches (so `activeElement` reflects
+ * it before this frame runs).
  */
 export function refocusEditorAfterCommand(view: { dom: Element; focus: () => void }): void {
   requestAnimationFrame(() => {

--- a/packages/extension-math/src/MathBlock.ts
+++ b/packages/extension-math/src/MathBlock.ts
@@ -92,17 +92,23 @@ export const MathBlock = Node.create<MathOptions>({
           if ($from.parent.type.spec.code) return false;
           if (dispatch) {
             const node = type.create({ latex });
-            // On an empty line, replace it with the equation (Notion parity) rather
-            // than inserting after it, which would leave a dangling empty paragraph.
-            // On a non-empty line, insert the block after the current block.
+            // On an empty line, replace it with the equation (Notion parity) so no
+            // empty paragraph is left behind. Skip the replace when the container
+            // requires a leading textblock (a list item is `paragraph block*`): the
+            // schema would refit the paragraph back, so insert after it instead.
+            const depth = $from.depth;
+            const idx = depth > 0 ? $from.index(depth - 1) : 0;
             const onEmptyLine =
-              $from.depth > 0 && $from.parent.isTextblock && $from.parent.content.size === 0;
+              depth > 0 &&
+              $from.parent.isTextblock &&
+              $from.parent.content.size === 0 &&
+              $from.node(depth - 1).canReplaceWith(idx, idx + 1, type);
             let pos: number;
             if (onEmptyLine) {
-              pos = $from.before($from.depth);
-              tr.replaceWith(pos, $from.after($from.depth), node);
+              pos = $from.before(depth);
+              tr.replaceWith(pos, $from.after(depth), node);
             } else {
-              pos = $from.depth > 0 ? $from.after($from.depth) : state.selection.to;
+              pos = depth > 0 ? $from.after(depth) : state.selection.to;
               tr.insert(pos, node);
             }
             if (!latex) {

--- a/packages/extension-math/src/MathBlock.ts
+++ b/packages/extension-math/src/MathBlock.ts
@@ -7,6 +7,7 @@
 import { Node } from '@domternal/core';
 import type { CommandSpec, ToolbarItem, FloatingMenuItem } from '@domternal/core';
 import { InputRule } from '@domternal/pm/inputrules';
+import { NodeSelection } from '@domternal/pm/state';
 import type { EditorState } from '@domternal/pm/state';
 import { MATH_BLOCK_NAME } from './shared.js';
 import type { MathOptions } from './shared.js';
@@ -87,6 +88,7 @@ export const MathBlock = Node.create<MathOptions>({
         ({ state, tr, dispatch }) => {
           const type = this.nodeType;
           if (!type) return false;
+          if (state.selection.$from.parent.type.spec.code) return false;
           if (dispatch) {
             const { $from } = state.selection;
             const insertPos = $from.depth > 0 ? $from.after($from.depth) : state.selection.to;
@@ -98,6 +100,25 @@ export const MathBlock = Node.create<MathOptions>({
           }
           return true;
         },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Keyboard path to edit a selected equation (WCAG 2.1.1): when the block
+      // math atom is node-selected, Enter opens the same edit popover as a click.
+      Enter: () => {
+        const editor = this.editor;
+        const type = this.nodeType;
+        if (!editor || !type) return false;
+        const { selection } = editor.state;
+        if (!(selection instanceof NodeSelection) || selection.node.type !== type) return false;
+        const latex = (selection.node.attrs['latex'] as string | undefined) ?? '';
+        editor.view.dispatch(
+          editor.state.tr.setMeta(mathEditPluginKey, { pos: selection.from, latex, displayMode: true }),
+        );
+        return true;
+      },
     };
   },
 

--- a/packages/extension-math/src/MathBlock.ts
+++ b/packages/extension-math/src/MathBlock.ts
@@ -131,7 +131,7 @@ export const MathBlock = Node.create<MathOptions>({
         if (!editor || !type) return false;
         const { selection } = editor.state;
         if (!(selection instanceof NodeSelection) || selection.node.type !== type) return false;
-        const latex = (selection.node.attrs['latex'] as string | undefined) ?? '';
+        const latex = selection.node.attrs['latex'] as string;
         editor.view.dispatch(
           editor.state.tr.setMeta(mathEditPluginKey, { pos: selection.from, latex, displayMode: true }),
         );

--- a/packages/extension-math/src/MathBlock.ts
+++ b/packages/extension-math/src/MathBlock.ts
@@ -88,13 +88,25 @@ export const MathBlock = Node.create<MathOptions>({
         ({ state, tr, dispatch }) => {
           const type = this.nodeType;
           if (!type) return false;
-          if (state.selection.$from.parent.type.spec.code) return false;
+          const { $from } = state.selection;
+          if ($from.parent.type.spec.code) return false;
           if (dispatch) {
-            const { $from } = state.selection;
-            const insertPos = $from.depth > 0 ? $from.after($from.depth) : state.selection.to;
-            tr.insert(insertPos, type.create({ latex }));
+            const node = type.create({ latex });
+            // On an empty line, replace it with the equation (Notion parity) rather
+            // than inserting after it, which would leave a dangling empty paragraph.
+            // On a non-empty line, insert the block after the current block.
+            const onEmptyLine =
+              $from.depth > 0 && $from.parent.isTextblock && $from.parent.content.size === 0;
+            let pos: number;
+            if (onEmptyLine) {
+              pos = $from.before($from.depth);
+              tr.replaceWith(pos, $from.after($from.depth), node);
+            } else {
+              pos = $from.depth > 0 ? $from.after($from.depth) : state.selection.to;
+              tr.insert(pos, node);
+            }
             if (!latex) {
-              tr.setMeta(mathEditPluginKey, { pos: insertPos, latex: '', displayMode: true });
+              tr.setMeta(mathEditPluginKey, { pos, latex: '', displayMode: true });
             }
             dispatch(tr);
           }

--- a/packages/extension-math/src/MathEditing.ts
+++ b/packages/extension-math/src/MathEditing.ts
@@ -9,6 +9,7 @@ import { Extension, positionFloating, copyThemeClass } from '@domternal/core';
 import { Plugin, PluginKey } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
 import type { MathRenderer } from './renderer.js';
+import { MATH_INLINE_NAME, MATH_BLOCK_NAME } from './shared.js';
 
 /** Payload carried by the edit signal (a transaction meta). */
 export interface MathEditEvent {
@@ -62,6 +63,7 @@ export const MathEditing = Extension.create<MathEditingOptions>({
     let currentPos: number | null = null;
     let currentDisplayMode = false;
     let isOpen = false;
+    let openedEmpty = false;
     let cleanupFloating: (() => void) | null = null;
 
     const renderPreview = (latex: string): void => {
@@ -86,20 +88,25 @@ export const MathEditing = Extension.create<MathEditingOptions>({
       if (!isOpen) return;
       isOpen = false;
       currentPos = null;
+      openedEmpty = false;
       cleanupFloating?.();
       cleanupFloating = null;
       el.removeAttribute('data-show');
     };
 
-    const apply = (): void => {
+    const apply = (opts?: { refocus?: boolean }): void => {
       const view = currentView;
       const pos = currentPos;
       const latex = textarea.value.trim();
+      const refocus = opts?.refocus !== false;
       close();
       if (!view || pos === null) return;
-      const node = view.state.doc.nodeAt(pos);
-      if (!node) {
-        view.focus();
+      // The position can be stale after intervening edits, so confirm it still
+      // points at a math node before mutating; otherwise we would write a bogus
+      // latex attr onto, or delete, an unrelated node.
+      const node = pos <= view.state.doc.content.size ? view.state.doc.nodeAt(pos) : null;
+      if (!node || (node.type.name !== MATH_INLINE_NAME && node.type.name !== MATH_BLOCK_NAME)) {
+        if (refocus) view.focus();
         return;
       }
       if (!latex) {
@@ -107,12 +114,26 @@ export const MathEditing = Extension.create<MathEditingOptions>({
       } else if (latex !== (node.attrs['latex'] as string | undefined)) {
         view.dispatch(view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, latex }));
       }
-      view.focus();
+      if (refocus) view.focus();
     };
 
     const cancel = (): void => {
       const view = currentView;
+      const pos = currentPos;
+      const wasEmpty = openedEmpty;
       close();
+      // A freshly inserted, still-empty equation that the user cancels out of
+      // should not be left behind as a dangling "New equation" atom.
+      if (view && pos !== null && wasEmpty && pos <= view.state.doc.content.size) {
+        const node = view.state.doc.nodeAt(pos);
+        if (
+          node &&
+          (node.type.name === MATH_INLINE_NAME || node.type.name === MATH_BLOCK_NAME) &&
+          !(node.attrs['latex'] as string | undefined)?.trim()
+        ) {
+          view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
+        }
+      }
       view?.focus();
     };
 
@@ -121,6 +142,7 @@ export const MathEditing = Extension.create<MathEditingOptions>({
       if (!view) return;
       currentPos = edit.pos;
       currentDisplayMode = edit.displayMode;
+      openedEmpty = edit.latex.trim() === '';
       textarea.value = edit.latex;
       renderPreview(edit.latex);
       el.setAttribute('data-show', '');
@@ -161,8 +183,21 @@ export const MathEditing = Extension.create<MathEditingOptions>({
 
     const onClickOutside = (e: MouseEvent): void => {
       if (!isOpen) return;
-      if (el.contains(e.target as globalThis.Node)) return;
-      apply();
+      const target = e.target as globalThis.Node;
+      if (el.contains(target)) return;
+      // Only pull focus back into the editor when the click landed inside it; a
+      // click on an element outside the editor keeps its own focus.
+      const insideEditor = currentView ? currentView.dom.contains(target) : false;
+      apply({ refocus: insideEditor });
+    };
+
+    const onFocusOut = (e: FocusEvent): void => {
+      if (!isOpen) return;
+      const next = e.relatedTarget as globalThis.Node | null;
+      if (next && el.contains(next)) return; // focus stayed within the popover
+      // Focus left the popover (e.g. Tab out): apply, honoring the "blur applies"
+      // contract, without yanking focus back into the editor.
+      apply({ refocus: false });
     };
 
     let lastEdit: MathEditEvent | null = null;
@@ -182,6 +217,7 @@ export const MathEditing = Extension.create<MathEditingOptions>({
           document.body.appendChild(el);
           textarea.addEventListener('input', onInput);
           textarea.addEventListener('keydown', onKeydown);
+          el.addEventListener('focusout', onFocusOut);
           document.addEventListener('mousedown', onClickOutside);
 
           return {
@@ -199,6 +235,7 @@ export const MathEditing = Extension.create<MathEditingOptions>({
               close();
               textarea.removeEventListener('input', onInput);
               textarea.removeEventListener('keydown', onKeydown);
+              el.removeEventListener('focusout', onFocusOut);
               document.removeEventListener('mousedown', onClickOutside);
               el.remove();
               currentView = null;

--- a/packages/extension-math/src/MathEditing.ts
+++ b/packages/extension-math/src/MathEditing.ts
@@ -164,7 +164,15 @@ export const MathEditing = Extension.create<MathEditingOptions>({
         placement: 'bottom-start',
         offsetValue: 6,
       });
+      // `data-show` flips the popover from visibility:hidden to visible, but a
+      // focus() before the browser recalculates style no-ops (the field is still
+      // computed-hidden), leaving the caret in the document. Reading offsetHeight
+      // forces the style/layout flush now so the field is focusable synchronously;
+      // the wrappers' post-command refocus (refocusEditorAfterCommand) then sees
+      // focus is already in this popover and yields instead of stealing it back.
+      void el.offsetHeight;
       textarea.focus();
+      textarea.select();
     };
 
     const onInput = (): void => {

--- a/packages/extension-math/src/MathEditing.ts
+++ b/packages/extension-math/src/MathEditing.ts
@@ -166,12 +166,10 @@ export const MathEditing = Extension.create<MathEditingOptions>({
         placement: currentDisplayMode ? 'bottom' : 'bottom-start',
         offsetValue: 6,
       });
-      // `data-show` flips the popover from visibility:hidden to visible, but a
-      // focus() before the browser recalculates style no-ops (the field is still
-      // computed-hidden), leaving the caret in the document. Reading offsetHeight
-      // forces the style/layout flush now so the field is focusable synchronously;
-      // the wrappers' post-command refocus (refocusEditorAfterCommand) then sees
-      // focus is already in this popover and yields instead of stealing it back.
+      // `data-show` flips the field from visibility:hidden to visible, but focus()
+      // before a style flush no-ops (still computed-hidden). Read offsetHeight to
+      // flush layout so the synchronous focus() lands; refocusEditorAfterCommand
+      // then sees focus is already here and yields instead of stealing it back.
       void el.offsetHeight;
       textarea.focus();
       textarea.select();
@@ -236,6 +234,9 @@ export const MathEditing = Extension.create<MathEditingOptions>({
               const edit = mathEditPluginKey.getState(view.state)?.edit ?? null;
               if (edit && edit !== lastEdit) {
                 lastEdit = edit;
+                // Commit any in-flight edit before re-anchoring to a new node, so a
+                // second signal can't silently discard unsaved LaTeX.
+                if (isOpen) apply({ refocus: false });
                 openPopover(edit);
               } else if (!edit) {
                 lastEdit = null;

--- a/packages/extension-math/src/MathEditing.ts
+++ b/packages/extension-math/src/MathEditing.ts
@@ -161,7 +161,9 @@ export const MathEditing = Extension.create<MathEditingOptions>({
             };
       cleanupFloating?.();
       cleanupFloating = positionFloating(reference, el, {
-        placement: 'bottom-start',
+        // Block math renders full-width and centered, so anchor the popover to the
+        // block's center; inline math wraps its node tightly, so anchor to its start.
+        placement: currentDisplayMode ? 'bottom' : 'bottom-start',
         offsetValue: 6,
       });
       // `data-show` flips the popover from visibility:hidden to visible, but a

--- a/packages/extension-math/src/MathInline.ts
+++ b/packages/extension-math/src/MathInline.ts
@@ -119,7 +119,7 @@ export const MathInline = Node.create<MathOptions>({
         if (!editor || !type) return false;
         const { selection } = editor.state;
         if (!(selection instanceof NodeSelection) || selection.node.type !== type) return false;
-        const latex = (selection.node.attrs['latex'] as string | undefined) ?? '';
+        const latex = selection.node.attrs['latex'] as string;
         editor.view.dispatch(
           editor.state.tr.setMeta(mathEditPluginKey, { pos: selection.from, latex, displayMode: false }),
         );

--- a/packages/extension-math/src/MathInline.ts
+++ b/packages/extension-math/src/MathInline.ts
@@ -7,7 +7,7 @@
 import { Node } from '@domternal/core';
 import type { CommandSpec, ToolbarItem, FloatingMenuItem } from '@domternal/core';
 import { InputRule } from '@domternal/pm/inputrules';
-import { TextSelection } from '@domternal/pm/state';
+import { NodeSelection, TextSelection } from '@domternal/pm/state';
 import type { EditorState } from '@domternal/pm/state';
 import { MATH_INLINE_NAME } from './shared.js';
 import type { MathOptions } from './shared.js';
@@ -102,6 +102,25 @@ export const MathInline = Node.create<MathOptions>({
           }
           return true;
         },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Keyboard path to edit a selected equation (WCAG 2.1.1): when the inline
+      // math atom is node-selected, Enter opens the same edit popover as a click.
+      Enter: () => {
+        const editor = this.editor;
+        const type = this.nodeType;
+        if (!editor || !type) return false;
+        const { selection } = editor.state;
+        if (!(selection instanceof NodeSelection) || selection.node.type !== type) return false;
+        const latex = (selection.node.attrs['latex'] as string | undefined) ?? '';
+        editor.view.dispatch(
+          editor.state.tr.setMeta(mathEditPluginKey, { pos: selection.from, latex, displayMode: false }),
+        );
+        return true;
+      },
     };
   },
 

--- a/packages/extension-math/src/MathInline.ts
+++ b/packages/extension-math/src/MathInline.ts
@@ -90,12 +90,16 @@ export const MathInline = Node.create<MathOptions>({
           const type = this.nodeType;
           if (!type) return false;
           if (state.selection.$from.parent.type.spec.code) return false;
+          const sel = state.selection;
+          // Notion behavior: with text selected and no explicit latex, the
+          // selected text becomes the equation source (select "x^2" -> inline math).
+          const effectiveLatex = latex || (sel.empty ? '' : state.doc.textBetween(sel.from, sel.to, ''));
           if (dispatch) {
             if (!tr.selection.empty) tr.deleteSelection();
             const pos = tr.selection.from;
-            tr.insert(pos, type.create({ latex }));
+            tr.insert(pos, type.create({ latex: effectiveLatex }));
             tr.setSelection(TextSelection.create(tr.doc, pos + 1));
-            if (!latex) {
+            if (!effectiveLatex) {
               tr.setMeta(mathEditPluginKey, { pos, latex: '', displayMode: false });
             }
             dispatch(tr);
@@ -148,10 +152,14 @@ export const MathInline = Node.create<MathOptions>({
         type: 'button',
         name: 'mathInline',
         command: 'insertMathInline',
-        icon: 'sigma',
+        icon: 'radical',
         label: 'Inline equation',
         group: 'insert',
         priority: 45,
+        // Also surfaced as a selection action in the bubble menu (Notion-style:
+        // turn selected text into an equation); see defaultBubbleContexts. Stays
+        // in the main toolbar too, so the classic editor keeps an explicit button.
+        bubbleMenu: 'text',
       },
     ];
   },
@@ -162,7 +170,7 @@ export const MathInline = Node.create<MathOptions>({
         name: 'mathInline',
         label: 'Inline equation',
         description: 'Insert an inline LaTeX formula',
-        icon: 'sigma',
+        icon: 'radical',
         group: 'Advanced',
         priority: 80,
         keywords: ['math', 'latex', 'equation', 'formula', 'inline'],

--- a/packages/extension-math/src/bugfixes.test.ts
+++ b/packages/extension-math/src/bugfixes.test.ts
@@ -10,6 +10,7 @@ import { MathBlock } from './MathBlock.js';
 import { mathEditPluginKey } from './MathEditing.js';
 import type { MathRenderer } from './renderer.js';
 import { Document, Text, Paragraph, CodeBlock, Editor } from '@domternal/core';
+import type { ToolbarButton } from '@domternal/core';
 import { NodeSelection, TextSelection } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
 
@@ -195,6 +196,32 @@ describe('apply on focus loss', () => {
     ta.value = 'blurred';
     ta.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }));
     expect(nodeLatex(editor, 'mathInline')).toBe('blurred');
+    editor.destroy();
+  });
+});
+
+describe('inline equation as a selection action (Notion-style)', () => {
+  it('wraps the selected text as the equation source', () => {
+    const editor = mk('<p>x^2</p>');
+    editor.view.dispatch(editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.doc, 1, 4)));
+    editor.commands.insertMathInline();
+    expect(nodeLatex(editor, 'mathInline')).toBe('x^2');
+    editor.destroy();
+  });
+
+  it('keeps the radical toolbar button and is flagged for the text bubble menu; block keeps sigma', () => {
+    const editor = mk('<p></p>');
+    const buttons = editor.toolbarItems.filter((i): i is ToolbarButton => i.type === 'button');
+    const inline = buttons.find((i) => i.name === 'mathInline');
+    // Inline stays in the main toolbar (classic editor) with a distinct radical
+    // icon, and is also offered as a selection action in the text bubble menu.
+    expect(inline?.toolbar).not.toBe(false);
+    expect(inline?.bubbleMenu).toBe('text');
+    expect(inline?.icon).toBe('radical');
+    // Block equation is a separate toolbar insert button with the sigma icon.
+    const block = buttons.find((i) => i.name === 'mathBlock');
+    expect(block?.toolbar).not.toBe(false);
+    expect(block?.icon).toBe('sigma');
     editor.destroy();
   });
 });

--- a/packages/extension-math/src/bugfixes.test.ts
+++ b/packages/extension-math/src/bugfixes.test.ts
@@ -9,7 +9,7 @@ import { MathInline } from './MathInline.js';
 import { MathBlock } from './MathBlock.js';
 import { mathEditPluginKey } from './MathEditing.js';
 import type { MathRenderer } from './renderer.js';
-import { Document, Text, Paragraph, CodeBlock, Editor } from '@domternal/core';
+import { Document, Text, Paragraph, CodeBlock, BulletList, ListItem, Editor } from '@domternal/core';
 import type { ToolbarButton } from '@domternal/core';
 import { NodeSelection, TextSelection } from '@domternal/pm/state';
 import type { EditorView } from '@domternal/pm/view';
@@ -159,6 +159,7 @@ describe('keyboard edit path', () => {
     const pos = findPos(editor, 'mathBlock');
     editor.view.dispatch(editor.view.state.tr.setSelection(NodeSelection.create(editor.view.state.doc, pos)));
     expect(pressEnter(editor.view)).toBe(true);
+    expect(mathEditPluginKey.getState(editor.view.state)?.edit?.pos).toBe(pos);
     expect(mathEditPluginKey.getState(editor.view.state)?.edit?.displayMode).toBe(true);
     editor.destroy();
   });
@@ -258,6 +259,37 @@ describe('insertMathBlock replaces an empty line (no dangling paragraph)', () =>
     expect(count(editor, 'paragraph')).toBe(2);
     expect(editor.getText()).toContain('a');
     expect(editor.getText()).toContain('b');
+    editor.destroy();
+  });
+
+  it('inside a list item, inserts after the empty line (the leading paragraph is schema-required)', () => {
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        BulletList,
+        ListItem,
+        MathBlock.configure({ renderer: stub }),
+      ],
+      content: '<ul><li><p></p></li></ul>',
+    });
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(TextSelection.atStart(editor.view.state.doc)),
+    );
+    editor.commands.insertMathBlock('x^2');
+    expect(count(editor, 'mathBlock')).toBe(1);
+    // A list item is `paragraph block*`, so its leading paragraph cannot be dropped;
+    // the equation lands after it inside the same item rather than replacing it.
+    let children: string[] = [];
+    editor.view.state.doc.descendants((n) => {
+      if (n.type.name === 'listItem') {
+        children = [];
+        n.forEach((c) => children.push(c.type.name));
+      }
+    });
+    expect(children).toEqual(['paragraph', 'mathBlock']);
     editor.destroy();
   });
 });

--- a/packages/extension-math/src/bugfixes.test.ts
+++ b/packages/extension-math/src/bugfixes.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for the math bug-fix pass: read-only click guard, the
+ * insertMathBlock code-context guard, cancel-deletes-empty, the keyboard edit
+ * path (Enter on a node-selected equation), the stale-position guard in apply(),
+ * and apply-on-focusout.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { MathInline } from './MathInline.js';
+import { MathBlock } from './MathBlock.js';
+import { mathEditPluginKey } from './MathEditing.js';
+import type { MathRenderer } from './renderer.js';
+import { Document, Text, Paragraph, CodeBlock, Editor } from '@domternal/core';
+import { NodeSelection, TextSelection } from '@domternal/pm/state';
+import type { EditorView } from '@domternal/pm/view';
+
+const stub: MathRenderer = { renderToString: (latex) => `<em>${latex}</em>` };
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    globalThis.ResizeObserver = class {
+      observe(): void {
+        /* no-op stub for jsdom */
+      }
+      unobserve(): void {
+        /* no-op stub for jsdom */
+      }
+      disconnect(): void {
+        /* no-op stub for jsdom */
+      }
+    } as unknown as typeof ResizeObserver;
+  }
+  if (!('requestAnimationFrame' in globalThis)) {
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number =>
+      setTimeout(() => {
+        cb(0);
+      }, 0) as unknown as number) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number): void => {
+      clearTimeout(id);
+    }) as typeof cancelAnimationFrame;
+  }
+});
+
+function mk(content: string, editable = true): Editor {
+  return new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      Document,
+      Text,
+      Paragraph,
+      CodeBlock,
+      MathInline.configure({ renderer: stub }),
+      MathBlock.configure({ renderer: stub }),
+    ],
+    content,
+    editable,
+  });
+}
+
+function findPos(editor: Editor, typeName: string): number {
+  let pos = -1;
+  editor.view.state.doc.descendants((n, p) => {
+    if (n.type.name === typeName) pos = p;
+  });
+  return pos;
+}
+
+function count(editor: Editor, typeName: string): number {
+  let n = 0;
+  editor.view.state.doc.descendants((node) => {
+    if (node.type.name === typeName) n++;
+  });
+  return n;
+}
+
+function nodeLatex(editor: Editor, typeName: string): string | null {
+  let latex: string | null = null;
+  editor.view.state.doc.descendants((n) => {
+    if (n.type.name === typeName) latex = (n.attrs['latex'] as string | undefined) ?? null;
+  });
+  return latex;
+}
+
+function shownTextarea(): HTMLTextAreaElement {
+  const ta = document.querySelector<HTMLTextAreaElement>('.dm-math-popover[data-show] textarea');
+  expect(ta).not.toBeNull();
+  return ta!;
+}
+
+function openEdit(editor: Editor, pos: number, latex: string, displayMode = false): void {
+  editor.view.dispatch(editor.view.state.tr.setMeta(mathEditPluginKey, { pos, latex, displayMode }));
+}
+
+describe('read-only guard', () => {
+  it('does not open the edit popover when the editor is read-only', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span></p>', false);
+    const el = editor.view.dom.querySelector('.dm-math-inline')!;
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(mathEditPluginKey.getState(editor.view.state)?.edit).toBeNull();
+    editor.destroy();
+  });
+});
+
+describe('insertMathBlock code-context guard', () => {
+  it('refuses to insert block math inside a code block', () => {
+    const editor = mk('<pre><code>x = 1</code></pre>');
+    editor.view.dispatch(editor.view.state.tr.setSelection(TextSelection.atEnd(editor.view.state.doc)));
+    expect(editor.commands.insertMathBlock('a^2')).toBe(false);
+    expect(count(editor, 'mathBlock')).toBe(0);
+    editor.destroy();
+  });
+});
+
+describe('cancel removes a freshly inserted empty equation', () => {
+  it('Escape deletes a just-inserted empty inline equation', () => {
+    const editor = mk('<p>x</p>');
+    editor.commands.insertMathInline();
+    expect(count(editor, 'mathInline')).toBe(1);
+    shownTextarea().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(count(editor, 'mathInline')).toBe(0);
+    editor.destroy();
+  });
+
+  it('Escape deletes a just-inserted empty block equation', () => {
+    const editor = mk('<p>x</p>');
+    editor.commands.insertMathBlock();
+    expect(count(editor, 'mathBlock')).toBe(1);
+    shownTextarea().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(count(editor, 'mathBlock')).toBe(0);
+    editor.destroy();
+  });
+
+  it('Escape keeps an existing non-empty equation untouched', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="keep"></span></p>');
+    openEdit(editor, findPos(editor, 'mathInline'), 'keep');
+    shownTextarea().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(nodeLatex(editor, 'mathInline')).toBe('keep');
+    editor.destroy();
+  });
+});
+
+describe('keyboard edit path', () => {
+  function pressEnter(view: EditorView): boolean {
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    return view.someProp('handleKeyDown', (handler) => handler(view, event)) === true;
+  }
+
+  it('Enter opens the popover for a node-selected inline equation', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span></p>');
+    const pos = findPos(editor, 'mathInline');
+    editor.view.dispatch(editor.view.state.tr.setSelection(NodeSelection.create(editor.view.state.doc, pos)));
+    expect(pressEnter(editor.view)).toBe(true);
+    expect(mathEditPluginKey.getState(editor.view.state)?.edit?.pos).toBe(pos);
+    editor.destroy();
+  });
+
+  it('Enter opens the popover for a node-selected block equation', () => {
+    const editor = mk('<div data-type="math-block" data-latex="y"></div>');
+    const pos = findPos(editor, 'mathBlock');
+    editor.view.dispatch(editor.view.state.tr.setSelection(NodeSelection.create(editor.view.state.doc, pos)));
+    expect(pressEnter(editor.view)).toBe(true);
+    expect(mathEditPluginKey.getState(editor.view.state)?.edit?.displayMode).toBe(true);
+    editor.destroy();
+  });
+
+  it('Enter is a no-op (returns false) for a normal text selection', () => {
+    const editor = mk('<p>hello</p>');
+    editor.view.dispatch(editor.view.state.tr.setSelection(TextSelection.atEnd(editor.view.state.doc)));
+    expect(pressEnter(editor.view)).toBe(false);
+    editor.destroy();
+  });
+});
+
+describe('apply guards against a stale position', () => {
+  it('does not corrupt the document when the target node is gone', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span>b</p>');
+    const pos = findPos(editor, 'mathInline');
+    openEdit(editor, pos, 'a');
+    // Delete the math node out from under the open popover.
+    editor.view.dispatch(editor.view.state.tr.delete(pos, pos + 1));
+    expect(count(editor, 'mathInline')).toBe(0);
+    const ta = shownTextarea();
+    ta.value = 'zzz';
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(count(editor, 'mathInline')).toBe(0);
+    expect(editor.getText().includes('zzz')).toBe(false);
+    editor.destroy();
+  });
+});
+
+describe('apply on focus loss', () => {
+  it('applies the edit when focus leaves the popover', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span></p>');
+    openEdit(editor, findPos(editor, 'mathInline'), 'a');
+    const ta = shownTextarea();
+    ta.value = 'blurred';
+    ta.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }));
+    expect(nodeLatex(editor, 'mathInline')).toBe('blurred');
+    editor.destroy();
+  });
+});

--- a/packages/extension-math/src/bugfixes.test.ts
+++ b/packages/extension-math/src/bugfixes.test.ts
@@ -225,3 +225,39 @@ describe('inline equation as a selection action (Notion-style)', () => {
     editor.destroy();
   });
 });
+
+describe('insertMathBlock replaces an empty line (no dangling paragraph)', () => {
+  it('replaces an empty line with the block', () => {
+    const editor = mk('<p></p>');
+    editor.commands.insertMathBlock('x^2');
+    expect(count(editor, 'mathBlock')).toBe(1);
+    expect(count(editor, 'paragraph')).toBe(0);
+    editor.destroy();
+  });
+
+  it('inserts after a non-empty line and keeps the paragraph', () => {
+    const editor = mk('<p>abc</p>');
+    editor.commands.insertMathBlock('x^2');
+    expect(count(editor, 'mathBlock')).toBe(1);
+    expect(count(editor, 'paragraph')).toBe(1);
+    expect(editor.getText()).toContain('abc');
+    editor.destroy();
+  });
+
+  it('replaces only the empty line between content, keeping its neighbors', () => {
+    const editor = mk('<p>a</p><p></p><p>b</p>');
+    let emptyPos = -1;
+    editor.view.state.doc.descendants((n, p) => {
+      if (n.type.name === 'paragraph' && n.content.size === 0) emptyPos = p;
+    });
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.doc, emptyPos + 1)),
+    );
+    editor.commands.insertMathBlock('x^2');
+    expect(count(editor, 'mathBlock')).toBe(1);
+    expect(count(editor, 'paragraph')).toBe(2);
+    expect(editor.getText()).toContain('a');
+    expect(editor.getText()).toContain('b');
+    editor.destroy();
+  });
+});

--- a/packages/extension-math/src/bugfixes.test.ts
+++ b/packages/extension-math/src/bugfixes.test.ts
@@ -292,4 +292,70 @@ describe('insertMathBlock replaces an empty line (no dangling paragraph)', () =>
     expect(children).toEqual(['paragraph', 'mathBlock']);
     editor.destroy();
   });
+
+  it('inserts after a node-selected top-level block (depth-0 selection)', () => {
+    const editor = mk('<div data-type="math-block" data-latex="a"></div>');
+    const pos = findPos(editor, 'mathBlock');
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(NodeSelection.create(editor.view.state.doc, pos)),
+    );
+    editor.commands.insertMathBlock('b');
+    expect(count(editor, 'mathBlock')).toBe(2);
+    editor.destroy();
+  });
+});
+
+describe('popover event paths', () => {
+  it('a mousedown inside the popover does not close it', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span></p>');
+    openEdit(editor, findPos(editor, 'mathInline'), 'a');
+    const el = document.querySelector<HTMLElement>('.dm-math-popover[data-show]')!;
+    el.querySelector('textarea')!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(document.querySelector('.dm-math-popover[data-show]')).not.toBeNull();
+    expect(count(editor, 'mathInline')).toBe(1);
+    editor.destroy();
+  });
+
+  it('focusout is ignored when the popover is closed', () => {
+    const editor = mk('<p>x</p>');
+    const el = document.querySelector<HTMLElement>('.dm-math-popover')!;
+    el.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    expect(count(editor, 'mathInline')).toBe(0);
+    editor.destroy();
+  });
+
+  it('focusout within the popover does not apply the edit', () => {
+    const editor = mk('<p><span data-type="math-inline" data-latex="a"></span></p>');
+    openEdit(editor, findPos(editor, 'mathInline'), 'a');
+    const el = document.querySelector<HTMLElement>('.dm-math-popover[data-show]')!;
+    shownTextarea().value = 'zz';
+    el.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: el.querySelector('.dm-math-popover-preview'),
+      }),
+    );
+    expect(nodeLatex(editor, 'mathInline')).toBe('a');
+    editor.destroy();
+  });
+
+  it('a second edit signal commits the in-flight edit before re-anchoring', () => {
+    const editor = mk(
+      '<p><span data-type="math-inline" data-latex="a"></span><span data-type="math-inline" data-latex="b"></span></p>',
+    );
+    const positions: number[] = [];
+    editor.view.state.doc.descendants((n, p) => {
+      if (n.type.name === 'mathInline') positions.push(p);
+    });
+    openEdit(editor, positions[0]!, 'a');
+    shownTextarea().value = 'AA';
+    // A second signal arrives while the first popover is still open.
+    openEdit(editor, positions[1]!, 'b');
+    let first: string | null = null;
+    editor.view.state.doc.descendants((n, p) => {
+      if (n.type.name === 'mathInline' && p === positions[0]) first = n.attrs['latex'] as string;
+    });
+    expect(first).toBe('AA');
+    editor.destroy();
+  });
 });

--- a/packages/extension-math/src/createMathNodeView.ts
+++ b/packages/extension-math/src/createMathNodeView.ts
@@ -64,6 +64,7 @@ export function createMathNodeView(
 
     if (editKey) {
       dom.addEventListener('click', () => {
+        if (!view.editable) return;
         const pos = getPos();
         if (pos === undefined) return;
         view.dispatch(

--- a/packages/react/src/DomternalFloatingMenu.tsx
+++ b/packages/react/src/DomternalFloatingMenu.tsx
@@ -15,6 +15,7 @@ import {
   FloatingMenuController,
   createFloatingMenuPlugin,
   defaultIcons,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type {
   Editor,
@@ -165,7 +166,7 @@ export function DomternalFloatingMenu({
     if (!editor || !controllerRef.current) return;
     controllerRef.current.execute(item);
     // Return focus to the editor so selection/cursor remain where expected.
-    requestAnimationFrame(() => { editor.view.focus(); });
+    refocusEditorAfterCommand(editor.view);
   }, [editor]);
 
   const onMenuKeyDown = useCallback((e: ReactKeyboardEvent<HTMLDivElement>): void => {

--- a/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
+++ b/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { Editor, BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown } from '@domternal/core';
-import { positionFloatingOnce } from '@domternal/core';
+import { positionFloatingOnce, refocusEditorAfterCommand } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useBubbleMenu } from './useBubbleMenu.js';
 
@@ -117,7 +117,7 @@ export function DomternalBubbleMenu({
               executeSubItem={(sub) => {
                 closeDropdown();
                 executeCommand(sub);
-                requestAnimationFrame(() => { editor?.view.focus(); });
+                if (editor) refocusEditorAfterCommand(editor.view);
               }}
             />
           );

--- a/packages/react/src/toolbar/DomternalToolbar.tsx
+++ b/packages/react/src/toolbar/DomternalToolbar.tsx
@@ -6,6 +6,7 @@ import type {
   ToolbarItem,
   ToolbarLayoutEntry,
 } from '@domternal/core';
+import { refocusEditorAfterCommand } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useToolbarController } from './useToolbarController.js';
 import { useToolbarIcons, DROPDOWN_CARET } from './useToolbarIcons.js';
@@ -71,7 +72,7 @@ export function DomternalToolbar({ editor: editorProp, icons, layout }: Domterna
     // Always refocus editor after executing a command via toolbar button.
     // Mouse clicks already keep focus via mousedown.preventDefault();
     // keyboard activations (Enter/Space) need explicit refocus.
-    requestAnimationFrame(() => { editor.view.focus(); });
+    refocusEditorAfterCommand(editor.view);
   }, [editor, closeDropdown, controllerRef]);
 
   const onDropdownItemClick = useCallback((item: ToolbarButtonType, event: React.MouseEvent): void => {
@@ -92,7 +93,7 @@ export function DomternalToolbar({ editor: editorProp, icons, layout }: Domterna
     }
 
     // Refocus editor so ::selection highlight stays visible
-    requestAnimationFrame(() => { editor.view.focus(); });
+    refocusEditorAfterCommand(editor.view);
   }, [editor, closeDropdown, controllerRef]);
 
   const onButtonFocus = useCallback((name: string): void => {

--- a/packages/theme/src/_math.scss
+++ b/packages/theme/src/_math.scss
@@ -65,11 +65,11 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
     Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;
   opacity: 0;
-  // Hide: keep it visible until the opacity fade finishes (visibility flips after
-  // the 0.2s delay). Show: the [data-show] rule below flips visibility to visible
-  // immediately (no transition on it), so the focused field is actually visible -
-  // a transition on visibility would keep it computed-hidden at t=0 and make the
-  // synchronous focus() in openPopover a no-op, leaving the caret in the document.
+  // Show: the [data-show] rule below flips visibility instantly (no transition on
+  // it) so the field is focusable at t=0. A transition on visibility would keep it
+  // computed-hidden when openPopover's synchronous focus() runs, leaving the caret
+  // in the document. Hide: delay the visibility flip 0.2s so the box stays through
+  // the opacity fade.
   transition: opacity 0.2s ease, visibility 0s linear 0.2s;
   z-index: var(--dm-z-popover, 60);
 

--- a/packages/theme/src/_math.scss
+++ b/packages/theme/src/_math.scss
@@ -14,6 +14,10 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
   .dm-math {
     cursor: pointer;
     border-radius: 0.25rem;
+    // LaTeX source is inherently LTR; isolate so the text-fallback states
+    // (placeholder, no-renderer raw source, render error) stay readable in RTL.
+    direction: ltr;
+    unicode-bidi: isolate;
 
     &.dm-math-inline {
       display: inline-block;
@@ -83,6 +87,8 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
   line-height: 1.4;
   resize: vertical;
   outline: none;
+  direction: ltr;
+  unicode-bidi: isolate;
 
   &:focus {
     border-color: $accent;
@@ -96,6 +102,8 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
   background: var(--dm-surface, rgba(0, 0, 0, 0.03));
   text-align: center;
   overflow-x: auto;
+  direction: ltr;
+  unicode-bidi: isolate;
 
   &:empty::before {
     content: "Preview";

--- a/packages/theme/src/_math.scss
+++ b/packages/theme/src/_math.scss
@@ -65,12 +65,18 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
     Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   visibility: hidden;
   opacity: 0;
-  transition: opacity 0.2s ease, visibility 0.2s;
+  // Hide: keep it visible until the opacity fade finishes (visibility flips after
+  // the 0.2s delay). Show: the [data-show] rule below flips visibility to visible
+  // immediately (no transition on it), so the focused field is actually visible -
+  // a transition on visibility would keep it computed-hidden at t=0 and make the
+  // synchronous focus() in openPopover a no-op, leaving the caret in the document.
+  transition: opacity 0.2s ease, visibility 0s linear 0.2s;
   z-index: var(--dm-z-popover, 60);
 
   &[data-show] {
     visibility: visible;
     opacity: 1;
+    transition: opacity 0.2s ease;
   }
 }
 

--- a/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
@@ -3,6 +3,7 @@ import {
   createBubbleMenuPlugin,
   defaultBubbleContexts,
   positionFloatingOnce,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import { resolveIcon } from '../shared/iconRenderer.js';
 import type {
@@ -735,7 +736,7 @@ export class DomternalBubbleMenu extends EventTarget {
   #onDropdownItemClick(sub: ToolbarButton): void {
     this.closeDropdown();
     ToolbarController.executeItem(this.#editor as never, sub);
-    requestAnimationFrame(() => { this.#editor.view.focus(); });
+    refocusEditorAfterCommand(this.#editor.view);
   }
 
   // === Dropdown lifecycle ===

--- a/packages/vanilla/src/floating-menu/DomternalFloatingMenu.ts
+++ b/packages/vanilla/src/floating-menu/DomternalFloatingMenu.ts
@@ -1,4 +1,4 @@
-import { FloatingMenuController, createFloatingMenuPlugin } from '@domternal/core';
+import { FloatingMenuController, createFloatingMenuPlugin, refocusEditorAfterCommand } from '@domternal/core';
 import type {
   Editor,
   FloatingMenuItem,
@@ -293,7 +293,7 @@ export class DomternalFloatingMenu extends EventTarget {
   #onItemClick(item: FloatingMenuItem): void {
     if (this.#destroyed || !this.#controller) return;
     this.#controller.execute(item);
-    requestAnimationFrame(() => { this.#editor.view.focus(); });
+    refocusEditorAfterCommand(this.#editor.view);
   }
 
   #onKeyDown(event: KeyboardEvent): void {

--- a/packages/vanilla/src/toolbar/DomternalToolbar.ts
+++ b/packages/vanilla/src/toolbar/DomternalToolbar.ts
@@ -1,6 +1,7 @@
 import {
   ToolbarController,
   positionFloatingOnce,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type {
   Editor,
@@ -574,7 +575,7 @@ export class DomternalToolbar extends EventTarget {
 
     // Refocus editor so caret stays visible (mousedown.preventDefault holds
     // focus on mouse path; keyboard activations need explicit refocus).
-    requestAnimationFrame(() => { this.#editor.view.focus(); });
+    refocusEditorAfterCommand(this.#editor.view);
   }
 
   #onDropdownToggle(dd: ToolbarDropdown): void {
@@ -615,7 +616,7 @@ export class DomternalToolbar extends EventTarget {
       this.#controller.executeCommand(item);
     }
 
-    requestAnimationFrame(() => { this.#editor.view.focus(); });
+    refocusEditorAfterCommand(this.#editor.view);
   }
 
   #onButtonFocus(name: string): void {

--- a/packages/vanilla/tsup.config.ts
+++ b/packages/vanilla/tsup.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
   sourcemap: true,
   splitting: false,
   treeshake: true,
-  external: ['@domternal/core', '@domternal/extension-block-controls'],
+  external: ['@domternal/core'],
 });

--- a/packages/vue/src/DomternalFloatingMenu.ts
+++ b/packages/vue/src/DomternalFloatingMenu.ts
@@ -14,6 +14,7 @@ import {
   FloatingMenuController,
   createFloatingMenuPlugin,
   defaultIcons,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type {
   Editor,
@@ -157,7 +158,7 @@ export const DomternalFloatingMenu = defineComponent({
       const ed = currentEditor;
       if (!ctl || !ed) return;
       ctl.execute(item);
-      requestAnimationFrame(() => { ed.view.focus(); });
+      refocusEditorAfterCommand(ed.view);
     };
 
     const onMenuKeyDown = (e: KeyboardEvent): void => {

--- a/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/DomternalBubbleMenu.ts
@@ -3,6 +3,7 @@ import type { PropType, ShallowRef, VNode } from 'vue';
 import {
   ToolbarController,
   positionFloatingOnce,
+  refocusEditorAfterCommand,
 } from '@domternal/core';
 import type { Editor, IconSet, ToolbarButton, ToolbarDropdown, BubbleMenuOptions } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
@@ -76,7 +77,7 @@ export const DomternalBubbleMenu = defineComponent({
       const ed = editorRef.value;
       if (!ed) return;
       ToolbarController.executeItem(ed as never, sub);
-      requestAnimationFrame(() => { ed.view.focus(); });
+      refocusEditorAfterCommand(ed.view);
     };
 
     // Refs to the trailing trigger buttons so we can pass the element as anchor

--- a/packages/vue/src/toolbar/DomternalToolbar.ts
+++ b/packages/vue/src/toolbar/DomternalToolbar.ts
@@ -7,6 +7,7 @@ import type {
   ToolbarItem,
   ToolbarLayoutEntry,
 } from '@domternal/core';
+import { refocusEditorAfterCommand } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
 import { useToolbarController } from './useToolbarController.js';
 import { useToolbarIcons, DROPDOWN_CARET } from './useToolbarIcons.js';
@@ -80,7 +81,7 @@ export const DomternalToolbar = defineComponent({
       // Always refocus editor after executing a command via toolbar button.
       // Mouse clicks already keep focus via mousedown.preventDefault();
       // keyboard activations (Enter/Space) need explicit refocus.
-      requestAnimationFrame(() => { editor.view.focus(); });
+      refocusEditorAfterCommand(editor.view);
     }
 
     function onDropdownItemClick(item: ToolbarButtonType, event: MouseEvent): void {
@@ -102,7 +103,7 @@ export const DomternalToolbar = defineComponent({
       }
 
       // Refocus editor so ::selection highlight stays visible
-      requestAnimationFrame(() => { editor.view.focus(); });
+      refocusEditorAfterCommand(editor.view);
     }
 
     function onButtonFocus(name: string): void {

--- a/tests/api-surface/snapshots/core.txt
+++ b/tests/api-surface/snapshots/core.txt
@@ -227,6 +227,7 @@ positionFloatingOnce
 PositionFloatingOptions
 Range
 RawCommands
+refocusEditorAfterCommand
 resetAttributes
 selectAll
 Selection

--- a/tests/bundle-size/budget.json
+++ b/tests/bundle-size/budget.json
@@ -7,6 +7,7 @@
   "extension-details": 6000,
   "extension-emoji": 19000,
   "extension-image": 7500,
+  "extension-math": 4500,
   "extension-mention": 5500,
   "extension-table": 17000,
   "extension-toc": 9000,


### PR DESCRIPTION
## Summary
Wires `@domternal/extension-math` into CI/tooling and lands a bug-fix and UX pass
on LaTeX math editing, with full e2e coverage across all four demos.

## CI
Codecov upload + flag, publint/attw, bundle-size budget, README table, core
API-surface snapshot.

## Fixes and UX
- Read-only and stale-position guards (no popover on read-only, no corruption on apply).
- Keyboard access: Enter on a selected equation opens the editor (WCAG 2.1.1).
- Cancel-on-empty, blur/click-outside apply, RTL isolation.
- Distinct inline icon (radical) in the bubble menu; selecting text wraps it as math.
- Focus-on-insert: the LaTeX field gets focus instead of the document.
- Centered block popover; empty-line insert replaces the line (insert-after inside
  list items, where the schema keeps the paragraph).
- Popover commits an in-flight edit before re-anchoring.

## Tests
- Unit: guards, cancel, keyboard edit, blur, wrap-selection, empty-line + list-item.
- e2e: 10 math tests per demo (render, edit, focus, empty-line, centering, cancel,
  keyboard, bubble wrap, `$$` / `$...$` input rules).
- Fixes the Angular spec selector (`.app-notion-demo` class vs `<app-notion-demo>`
  tag) that had never matched.

## Verification
typecheck, lint, unit pass (core + extension-math); full e2e green on all four demos
(one contention-only ToC flake, passes in isolation).