### PR TITLE
docs: package-specific READMEs and a single Live examples link, plus a theme contrast fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A lightweight, extensible rich text editor toolkit built on [ProseMirror](https:
 - **~44 KB gzipped** (own code), [~117 KB total](https://domternal.dev/v1/packages) with ProseMirror - see Packages for full bundle breakdown
 - **TypeScript first** - 100% typed, zero `any`
 - **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
+- **Light and dark theme** - 160+ CSS custom properties for full visual control
 - **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
 - **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
@@ -67,7 +67,7 @@ Import only what you need for full control and zero bloat. Use `StarterKit` for 
 | Package | Description |
 |---|---|
 | [`@domternal/core`](https://www.npmjs.com/package/@domternal/core) | Editor engine with 13 nodes, 9 marks, 27 extensions, toolbar controller, and 51 built-in icons |
-| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme) | Light and dark themes with 120+ CSS custom properties |
+| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme) | Light and dark themes with 160+ CSS custom properties |
 | [`@domternal/angular`](https://www.npmjs.com/package/@domternal/angular) | 6 Angular components: editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker |
 | [`@domternal/react`](https://www.npmjs.com/package/@domternal/react) | React 18+ wrapper: composable component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views |
 | [`@domternal/vue`](https://www.npmjs.com/package/@domternal/vue) | Vue 3.3+ wrapper: composable component, composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight, extensible rich text editor toolkit built on [ProseMirror](https:
 
 **[Website](https://domternal.dev)** · **[Getting Started](https://domternal.dev/v1/getting-started)** · **[Packages & Bundle Size](https://domternal.dev/v1/packages)**
 
-**[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)** · **[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)** · **[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)** · **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)**
+**[Live examples](https://domternal.dev/examples)** - full editors for Angular, React, Vue, and Vanilla, editable in the browser
 
 ## Features
 
@@ -54,13 +54,7 @@ Import only what you need for full control and zero bloat. Use `StarterKit` for 
 
 > **[Getting Started Guide](https://domternal.dev/v1/getting-started)** - headless core, themed UI with toolbar, and Angular/React/Vue component setup
 >
-> **[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)** - full Angular example with all extensions, toolbar, and bubble menu
->
-> **[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)** - full React example with composable components, toolbar, and bubble menu
->
-> **[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)** - full Vue example with composable components, toolbar, and bubble menu
->
-> **[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)** - full vanilla example with toolbar, bubble menu, and all extensions
+> **[Live examples](https://domternal.dev/examples)** - full, editable editors for Angular, React, Vue, and Vanilla with all extensions, toolbar, and bubble menu
 
 ## Packages
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -3,42 +3,117 @@
 [![Version](https://img.shields.io/npm/v/@domternal/angular.svg)](https://www.npmjs.com/package/@domternal/angular)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Angular components for the [Domternal](https://domternal.dev) editor: six standalone,
+signals-driven, OnPush, zoneless-ready components that wrap the headless core with
+Angular-native APIs. `DomternalEditorComponent` implements `ControlValueAccessor`, so
+it drops into `ngModel` and reactive forms. The toolbar, bubble menu, floating menu,
+emoji picker, and Notion color picker auto-render from the extensions you load.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/guides/angular)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/angular @domternal/core @domternal/theme
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@angular/core` (>=17.1), `@angular/forms` (>=17.1), and `@domternal/core` (>=0.11.0)
+are peer dependencies. Add the theme to your global stylesheet:
 
-## Documentation
+```scss title="styles.scss"
+@use '@domternal/theme';
+```
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+## Usage
 
-## License
+```ts
+import { Component, signal } from '@angular/core';
+import {
+  DomternalEditorComponent,
+  DomternalToolbarComponent,
+  DomternalBubbleMenuComponent,
+} from '@domternal/angular';
+import { Editor, StarterKit, BubbleMenu } from '@domternal/core';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+@Component({
+  selector: 'app-editor',
+  imports: [
+    DomternalEditorComponent,
+    DomternalToolbarComponent,
+    DomternalBubbleMenuComponent,
+  ],
+  template: `
+    @if (editor(); as ed) {
+      <domternal-toolbar [editor]="ed" />
+    }
+    <domternal-editor
+      [extensions]="extensions"
+      [content]="content"
+      (editorCreated)="editor.set($event)"
+    />
+    @if (editor(); as ed) {
+      <domternal-bubble-menu [editor]="ed" />
+    }
+  `,
+})
+export class EditorComponent {
+  editor = signal<Editor | null>(null);
+  extensions = [StarterKit, BubbleMenu];
+  content = '<p>Hello from Angular!</p>';
+}
+```
+
+The toolbar and bubble menu render their buttons from the loaded extensions, so no
+manual button wiring is needed.
+
+### Reactive forms
+
+`DomternalEditorComponent` is a `ControlValueAccessor`, so it binds directly to
+`ngModel` or a `FormControl`. Set `outputFormat="json"` to emit JSON instead of HTML;
+calling `disable()`/`enable()` on the bound `FormControl` toggles the editor's editable
+state.
+
+```ts
+import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { DomternalEditorComponent } from '@domternal/angular';
+import { StarterKit } from '@domternal/core';
+
+@Component({
+  selector: 'app-form-editor',
+  imports: [ReactiveFormsModule, DomternalEditorComponent],
+  template: `
+    <domternal-editor [extensions]="extensions" [formControl]="editorControl" />
+  `,
+})
+export class FormEditorComponent {
+  extensions = [StarterKit];
+  editorControl = new FormControl('<p>Initial content</p>');
+}
+```
+
+## Components
+
+All components are standalone (no NgModule). Import them directly from
+`@domternal/angular`:
+
+- `DomternalEditorComponent` (`<domternal-editor>`): the editor, with reactive
+  `extensions` / `content` / `editable` / `autofocus` / `outputFormat` inputs,
+  `editorCreated` and content/selection/focus outputs, and read-only `htmlContent`,
+  `jsonContent`, `isEmpty`, `isFocused`, `isEditable` signals.
+- `DomternalToolbarComponent` (`<domternal-toolbar>`): auto-rendered formatting
+  toolbar with keyboard navigation, custom `icons`, and `layout` overrides.
+- `DomternalBubbleMenuComponent` (`<domternal-bubble-menu>`): inline selection menu
+  with `items` / `contexts` / `shouldShow` controls and content projection.
+- `DomternalFloatingMenuComponent` (`<domternal-floating-menu>`): insert menu shown
+  on empty lines.
+- `DomternalEmojiPickerComponent` (`<domternal-emoji-picker>`): searchable emoji
+  panel, driven by an `emojis: EmojiPickerItem[]` input.
+- `DomternalNotionColorPickerComponent` (`<domternal-notion-color-picker>`):
+  Notion-style text and background color palette.
+
+`DEFAULT_EXTENSIONS` (`[Document, Paragraph, Text, BaseKeymap, History]`) and the core
+`Editor` class plus `Content`, `AnyExtension`, `FocusPosition`, and `JSONContent` types
+are re-exported for convenience.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,42 +3,89 @@
 [![Version](https://img.shields.io/npm/v/@domternal/core.svg)](https://www.npmjs.com/package/@domternal/core)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+The framework-agnostic editor engine of [Domternal](https://domternal.dev), built on
+[ProseMirror](https://prosemirror.net/). It provides the headless `Editor` class, the
+extension system (`Extension`, `Node`, `Mark`), a chainable command API, and the
+built-in nodes, marks, and behaviors (paragraph, heading, lists, tasks, links,
+inline formatting, history, keymaps) bundled as `StarterKit`. Use it directly with
+vanilla JS/TS, or as the runtime under the Angular, React, Vue, and Vanilla wrappers.
+Every export is tree-shakeable, so unused extensions are stripped from your bundle.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/getting-started)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/core
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`linkedom` is an optional peer dependency: install it only if you call the SSR
+helpers (`generateHTML`, `generateJSON`, `generateText`) outside a browser.
 
-## Documentation
+```bash
+pnpm add linkedom
+```
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+## Usage
 
-## License
+```ts
+import { Editor, StarterKit } from '@domternal/core';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [StarterKit],
+  content: '<p>Hello <strong>world</strong></p>',
+  onUpdate: ({ editor }) => {
+    console.log(editor.getJSON());
+  },
+});
+
+// Chainable command API
+editor.chain().focus().toggleBold().run();
+
+// Read content
+const html = editor.getHTML();
+const json = editor.getJSON();
+
+// Tear down
+editor.destroy();
+```
+
+`StarterKit` bundles the common nodes, marks, and behaviors; each entry can be
+configured or disabled individually.
+
+```ts
+StarterKit.configure({
+  codeBlock: false,                  // disable an extension
+  heading: { levels: [1, 2, 3] },    // configure an extension
+  link: { openOnClick: false },
+});
+```
+
+To trim the bundle further, skip `StarterKit` and compose only the extensions you
+need:
+
+```ts
+import { Editor, Document, Paragraph, Text, Bold, History } from '@domternal/core';
+
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [Document, Paragraph, Text, Bold, History],
+});
+```
+
+## SSR
+
+The `generateHTML`, `generateJSON`, and `generateText` helpers render content
+without an editor instance, for example on the server.
+
+```ts
+import { generateHTML, StarterKit } from '@domternal/core';
+
+const html = generateHTML(
+  { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hi' }] }] },
+  [StarterKit],
+);
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-block-controls/README.md
+++ b/packages/extension-block-controls/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-block-controls/README.md
+++ b/packages/extension-block-controls/README.md
@@ -3,42 +3,76 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-block-controls.svg)](https://www.npmjs.com/package/@domternal/extension-block-controls)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Notion-style block controls for the [Domternal](https://domternal.dev) editor. Ships
+six coordinated extensions: `BlockHandle` (hover gutter with a drag handle and `+`
+button), `BlockContextMenu` (Delete / Duplicate / Turn into), `SlashCommand` (type `/`
+for a filtered insert popup), `SmartPaste` (preserves block formatting when pasting at
+inline positions), `KeyboardReorder` (`Mod-Shift-ArrowUp/Down` moves the current block),
+and `FloatingMenu` (the empty-line insert menu). They cooperate through DOM events, so
+opening one overlay closes the others.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/extensions/block-controls)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-block-controls
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies and are pulled in by any
+Domternal editor setup.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+Add the extensions you want to your editor's extension list. Most apps use the full set
+together for the Notion experience:
 
-## License
+```ts
+import { Editor, StarterKit } from '@domternal/core';
+import {
+  BlockHandle,
+  BlockContextMenu,
+  SlashCommand,
+  SmartPaste,
+  KeyboardReorder,
+  FloatingMenu,
+} from '@domternal/extension-block-controls';
+import '@domternal/theme';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit,
+    BlockHandle.configure({ nested: true }),
+    BlockContextMenu,
+    SlashCommand,
+    SmartPaste,
+    KeyboardReorder,
+    FloatingMenu.configure({
+      element: document.getElementById('floating-menu')!,
+      requireExplicitTrigger: true,
+    }),
+  ],
+});
+```
+
+The `SlashCommand` and `FloatingMenu` popups draw their items from
+`editor.floatingMenuItems` (collected from every extension's `addFloatingMenuItems()`
+hook), so installed extensions register their own insert actions automatically.
+
+## Extensions
+
+- **`BlockHandle`** - hover gutter with a drag handle (click to open the context menu,
+  drag to reorder with a nesting-aware drop indicator) and a `+` button that inserts an
+  empty paragraph and opens the `FloatingMenu`.
+- **`BlockContextMenu`** - Delete / Duplicate / Turn into actions, opened from the drag
+  handle.
+- **`SlashCommand`** - typing `/` opens a filtered, ranked popup of insertable blocks;
+  selecting one replaces the `/query` range and runs the item's command.
+- **`SmartPaste`** - keeps block-level formatting intact when pasting at an inline cursor.
+- **`KeyboardReorder`** - `Mod-Shift-ArrowUp` / `Mod-Shift-ArrowDown` move the current
+  top-level block.
+- **`FloatingMenu`** - the empty-line insert menu; `requireExplicitTrigger` gates it
+  behind the `+` button for Notion mode.

--- a/packages/extension-block-menu/README.md
+++ b/packages/extension-block-menu/README.md
@@ -16,4 +16,8 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-block-menu.svg)](https://www.npmjs.com/package/@domternal/extension-block-menu)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
+## Links
+
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/extensions/block-controls)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
+
 See [`@domternal/extension-block-controls`](https://www.npmjs.com/package/@domternal/extension-block-controls) for the full documentation and API.

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -3,42 +3,93 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-code-block-lowlight.svg)](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Syntax highlighting for the [Domternal](https://domternal.dev) editor's code blocks,
+powered by [lowlight](https://github.com/wooorm/lowlight) (a lightweight highlight.js
+wrapper, 190+ languages). `CodeBlockLowlight` extends the core `CodeBlock` node with
+language auto-detection, Tab/Shift-Tab indentation, and incremental re-highlighting that
+only updates the blocks affected by an edit. It inherits every command, shortcut, toolbar
+item, and input rule from `CodeBlock`, so it is a drop-in replacement. Server-side and
+inline-style highlighting helpers (`generateHighlightedHTML`, `createCodeHighlighter`) are
+included for SSR and email rendering.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/extensions/code-block-lowlight)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-code-block-lowlight lowlight
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`lowlight` is a peer dependency (alongside `@domternal/core` and `@domternal/pm`). Install
+it yourself and pass a configured instance via the required `lowlight` option.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { Editor, Document, Paragraph, Text } from '@domternal/core';
+import { CodeBlockLowlight } from '@domternal/extension-code-block-lowlight';
+import { createLowlight, common } from 'lowlight';
 
-## License
+const lowlight = createLowlight(common); // ~40 common languages; use `all` for ~190
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    Document,
+    Paragraph,
+    Text,
+    CodeBlockLowlight.configure({
+      lowlight,
+      defaultLanguage: 'javascript',
+      autoDetect: true,
+      tabIndentation: true,
+      tabSize: 2,
+    }),
+  ],
+});
+
+// Inherited from CodeBlock
+editor.commands.toggleCodeBlock({ language: 'typescript' });
+
+// Languages registered on the lowlight instance.
+// Storage is keyed by the inherited `codeBlock` name, not `codeBlockLowlight`.
+editor.storage.codeBlock.listLanguages();
+```
+
+> `CodeBlockLowlight` **replaces** the built-in `CodeBlock`. Do not register both. With
+> `StarterKit`, disable the core code block: `StarterKit.configure({ codeBlock: false })`.
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `lowlight` | `Lowlight` | `null` (required) | The instance from `createLowlight()`. Throws at init if missing. |
+| `defaultLanguage` | `string \| null` | `null` | Language used when a block has none set. |
+| `autoDetect` | `boolean` | `true` | Detect the language via `highlightAuto()` when none is set. |
+| `tabIndentation` | `boolean` | `true` | Tab inserts spaces inside code blocks; Shift-Tab outdents. |
+| `tabSize` | `number` | `2` | Number of spaces per tab. |
+
+## Server-side highlighting
+
+`generateHighlightedHTML` renders JSON content to HTML with highlighted code blocks, and
+`createCodeHighlighter` produces a `codeHighlighter` callback for `inlineStyles()` (email,
+CMS, and Google Docs output):
+
+```ts
+import {
+  generateHighlightedHTML,
+  createCodeHighlighter,
+} from '@domternal/extension-code-block-lowlight';
+import { inlineStyles } from '@domternal/core';
+import { createLowlight, common } from 'lowlight';
+
+const lowlight = createLowlight(common);
+
+const html = generateHighlightedHTML(json, extensions, lowlight);
+
+const styled = inlineStyles(plainHtml, {
+  codeHighlighter: createCodeHighlighter(lowlight),
+});
+```

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -3,42 +3,62 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-details.svg)](https://www.npmjs.com/package/@domternal/extension-details)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Collapsible accordion blocks for the [Domternal](https://domternal.dev) editor,
+built on semantic `<details>` / `<summary>` HTML. Each block has a clickable
+summary header and an expandable content area that holds any block-level content
+(paragraphs, lists, code blocks, tables, and more). The toggle is an accessible
+disclosure (`aria-expanded` / `aria-controls`), and open state can optionally be
+persisted into the document so the serialized JSON/HTML reflects user choices.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/details)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-details
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+The `Details` extension automatically pulls in its child nodes (`DetailsSummary`
+and `DetailsContent`), so adding `Details` to your extension list is enough.
 
-## License
+```ts
+import { Editor, Document, Text, Paragraph } from '@domternal/core';
+import { Details } from '@domternal/extension-details';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  extensions: [
+    Document,
+    Text,
+    Paragraph,
+    Details.configure({ persist: true }),
+  ],
+  content:
+    '<details><summary>Click to expand</summary><div data-details-content><p>Hidden content here.</p></div></details>',
+});
+
+// Wrap the current selection in a collapsible block, then open it
+editor.chain().focus().setDetails().openDetails().run();
+```
+
+## Commands
+
+- `setDetails()` - wrap the selected block(s) in a new details accordion
+- `unsetDetails()` - unwrap the surrounding details back into plain blocks
+- `toggleDetails()` - wrap if outside a details, unwrap if inside one
+- `openDetails()` / `closeDetails()` - expand or collapse the current details
+- `setDetailsOpen(open: boolean)` - set the open state explicitly
+
+## Options
+
+`Details.configure({ ... })` accepts:
+
+- `persist` (default `false`) - when `true`, the `open` attribute is saved and
+  restored so the open/closed state lives in the document
+- `openClassName` (default `'is-open'`) - CSS class applied while a block is open
+- `HTMLAttributes` - extra attributes for the rendered element

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -3,42 +3,68 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-emoji.svg)](https://www.npmjs.com/package/@domternal/extension-emoji)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Inline emoji for the [Domternal](https://domternal.dev) editor. Adds an atom
+`emoji` node with `:shortcode:` input rules, optional emoticon shortcuts (`:)`,
+`<3`), and a **headless** suggestion plugin that powers autocomplete dropdowns on
+a `:` trigger. Ships a curated ~200-emoji dataset (`emojis`) plus the full
+Unicode set (`allEmojis`), built-in frequency tracking, and a framework-free
+vanilla DOM renderer. No external suggestion library required.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/emoji)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-emoji
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies (installed with the
+editor itself).
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { Editor, Document, Text, Paragraph } from '@domternal/core';
+import { Emoji, emojis, createEmojiSuggestionRenderer } from '@domternal/extension-emoji';
 
-## License
+const editor = new Editor({
+  extensions: [
+    Document,
+    Text,
+    Paragraph,
+    Emoji.configure({
+      emojis,
+      enableEmoticons: true,
+      suggestion: { render: createEmojiSuggestionRenderer() },
+    }),
+  ],
+  content: '<p>Type :smile: or :) to insert an emoji.</p>',
+});
+```
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+Typing `:smile:` converts to an emoji node; with `enableEmoticons: true`,
+emoticons like `:)` and `<3` convert too. Typing `:` followed by a name opens the
+suggestion dropdown (when a `render` factory is provided).
+
+## Commands
+
+```ts
+editor.commands.insertEmoji('fire'); // insert by name
+editor.commands.suggestEmoji();        // type the trigger char to open the picker
+```
+
+## Options
+
+- `emojis` - dataset to use. Defaults to the built-in ~200 popular emoji; pass
+  `allEmojis` for the full Unicode set, or your own `EmojiItem[]`.
+- `enableEmoticons` - convert text emoticons like `:)` and `<3`. Default `false`.
+- `plainText` - insert the raw emoji character instead of an atom node. Default `false`.
+- `suggestion` - `SuggestionOptions` for the autocomplete picker, or `null` to disable. Default `null`.
+- `toolbar` - show the emoji button in the toolbar. Default `true`.
+- `HTMLAttributes` - attributes applied to the rendered emoji `span`.
+
+For a custom picker, drive the headless plugin directly with `createSuggestionPlugin`
+and read its state via `emojiSuggestionPluginKey`. The `Emoji` storage also exposes
+`searchEmoji`, `findEmoji`, `getFrequentlyUsed`, and `addFrequentlyUsed`.

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -3,42 +3,75 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-image.svg)](https://www.npmjs.com/package/@domternal/extension-image)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+An image node for the [Domternal](https://domternal.dev) editor: corner-handle
+resizing, float/text-wrapping controls (`left`, `center`, `right`), paste and
+drag-and-drop file upload through your own `uploadHandler`, a markdown
+`![alt](src "title")` input rule, and defense-in-depth XSS validation on `src`
+(blocks `javascript:`, `vbscript:`, `file:`, and non-image `data:` URLs across
+parse, render, command, and input-rule layers). Block-level by default, optional
+`inline` mode.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/image)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-image
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies (you already have
+them if you are building a Domternal editor).
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { Editor, Document, Paragraph, Text } from '@domternal/core';
+import { Image } from '@domternal/extension-image';
 
