### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1 (2026-06-30)
+
+### Fixes
+
+- fix(extension-details): the disclosure toggle stays open on click. A DOMObserver flush triggered right after the pointer click (for example moving the selection out of the details) no longer redraws the node view and discards the DOM-only open state. (#117)
+
 ## 0.11.0 (2026-06-25)
 
 ### Breaking

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-controls",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Notion-style block controls for the Domternal editor: BlockHandle (hover gutter + drag), SlashCommand, FloatingMenu, ContextMenu, keyboard reorder, and SmartPaste",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "DEPRECATED: renamed to @domternal/extension-block-controls. This package is now a thin shim that re-exports it; removed in v1.0.0.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-math",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "LaTeX math (inline + block) for Domternal editor with a pluggable renderer (KaTeX by default)",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release v0.11.1. Bumps all 17 packages 0.11.0 → 0.11.1 + changelog. No source changes; the fix already landed on main via #117.

## Changes

- fix(extension-details): the disclosure toggle stays open on click; a DOMObserver flush no longer redraws the node view and discards the open state. (#117)