-## License
+const editor = new Editor({
+  extensions: [
+    Document,
+    Paragraph,
+    Text,
+    Image.configure({
+      // Optional: enables paste/drop upload. Return the stored URL.
+      uploadHandler: async (file) => {
+        const form = new FormData();
+        form.append('file', file);
+        const res = await fetch('/api/upload', { method: 'POST', body: form });
+        const { url } = (await res.json()) as { url: string };
+        return url;
+      },
+    }),
+  ],
+});
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+// Insert an image
+editor.commands.setImage({ src: 'https://example.com/photo.jpg', alt: 'A photo' });
+
+// Wrap text around it
+editor.commands.setImageFloat('left');
+
+// Remove the selected image
+editor.commands.deleteImage();
+```
+
+## Options
+
+`Image.configure({ ... })` accepts:
+
+- `inline` (`boolean`, default `false`) - render images inline within paragraphs instead of as block nodes.
+- `allowBase64` (`boolean`, default `true`) - permit `data:image/` URLs; when `false`, only non-data sources are allowed.
+- `uploadHandler` (`(file: File) => Promise<string>` or `null`, default `null`) - when set, enables image upload on paste and drop.
+- `allowedMimeTypes` (`string[]`) - MIME types accepted for upload (defaults to common image types).
+- `maxFileSize` (`number`, default `0`) - max upload size in bytes; `0` means unlimited.
+- `onUploadStart` / `onUploadError` - callbacks fired when an upload begins or fails.
+- `HTMLAttributes` (`Record<string, unknown>`) - attributes merged onto the rendered `<img>`.
+
+## Commands
+
+- `setImage(attributes: SetImageOptions)` - insert an image (`src` required; optional `alt`, `title`, `width`, `height`, `loading`, `crossorigin`, `float`).
+- `setImageFloat(float: ImageFloat)` - set wrapping on the selected image (`'none' | 'left' | 'right' | 'center'`).
+- `deleteImage()` - delete the selected image.

--- a/packages/extension-math/README.md
+++ b/packages/extension-math/README.md
@@ -8,6 +8,10 @@ block (`$$`) equation nodes. The rendering engine is **pluggable** and supplied 
 you, so the package itself stays light and you ship only the engine you choose.
 [KaTeX](https://katex.org/) is the recommended default.
 
+## Links
+
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/math)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
+
 ## Install
 
 ```bash

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -3,42 +3,92 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-mention.svg)](https://www.npmjs.com/package/@domternal/extension-mention)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Inline `@`-mention nodes for the [Domternal](https://domternal.dev) editor. Adds an
+atomic `mention` node that carries an `id` and `label`, plus a headless suggestion
+plugin that watches one or more trigger characters (`@`, `#`, ...), tracks the query,
+and fetches matching items from your own data source (sync or async). You supply the
+data and, optionally, the dropdown UI; a framework-free default renderer is included.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/mention)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-mention
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies (you already have them
+when using the editor).
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { Editor, Document, Paragraph, Text } from '@domternal/core';
+import { Mention, createMentionSuggestionRenderer } from '@domternal/extension-mention';
 
-## License
+const users = [
+  { id: '1', label: 'Alice Johnson' },
+  { id: '2', label: 'Bob Smith' },
+  { id: '3', label: 'Charlie Brown' },
+];
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  extensions: [
+    Document,
+    Paragraph,
+    Text,
+    Mention.configure({
+      suggestion: {
+        char: '@',
+        name: 'user',
+        items: ({ query }) =>
+          users.filter((u) =>
+            u.label.toLowerCase().includes(query.toLowerCase()),
+          ),
+        render: createMentionSuggestionRenderer(),
+      },
+    }),
+  ],
+  content: '<p>Type @ to mention someone!</p>',
+});
+```
+
+Type `@` to open the dropdown, navigate with arrow keys, and press `Enter` to insert.
+`items` may also return a `Promise`, so suggestions can come from a remote API; pair
+that with `debounce` on the trigger to rate-limit calls.
+
+## Commands
+
+The extension registers two chainable commands:
+
+```ts
+// Insert a mention at the current selection
+editor.commands.insertMention({ id: '1', label: 'Alice', type: 'user' });
+
+// Delete by id, or the mention immediately before the cursor when no id is passed
+editor.commands.deleteMention('1');
+editor.commands.deleteMention();
+```
+
+It also exposes `editor.storage.mention.findMentions()`, which returns every mention
+in the document as `{ id, label, type, pos }`.
+
+## Multiple triggers
+
+Pass a `triggers` array to mix, for example, `@` users and `#` tags. Each trigger has
+its own `name`, `items` source, and renderer:
+
+```ts
+Mention.configure({
+  triggers: [
+    { char: '@', name: 'user', items: fetchUsers, render: createMentionSuggestionRenderer() },
+    { char: '#', name: 'tag', items: fetchTags, render: createMentionSuggestionRenderer() },
+  ],
+});
+```
+
+For full options (`minQueryLength`, `allowSpaces`, `appendText`, `invalidNodes`,
+`shouldShow`, custom `renderHTML`/`renderText`) and framework wrapper examples, see the
+[documentation](https://domternal.dev/v1/nodes/mention).

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -3,42 +3,71 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-table.svg)](https://www.npmjs.com/package/@domternal/extension-table)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Full-featured tables for the [Domternal](https://domternal.dev) editor, built on
+`prosemirror-tables`. Provides the `Table`, `TableRow`, `TableCell`, and
+`TableHeader` nodes with cell merge/split, three column-resize modes, header
+row/column toggles, cell selection, and `Tab`/arrow keyboard navigation. The
+built-in `TableView` adds row/column handles, a cell toolbar, and drag-to-resize,
+or you can disable it (`View: null`) and drive everything through commands. All
+free, no paid tier.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/nodes/table)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-table
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies and are already
+present in any Domternal editor setup.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+Add the `Table` extension to your editor. It pulls in `TableRow`, `TableCell`,
+`TableHeader`, and `Gapcursor` automatically, so a single import is enough.
 
-## License
+```ts
+import { Editor, Document, Paragraph, Text } from '@domternal/core';
+import { Table } from '@domternal/extension-table';
+import '@domternal/theme';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const editor = new Editor({
+  extensions: [Document, Paragraph, Text, Table],
+});
+
+// Insert a 3x3 table with a header row, then add a row and merge selected cells.
+editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+editor.commands.addRowAfter();
+editor.commands.mergeCells();
+```
+
+Configure resize and rendering behavior through `Table.configure`:
+
+```ts
+Table.configure({
+  resizeBehavior: 'neighbor', // 'neighbor' | 'independent' | 'redistribute'
+  constrainToContainer: true,
+  cellMinWidth: 25,
+  defaultCellMinWidth: 100,
+  View: null, // disable the built-in TableView and use your own UI
+});
+```
+
+## Commands
+
+Registered on the editor when the extension is active:
+
+- `insertTable({ rows?, cols?, withHeaderRow? })`, `deleteTable`
+- `addRowBefore`, `addRowAfter`, `deleteRow`
+- `addColumnBefore`, `addColumnAfter`, `deleteColumn`
+- `toggleHeaderRow`, `toggleHeaderColumn`, `toggleHeaderCell`
+- `mergeCells`, `splitCell`
+- `setCellAttribute(name, value)`, `setCellSelection({ anchorCell, headCell? })`
+- `goToNextCell`, `goToPreviousCell`, `fixTables`
+
+The package also exports the `TableView` node view, the `createTable` and
+`deleteTableWhenAllCellsSelected` helpers, and re-exports `CellSelection` and
+`TableMap` from `prosemirror-tables`.

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/extension-toc/README.md
+++ b/packages/extension-toc/README.md
@@ -3,42 +3,79 @@
 [![Version](https://img.shields.io/npm/v/@domternal/extension-toc.svg)](https://www.npmjs.com/package/@domternal/extension-toc)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Notion-style Table of Contents for the [Domternal](https://domternal.dev) editor.
+A shared heading-discovery data layer feeds three pieces that work together:
+`TableOfContents` (the headless heading observer that maintains a reactive
+heading list in `editor.storage.toc` and exposes the `scrollToHeading` command),
+`FloatingTocOutline` (a sticky right-rail outline with a hover-expanded card,
+anchored to the editor or the viewport), and `TableOfContentsBlock` (an inline
+`/toc` atom node). Active-heading tracking, smooth click-to-jump scrolling, and
+initial-load `#hash` navigation are built in.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/extensions/table-of-contents)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/extension-toc
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` and `@domternal/pm` are peer dependencies. `TableOfContents`
+also requires the `UniqueID` extension (from `@domternal/core`) to be loaded: it
+reads UniqueID's `id` attribute on headings as the navigation anchor and stays
+inert without it.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { Editor, StarterKit, UniqueID } from '@domternal/core';
+import {
+  TableOfContents,
+  FloatingTocOutline,
+  TableOfContentsBlock,
+} from '@domternal/extension-toc';
+import '@domternal/theme';
 
-## License
+const editor = new Editor({
+  element: document.getElementById('editor')!,
+  extensions: [
+    StarterKit,
+    UniqueID.configure({ types: ['heading'] }),
+    TableOfContents.configure({ levels: [1, 2, 3] }),
+    FloatingTocOutline.configure({ anchor: 'editor' }),
+    TableOfContentsBlock,
+  ],
+});
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+// Jump to a heading by its UniqueID-assigned id (updates the URL hash).
+editor.commands.scrollToHeading('introduction');
+
+// Read the live heading list, or subscribe via the onUpdate option.
+console.log(editor.storage.toc.content); // HeadingEntry[]
+```
+
+`UniqueID` stamps ids on headings; `TableOfContents` watches the document and
+keeps `editor.storage.toc` in sync; `FloatingTocOutline` renders the sticky
+outline; `TableOfContentsBlock` adds the `/toc` atom so users can insert an
+inline contents list.
+
+## Exports
+
+```ts
+import {
+  TableOfContents,
+  tocPluginKey,
+  FloatingTocOutline,
+  floatingTocOutlinePluginKey,
+  TableOfContentsBlock,
+  walkHeadings,
+  scrollToHeading,
+  createActiveStateTracker,
+} from '@domternal/extension-toc';
+```
+
+`walkHeadings`, `scrollToHeading`, and `createActiveStateTracker` are exposed as
+standalone helpers so you can build a custom outline UI on top of the same
+data layer and active-tracking rule.

--- a/packages/extension-toc/README.md
+++ b/packages/extension-toc/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -3,42 +3,61 @@
 [![Version](https://img.shields.io/npm/v/@domternal/pm.svg)](https://www.npmjs.com/package/@domternal/pm)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+The ProseMirror dependency layer for the [Domternal](https://domternal.dev) editor. It
+re-exports the underlying `prosemirror-*` libraries under stable `@domternal/pm/*`
+subpaths so every Domternal package imports ProseMirror from one place. Because the
+`prosemirror-*` packages are pinned here as direct dependencies, your package manager
+dedupes them to a single copy across `@domternal/core` and every extension. You rarely
+install it yourself: it ships transitively with `@domternal/core`.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/packages)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+Already a dependency of `@domternal/core`, so most apps never add it directly. Install
+it explicitly only when you import ProseMirror primitives in your own code:
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+```bash
+pnpm add @domternal/pm
+```
 
-## Documentation
+There are no peer dependencies: the `prosemirror-*` libraries are bundled as
+dependencies of this package.
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+## Usage
 
-## License
+Import from a subpath matching the ProseMirror package you need. Each subpath
+re-exports the full API of its `prosemirror-*` counterpart.
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+```ts
+import { Schema } from '@domternal/pm/model';
+import { EditorState, Plugin, PluginKey } from '@domternal/pm/state';
+import { EditorView } from '@domternal/pm/view';
+
+const myPlugin = new Plugin({
+  key: new PluginKey('my-plugin'),
+  view: (view: EditorView) => ({ destroy: () => {} }),
+});
+
+// `state` and `view` are the same APIs you would get from
+// 'prosemirror-state' and 'prosemirror-view' directly.
+```
+
+## Subpaths
+
+| Subpath | Re-exports |
+| --- | --- |
+| `@domternal/pm/commands` | `prosemirror-commands` |
+| `@domternal/pm/dropcursor` | `prosemirror-dropcursor` |
+| `@domternal/pm/gapcursor` | `prosemirror-gapcursor` |
+| `@domternal/pm/history` | `prosemirror-history` |
+| `@domternal/pm/inputrules` | `prosemirror-inputrules` |
+| `@domternal/pm/keymap` | `prosemirror-keymap` |
+| `@domternal/pm/model` | `prosemirror-model` |
+| `@domternal/pm/schema-list` | `prosemirror-schema-list` |
+| `@domternal/pm/state` | `prosemirror-state` |
+| `@domternal/pm/tables` | `prosemirror-tables` |
+| `@domternal/pm/transform` | `prosemirror-transform` |
+| `@domternal/pm/view` | `prosemirror-view` |

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,42 +3,83 @@
 [![Version](https://img.shields.io/npm/v/@domternal/react.svg)](https://www.npmjs.com/package/@domternal/react)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+React components and hooks for the [Domternal](https://domternal.dev) editor. Wraps the headless
+[`@domternal/core`](https://www.npmjs.com/package/@domternal/core) editor with React-native APIs: a composable
+`Domternal` component with namespaced subcomponents (`Toolbar`, `Content`, `BubbleMenu`, `FloatingMenu`,
+`EmojiPicker`), a `useEditor` hook for full control, an `EditorProvider` context, and `ReactNodeViewRenderer`
+for writing custom node views as React components. Works with React 18 and React 19.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/guides/react)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/react @domternal/core react react-dom
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`react` (>=18), `react-dom` (>=18), and `@domternal/core` are peer dependencies. Import the theme
+([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)) in your entry CSS for default styling:
 
-## Documentation
+```css
+@import '@domternal/theme';
+```
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+## Usage
 
-## License
+The recommended pattern uses the composable `Domternal` component. It creates the editor and provides it
+to every subcomponent via context, so no `editor` prop needs to be passed down:
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+```tsx
+import { Domternal } from '@domternal/react';
+import { StarterKit, BubbleMenu } from '@domternal/core';
+
+export default function Editor() {
+  return (
+    <Domternal
+      extensions={[StarterKit, BubbleMenu]}
+      content="<p>Hello from React!</p>"
+    >
+      <Domternal.Toolbar />
+      <Domternal.Content />
+      <Domternal.BubbleMenu contexts={{ text: ['bold', 'italic', 'underline'] }} />
+    </Domternal>
+  );
+}
+```
+
+Need direct access to the editor instance? Use the `useEditor` hook and mount the view yourself:
+
+```tsx
+import { useEditor, EditorProvider, DomternalToolbar } from '@domternal/react';
+import { StarterKit } from '@domternal/core';
+
+export default function Editor() {
+  const { editor, editorRef } = useEditor({
+    extensions: [StarterKit],
+    content: '<p>Hello</p>',
+    onUpdate: ({ editor }) => console.log(editor.getHTML()),
+  });
+
+  return (
+    <EditorProvider editor={editor}>
+      {editor && <DomternalToolbar />}
+      <div className="dm-editor">
+        <div ref={editorRef} />
+      </div>
+    </EditorProvider>
+  );
+}
+```
+
+## Exports
+
+- **Hooks**: `useEditor`, `useEditorState`, `useCurrentEditor`
+- **Constants**: `DEFAULT_EXTENSIONS`
+- **Composable component**: `Domternal` with `Domternal.Toolbar`, `Domternal.Content`, `Domternal.BubbleMenu`,
+  `Domternal.FloatingMenu`, `Domternal.EmojiPicker`, `Domternal.Loading`
+- **Components**: `DomternalEditor`, `EditorContent`, `DomternalToolbar`, `DomternalBubbleMenu`,
+  `DomternalFloatingMenu`, `DomternalEmojiPicker`, `DomternalNotionColorPicker`, `EditorProvider`
+- **Node views**: `ReactNodeViewRenderer`, `NodeViewWrapper`, `NodeViewContent`, `useReactNodeView`
+- **SSR helpers** (re-exported from core, work without an editor instance): `generateHTML`, `generateJSON`, `generateText`

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -3,42 +3,79 @@
 [![Version](https://img.shields.io/npm/v/@domternal/theme.svg)](https://www.npmjs.com/package/@domternal/theme)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Ready-made light and dark styles for the [Domternal](https://domternal.dev) editor,
+toolbar, bubble menu, floating menu, popovers, and every UI component. It is a
+CSS-only package (no JavaScript), built from Sass into a single stylesheet. Every
+visual property is exposed as a CSS custom property, so you can rebrand colors,
+fonts, spacing, and borders by overriding a variable instead of touching the source.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/guides/theming)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/theme
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+This package has no peer dependencies.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+Import the stylesheet once in your application entry point:
 
-## License
+```ts
+// JavaScript/TypeScript bundler (Vite, Webpack, esbuild)
+import '@domternal/theme';
+```
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+```scss
+// Sass pipeline (imports the SCSS source)
+@use '@domternal/theme/scss';
+```
+
+```html
+<!-- Plain HTML link tag -->
+<link rel="stylesheet" href="node_modules/@domternal/theme/dist/domternal-theme.css" />
+```
+
+Light mode is the default. Toggle dark mode by adding a class to the editor or any
+ancestor element:
+
+```html
+<!-- Always dark -->
+<div class="dm-theme-dark">
+  <div class="dm-toolbar">...</div>
+  <div class="dm-editor">...</div>
+</div>
+
+<!-- Follow the system preference -->
+<div class="dm-theme-auto">...</div>
+
+<!-- Force light inside a dark context -->
+<div class="dm-theme-light">...</div>
+```
+
+Override any CSS custom property on `.dm-editor`, `.dm-toolbar`, or a parent to
+customize the look:
+
+```css
+.my-editor {
+  --dm-accent: #e11d48;
+  --dm-accent-hover: #be123c;
+  --dm-accent-surface: rgba(225, 29, 72, 0.1);
+}
+
+.my-editor .dm-editor {
+  --dm-bg: #fefce8;
+}
+```
+
+## Entry points
+
+| Import | Resolves to | Description |
+|---|---|---|
+| `@domternal/theme` | `dist/domternal-theme.css` | Default: compiled CSS |
+| `@domternal/theme/css` | `dist/domternal-theme.css` | Explicit CSS import |
+| `@domternal/theme/scss` | `src/index.scss` | SCSS source for Sass pipelines |

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/theme/src/_variables.scss
+++ b/packages/theme/src/_variables.scss
@@ -17,7 +17,7 @@
   // ---------------------------------------------------------------------------
   --dm-bg: #ffffff;
   --dm-text: #1a1a1a;
-  --dm-muted: #999999;
+  --dm-muted: #6b7280;
   --dm-surface: #f8f9fa;
   --dm-border-color: #e5e7eb;
   --dm-hover: rgba(0, 0, 0, 0.04);

--- a/packages/theme/src/themes/_dark.scss
+++ b/packages/theme/src/themes/_dark.scss
@@ -16,7 +16,7 @@
   --dm-color-scheme: dark;
   --dm-bg: #1e1e1e;
   --dm-text: #e0e0e0;
-  --dm-muted: #777777;
+  --dm-muted: #9ca3af;
   --dm-surface: #2a2a2a;
   --dm-border-color: #3a3a3a;
   --dm-hover: rgba(255, 255, 255, 0.08);

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -3,42 +3,78 @@
 [![Version](https://img.shields.io/npm/v/@domternal/vanilla.svg)](https://www.npmjs.com/package/@domternal/vanilla)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Framework-free DOM components for the [Domternal](https://domternal.dev) editor.
+Each component is a class you instantiate against a host element:
+`DomternalEditor`, `DomternalToolbar`, `DomternalBubbleMenu`, `DomternalFloatingMenu`,
+`DomternalEmojiPicker`, and `DomternalNotionColorPicker`. Every class extends
+`EventTarget`, exposes plain getters and setters, dispatches `CustomEvent`s for state
+changes, and tears down with an idempotent `destroy()`. Use it in Astro, Svelte, Solid,
+Lit, Web Components, or plain HTML - anywhere without a framework runtime.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/guides/vanilla)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/core @domternal/theme @domternal/vanilla
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`@domternal/core` is a peer dependency. `@domternal/theme` supplies the editor styles
+(import it once in your app).
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+```ts
+import { StarterKit, BubbleMenu } from '@domternal/core';
+import {
+  DomternalEditor,
+  DomternalToolbar,
+  DomternalBubbleMenu,
+} from '@domternal/vanilla';
+import '@domternal/theme';
 
-## License
+const toolbarEl = document.getElementById('toolbar')!;
+const editorEl = document.getElementById('editor')!;
+const bubbleEl = document.getElementById('bubble')!;
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const dm = new DomternalEditor(editorEl, {
+  extensions: [StarterKit, BubbleMenu.configure({ element: bubbleEl })],
+  content: '<p>Hello world</p>',
+  onUpdate: ({ editor }) => console.log(editor.getHTML()),
+});
+
+new DomternalToolbar(toolbarEl, { editor: dm.editor });
+new DomternalBubbleMenu(bubbleEl, { editor: dm.editor });
+
+// Reactive-friendly getters:
+console.log(dm.htmlContent, dm.isEmpty);
+
+// CustomEvent subscription:
+dm.addEventListener('update', () => console.log('content changed'));
+
+// Cleanup (idempotent):
+dm.destroy();
+```
+
+The matching mount points:
+
+```html
+<div id="toolbar"></div>
+<div id="editor" class="dm-editor"></div>
+<div id="bubble" class="dm-bubble-menu"></div>
+```
+
+> Construction is browser-only: every constructor calls `assertBrowser()` and throws in
+> SSR. Module-scope imports stay SSR-safe, so gate instantiation behind a client-side
+> entry point (e.g. an Astro `<script>` block or `client:only`).
+
+## Exports
+
+- `DomternalEditor` / `DomternalEditorOptions` - wraps core's `Editor`, plus
+  `DEFAULT_EXTENSIONS` (Document, Paragraph, Text, BaseKeymap, History).
+- `DomternalToolbar`, `DomternalBubbleMenu`, `DomternalFloatingMenu`,
+  `DomternalEmojiPicker`, `DomternalNotionColorPicker` - the floating UI components.
+- Shared helpers: `isBrowser`, `assertBrowser`, `createPluginKey`, `renderIconInto`,
+  `resolveIcon`, `subscribe`.

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -9,7 +9,7 @@ Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop 
 ## Links
 
 <u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[StackBlitz (Angular)](https://stackblitz.com/edit/domternal-angular-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (React)](https://stackblitz.com/edit/domternal-react-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vue)](https://stackblitz.com/edit/domternal-vue-full-example)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[StackBlitz (Vanilla TS)](https://stackblitz.com/edit/domternal-vanilla-full-example)</u>
+<u>[Live examples](https://domternal.dev/examples)</u>
 
 ## Features
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -3,42 +3,81 @@
 [![Version](https://img.shields.io/npm/v/@domternal/vue.svg)](https://www.npmjs.com/package/@domternal/vue)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/domternal/domternal/blob/main/LICENSE)
 
-A lightweight, extensible rich text editor toolkit built on <u>[ProseMirror](https://prosemirror.net/)</u>. Framework-agnostic headless core with first-class Angular, React, Vue, and Vanilla wrappers.
-Use it headless with vanilla JS/TS, add the built-in toolbar and theme, or drop in ready-made framework components. Fully tree-shakeable, import only what you use, unused extensions are stripped from your bundle.
+Vue 3 bindings for the [Domternal](https://domternal.dev) editor. Provides the composable
+`Domternal` component (with namespaced `Domternal.Toolbar`, `Domternal.Content`,
+`Domternal.BubbleMenu`, `Domternal.FloatingMenu`, and `Domternal.EmojiPicker` subcomponents),
+the `useEditor` and `useEditorState` composables for full control, provide/inject helpers for
+sharing one editor across descendants, and `VueNodeViewRenderer` for writing custom node views as
+Vue SFCs. SSR-safe by default: the editor is created in `onMounted`. Requires Vue 3.3+ and the
+Composition API.
 
 ## Links
 
-<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/introduction)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-<u>[Live examples](https://domternal.dev/examples)</u>
+<u>[Website](https://domternal.dev)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Documentation](https://domternal.dev/v1/guides/vue)</u> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; <u>[Live examples](https://domternal.dev/examples)</u>
 
-## Features
+## Install
 
-See <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> for a full breakdown of all packages and what each one includes.
+```bash
+pnpm add @domternal/vue @domternal/core @domternal/theme vue
+```
 
-- **Headless core** - use with any framework or vanilla JS/TS
-- **Angular components** - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker (signals, OnPush, zoneless-ready)
-- **React components** - composable `Domternal` component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (React 18+)
-- **Vue components** - composable `Domternal` component, `useEditor`/`useEditorState` composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, custom node views (Vue 3.3+)
-- **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
-- **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents
-- **70+ extensions across 16 packages** - nodes, marks, and behavior extensions
-- **125+ chainable commands** - `editor.chain().focus().toggleBold().run()`
-- **Full table support** - cell merging, column resize, row/column controls, cell toolbar, all free and MIT licensed
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~44 KB gzipped** (own code), <u>[see Packages](https://domternal.dev/v1/packages)</u> for full bundle breakdown with ProseMirror
-- **TypeScript first** - 100% typed, zero `any`
-- **15,000+ tests** - 4,000+ unit and 11,000+ E2E across 230+ Playwright specs and 4 demo apps
-- **Light and dark theme** - 120+ CSS custom properties for full visual control
-- **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
-- **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
+`vue` (>=3.3) and `@domternal/core` are peer dependencies. `@domternal/theme` supplies the
+editor styles.
 
-## Documentation
+## Usage
 
-- <u>[Getting Started](https://domternal.dev/v1/getting-started)</u> - install and create your first editor
-- <u>[Introduction](https://domternal.dev/v1/introduction)</u> - core concepts, architecture, and design decisions
-- <u>[Packages & Bundle Size](https://domternal.dev/v1/packages)</u> - what each package includes and bundle size breakdown
-- <u>[Blog](https://domternal.dev/blog)</u>
+Composable component pattern (recommended): `Domternal` creates the editor and provides it to all
+subcomponents via inject, so children need no `editor` prop.
 
-## License
+```vue
+<script setup lang="ts">
+import { Domternal } from '@domternal/vue';
+import { StarterKit, BubbleMenu } from '@domternal/core';
+import '@domternal/theme';
 
-<u>[MIT](https://github.com/domternal/domternal/blob/main/LICENSE)</u>
+const extensions = [StarterKit, BubbleMenu];
+</script>
+
+<template>
+  <Domternal :extensions="extensions" content="<p>Hello from Vue!</p>">
+    <Domternal.Toolbar />
+    <Domternal.Content />
+    <Domternal.BubbleMenu :contexts="{ text: ['bold', 'italic', 'underline'] }" />
+  </Domternal>
+</template>
+```
+
+### Composable hook
+
+Use `useEditor` directly when you need the editor instance, then read reactive state with
+`useEditorState`:
+
+```vue
+<script setup lang="ts">
+import { useEditor, useEditorState, provideEditor, DomternalToolbar } from '@domternal/vue';
+import { StarterKit } from '@domternal/core';
+
+const { editor, editorRef } = useEditor({
+  extensions: [StarterKit],
+  content: '<p>Start typing…</p>',
+  onUpdate: ({ editor }) => console.log(editor.getHTML()),
+});
+
+provideEditor(editor);
+
+const { htmlContent, isEmpty } = useEditorState(editor);
+</script>
+
+<template>
+  <DomternalToolbar />
+  <div ref="editorRef" class="dm-editor" />
+</template>
+```
+
+`useEditor` returns `editor` (a `ShallowRef<Editor | null>`, null until mounted) and `editorRef`
+(bind to the mount element). `useEditorState` returns `htmlContent`, `jsonContent`, `isEmpty`,
+`isFocused`, and `isEditable`, or pass a selector for a granular `ComputedRef`:
+
+```ts
+const isBold = useEditorState(editor, (ed) => ed.isActive('bold'));
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,50 +367,50 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@25.2.3)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.55.1)(sass@1.97.3)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.2.1)
       '@domternal/angular':
-        specifier: 0.11.0
-        version: 0.11.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.0(linkedom@0.18.12))
+        specifier: 0.11.1
+        version: 0.11.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.1(linkedom@0.18.12))
       '@domternal/core':
-        specifier: 0.11.0
-        version: 0.11.0(linkedom@0.18.12)
+        specifier: 0.11.1
+        version: 0.11.1(linkedom@0.18.12)
       '@domternal/extension-block-controls':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-code-block-lowlight':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)(lowlight@3.3.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)(lowlight@3.3.0)
       '@domternal/extension-details':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-emoji':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-image':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-mention':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-table':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/extension-toc':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
       '@domternal/pm':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.11.1
+        version: 0.11.1
       '@domternal/react':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@domternal/theme':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.11.1
+        version: 0.11.1
       '@domternal/vanilla':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))
       '@domternal/vue':
-        specifier: 0.11.0
-        version: 0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
+        specifier: 0.11.1
+        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -1917,8 +1917,8 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@domternal/angular@0.11.0':
-    resolution: {integrity: sha512-qcj99qg0BVoc+N/Z+bz5BEMi2nBBmHGqoIQWvX9ifkXCIW22dAeJ0X9060aCV3sYjaY/R8VJhwRnSjOiSlj01w==}
+  '@domternal/angular@0.11.1':
+    resolution: {integrity: sha512-HgYByz5Z55B4vp/x1uZafsVCOQlOs2Cf0nIWvOQTYoF+pb7lkn2KAgEofB3SekiREAgw6ajWWvYHR4/DRpA5HQ==}
     peerDependencies:
       '@angular/core': ^21.2.5
       '@angular/forms': ^21.2.5
@@ -1931,8 +1931,8 @@ packages:
       '@angular/forms': ^21.2.5
       '@domternal/core': '>=0.6.1'
 
-  '@domternal/core@0.11.0':
-    resolution: {integrity: sha512-2agNxMSWp/O2O+tYVcFYREk4sw1TOr/JRxmeMgayR03R7qo3eKIiHfcpPIFk+7a9mRg5ngELCFwDAoQQj8rC+A==}
+  '@domternal/core@0.11.1':
+    resolution: {integrity: sha512-U7QoHexYA1HXIfVRfyi9SFff9K4SxYav7XSiFcsDZXvjJHUIcSOu7VjjXimRLbaateXupFEvdiiwl+oyiXIx6A==}
     engines: {node: '>=20'}
     peerDependencies:
       linkedom: ^0.18.0
@@ -1949,68 +1949,68 @@ packages:
       linkedom:
         optional: true
 
-  '@domternal/extension-block-controls@0.11.0':
-    resolution: {integrity: sha512-9MEhSrBo6N09cxAqefH4qa8DkIsLHwuZ0vr2QQ7ZFwrunL0N6wpSsIMJrfjjrmvaOomAJY8v/yhxhsMP9zGfBg==}
+  '@domternal/extension-block-controls@0.11.1':
+    resolution: {integrity: sha512-rXm+qDOP33krUR2p2HdMGreaSsk0rD4c919r2+9+Ccy2sGhQs/C2FrFE87ozlf6NP+mSf2FoW2pfKyERI9DMOg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-code-block-lowlight@0.11.0':
-    resolution: {integrity: sha512-VPvi1GgM0Af60grqcYaSlqT5ZhTKULEAgdPZ8NZqY6j0fB/FnGvizgDFefbfZ3fXoQeJ8clGRihoHARe6Id7QA==}
+  '@domternal/extension-code-block-lowlight@0.11.1':
+    resolution: {integrity: sha512-Y2HLazc6I+7T1Yz1mNrnaB9VTo8J603Wu0Tr9KDyNbnS2mfyKTFMA+QuDzQ7LeGUepzJW3NSqiD0q7iPO9iWJw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
       lowlight: ^3.0.0
 
-  '@domternal/extension-details@0.11.0':
-    resolution: {integrity: sha512-Sb7NDa8O1pY0Gxl+5Fx0ioqMNUkBGnJFuHkXP20Bpm3mX5Xd4Dr0Smmws8v0cR5/TyIZ3iI8pEUGsnuBncOWGQ==}
+  '@domternal/extension-details@0.11.1':
+    resolution: {integrity: sha512-PfsPIv8O2gIimsTLubJjijlWtEsQ0SoZwbAU6hK3gCOQcmrUcBGjBL9bcRIukWB4qjNYo2U9ufFh43gmybHAqg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-emoji@0.11.0':
-    resolution: {integrity: sha512-FyCE+hIGOn2d+JwndAbot+LFjx9k1bTiW7rGrOYaTGpAC+SC+wF79Ofxtxl+6guyjUmDvNgWwyScg0ojNHf8Jg==}
+  '@domternal/extension-emoji@0.11.1':
+    resolution: {integrity: sha512-jPI1lbuA3ufKH6V857iqLTdD2OCRd4Gx5q73PbEVuHDD1vuJw+0RYR2ibKRvcl9+X71wlWVcxMAfBMSCb2q5pQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-image@0.11.0':
-    resolution: {integrity: sha512-NEBD2cFxD1vpf7yklTx3hdY9qh3rlL53CN2bBsDCmGKPgmorLZMbcZ+3nNuNe8qFSH7j/Oh/augqjkYrPkhF6A==}
+  '@domternal/extension-image@0.11.1':
+    resolution: {integrity: sha512-GOOnD5gKiTONeqppbwvnp4FoTVrlmEtnGa220BDsCRyAdtJ4y+q0eYCkuNtPbNTE0oQW/G94YWbBeFS7S5tqRg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-mention@0.11.0':
-    resolution: {integrity: sha512-5efQl8oGJxuUUbvgOohdi9cdi9yvZ6pZiZMrqci1Ki3RAzRoKa+Ebi2SMWmHp6bWx2kJdWbp+pPEG5bllUkMFQ==}
+  '@domternal/extension-mention@0.11.1':
+    resolution: {integrity: sha512-SgwOrLMK//woN7wfM4/Z4y1FyvTe6cp+nyO6OB9h2c/DS39K3y1sTK6B1MemJSZHsFZQGESIPwtNEghQPPW9sA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-table@0.11.0':
-    resolution: {integrity: sha512-NEMZkcoXKA/i84Q8M3twIDOPLlUXuGApKX0zcLZHnpuJc/ioIsrwBZDM1OU+5h0hOvWFcmJnmXoK8PdUUEcBOg==}
+  '@domternal/extension-table@0.11.1':
+    resolution: {integrity: sha512-BzVKxf+NjpwraC13LruCASA2di0mC/UCDnKxxTnNmhr8DhB99FpvfH6jYZqL1EYel7uGHHYSRWF3N9+oAXAj6w==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-toc@0.11.0':
-    resolution: {integrity: sha512-JqBf/iIT0NcFmOygxGMgxAnxco67NAJHzC5EtMlAM5zE3libJMX41a2ld8EDm92YhmkDDCZ6NgHeYv2bnqSQsg==}
+  '@domternal/extension-toc@0.11.1':
+    resolution: {integrity: sha512-6myGr3z5AkHiGG/q1fDEcLtAJFhM4Z7L0JQaAwLYLZ0yxre0tADIMKjoRQSUdCywh43nTYFL5NpLDrae8GaPiQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/pm@0.11.0':
-    resolution: {integrity: sha512-p9uf+wKNl6n3S+AuwPo+FPGDf69vowzHhUaBo1BgfRYiZJMMbEa9xgpPbB06vmd1+uv/VBjT5NYdQMj3dpVxnQ==}
+  '@domternal/pm@0.11.1':
+    resolution: {integrity: sha512-He15iQTo0sxKyITS64iC0pCQh2/J2diitg8w9JXK+879sPmDIEATNsyRWvEiAra7YoF58EI89bzi73JwNCRlJg==}
 
-  '@domternal/react@0.11.0':
-    resolution: {integrity: sha512-ejqWtJn4NFLtCeBIaOL2mNYtJICwSYip7NI9cG0k6w9cjxTPk6ERtVIoMR9sxkU/nGQOZhCZPApXhpOpeBSioQ==}
+  '@domternal/react@0.11.1':
+    resolution: {integrity: sha512-xzBDV5dU+PG9KwwXDQrwQ0RzGD76oJh5PwqUNvfd0XACYeDrQbAw1+TJ0fOIEmaQQq4GPq8VLkDt7POeeHnzvw==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       react: '>=18'
@@ -2023,19 +2023,19 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  '@domternal/theme@0.11.0':
-    resolution: {integrity: sha512-xUaC4jck1NiYez711mnzyF+ER/A1LiCYvI5UAlSDGVKFsF9j844c9OQlRA1YjzMQz7bMszRAph90QyZckCLyFQ==}
+  '@domternal/theme@0.11.1':
+    resolution: {integrity: sha512-OCUM7VtWWLXGXpeYpq+g87wEeTIfw7nEEhpFPEwvsnF28ppMI0j0Jz0IgywXNlHh131OMssyKAzMpGyGbA2aPg==}
 
   '@domternal/theme@0.6.2':
     resolution: {integrity: sha512-dOezxQwmakDBpx6sgwr6tGL/DP55Pu+NNDVsgUa5guTsYaWi7NS5LI0ymCdoSWnLI40oqKYClOo33ZPF4JB/Og==}
 
-  '@domternal/vanilla@0.11.0':
-    resolution: {integrity: sha512-dv3vFGP6eujymtuR4D7xOjqoULLa01W6Xuh8TKtdy8p/wnvKUJ37JTRiutyqOj3SxypAgi23tnjDNj3mGCYLQQ==}
+  '@domternal/vanilla@0.11.1':
+    resolution: {integrity: sha512-Kbx+sDZs+pvTjPRY1ZasSL94PJ5gSt/75JZkLB2zYN+bh9qFi0a4Rw8ozh8mG6utE3KE/zj0/8HoLTPmruaNeQ==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
 
-  '@domternal/vue@0.11.0':
-    resolution: {integrity: sha512-r/u9QZAZo+EvUIayN5FpLM7+HfihUYID75lN8nv7TpluZ4lNsqQxmcNCzTl3A1KXbB5UaThUAA6hVxZxtNefdA==}
+  '@domternal/vue@0.11.1':
+    resolution: {integrity: sha512-zPLImpGiAPJgIV2itWK+WDiHZ0jrPDKIHD63wOJ4IBH/7m+f12ZD2NkBKdv4xVXdqOzAytaPcC7w9JpauWO/kg==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       vue: '>=3.3'
@@ -9973,11 +9973,11 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@domternal/angular@0.11.0(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.0(linkedom@0.18.12))':
+  '@domternal/angular@0.11.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.1(linkedom@0.18.12))':
     dependencies:
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/forms': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
       tslib: 2.8.1
 
   '@domternal/angular@0.6.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.2(linkedom@0.18.12))':
@@ -9987,9 +9987,9 @@ snapshots:
       '@domternal/core': 0.6.2(linkedom@0.18.12)
       tslib: 2.8.1
 
-  '@domternal/core@0.11.0(linkedom@0.18.12)':
+  '@domternal/core@0.11.1(linkedom@0.18.12)':
     dependencies:
-      '@domternal/pm': 0.11.0
+      '@domternal/pm': 0.11.1
       '@floating-ui/dom': 1.7.5
       linkifyjs: 4.3.2
     optionalDependencies:
@@ -9997,55 +9997,55 @@ snapshots:
 
   '@domternal/core@0.6.2(linkedom@0.18.12)':
     dependencies:
-      '@domternal/pm': 0.11.0
+      '@domternal/pm': 0.11.1
       '@floating-ui/dom': 1.7.5
       linkifyjs: 4.3.2
     optionalDependencies:
       linkedom: 0.18.12
 
-  '@domternal/extension-block-controls@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-block-controls@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-code-block-lowlight@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)(lowlight@3.3.0)':
+  '@domternal/extension-code-block-lowlight@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)(lowlight@3.3.0)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
       hast-util-to-html: 9.0.5
       lowlight: 3.3.0
 
-  '@domternal/extension-details@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-details@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-emoji@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-emoji@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-image@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-image@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-mention@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-mention@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-table@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-table@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/extension-toc@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(@domternal/pm@0.11.0)':
+  '@domternal/extension-toc@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
-      '@domternal/pm': 0.11.0
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/pm': 0.11.1
 
-  '@domternal/pm@0.11.0':
+  '@domternal/pm@0.11.1':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-dropcursor: 1.8.2
@@ -10060,9 +10060,9 @@ snapshots:
       prosemirror-transform: 1.10.5
       prosemirror-view: 1.41.5
 
-  '@domternal/react@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@domternal/react@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -10072,17 +10072,17 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@domternal/theme@0.11.0': {}
+  '@domternal/theme@0.11.1': {}
 
   '@domternal/theme@0.6.2': {}
 
-  '@domternal/vanilla@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))':
+  '@domternal/vanilla@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
 
-  '@domternal/vue@0.11.0(@domternal/core@0.11.0(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
+  '@domternal/vue@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      '@domternal/core': 0.11.0(linkedom@0.18.12)
+      '@domternal/core': 0.11.1(linkedom@0.18.12)
       vue: 3.5.32(typescript@5.9.3)
 
   '@domternal/vue@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))':


### PR DESCRIPTION
## Summary

Three related changes on this branch:

1. **Package-specific READMEs.** The 15 packages that shared an identical generic template now have real, package-specific READMEs: a concrete description, `## Install` with the correct peer deps, `## Usage` with working code, and a `## Links` section, modeled on the existing `@domternal/extension-math` README. `extension-math` and the `extension-block-menu` shim also gained a matching `## Links` section, so all 17 package READMEs are now consistent.

2. **Consolidated example links.** The four per-framework StackBlitz links in the root README and the 15 package READMEs are replaced by a single **[Live examples](https://domternal.dev/examples)** link. The `/examples` page itself (which lists the per-framework StackBlitz examples) ships separately on the docs site and is already live; the matching docs/blog link updates landed there too.

3. **Theme contrast fix.** `--dm-muted` (muted / placeholder text) failed WCAG AA on both themes: `#999` was 2.85:1 on the light background and `#777` was 3.7:1 on the dark one. Now `#6b7280` (light, ~4.6:1) and `#9ca3af` (dark, ~6.6:1). The README CSS-property count is also corrected from 120+ to 160+ to match the site, and the root lockfile is relinked to 0.11.1.

## Changes

- `fix(theme)`: accessible `--dm-muted` on light and dark backgrounds.
- `docs`: 17 package READMEs rewritten / updated; per-framework StackBlitz links consolidated to one Live examples link.
- `chore`: root `pnpm-lock.yaml` relinked to 0.11.1.

## Verified

- Each rewritten README was adversarially verified against its package source: no invented exports or commands, install peer deps and usage code checked against the real API. Four real inaccuracies were caught and fixed (wrong storage key, an emoji not in the default dataset, a mis-attributed Angular method, a mis-grouped React export).
- All 17 package READMEs have a `## Links` section linking to `/examples`.
- Theme contrast values computed to meet WCAG AA (>= 4.5:1).
