### PR TITLE
chore: add LICENSE files to six packages and GitHub community files (issue forms, PR template, code of conduct, security policy)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something in Domternal does not work as expected
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Before submitting, please search
+        [existing issues](https://github.com/domternal/domternal/issues) to avoid duplicates.
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework
+      description: Which wrapper are you using?
+      options:
+        - React (@domternal/react)
+        - Vue (@domternal/vue)
+        - Angular (@domternal/angular)
+        - Vanilla JS (@domternal/vanilla)
+        - Core / not framework-specific
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Domternal version
+      description: The version of the @domternal packages you are using.
+      placeholder: "0.11.2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what happened, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Create an editor with StarterKit
+        2. Type "..."
+        3. Press Enter
+        4. See the error
+    validations:
+      required: true
+
+  - type: input
+    id: repro
+    attributes:
+      label: Minimal reproduction (optional but very helpful)
+      description: |
+        Fork the starter for your framework, reproduce the bug, and paste the link:
+        [React](https://stackblitz.com/edit/domternal-react-full-example) ·
+        [Vue](https://stackblitz.com/edit/domternal-vue-full-example) ·
+        [Angular](https://stackblitz.com/edit/domternal-angular-full-example) ·
+        [Vanilla JS](https://stackblitz.com/edit/domternal-vanilla-full-example)
+      placeholder: "https://stackblitz.com/edit/..."
+
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and OS
+      placeholder: "Chrome 138, macOS 15"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://domternal.dev/v1/introduction
+    about: Guides, extension docs, and API reference.
+  - name: Live examples
+    url: https://domternal.dev/examples
+    about: Try Domternal in the browser and open framework starters on StackBlitz.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new feature or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Before submitting, please search
+        [existing issues](https://github.com/domternal/domternal/issues) to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that Domternal does not support today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? API sketches are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or how other editors solve this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Summary
+
+<!-- Short summary of all the changes in this PR -->
+
+<!-- Fill in the sections that apply and delete the ones that don't.
+     A PR can have just one of Features/Changes/Fix, or all of them. -->
+
+# Features
+
+<!-- Which features were added -->
+
+# Fix
+
+<!-- What was fixed, which bugs -->
+
+# Changes
+
+<!-- Which changes were made -->
+
+# Verified
+
+<!-- What was tested and how, e.g. "built all packages, ran unit tests, tested in demo app" -->
+<!--
+Before opening: pnpm lint, pnpm typecheck, pnpm build and pnpm test pass locally.
+If public exports changed: run `node tests/api-surface/dump.mjs` and commit the updated snapshot.
+If a bundle grew intentionally: bump its budget in tests/bundle-size/budget.json (pnpm test:bundle-size).
+If theme CSS variables changed: pnpm test:css-vars passes.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at
+[info@domternal.dev](mailto:info@domternal.dev).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,14 @@ We use **Squash and Merge**. The PR title becomes the final commit message.
 ### PR Description
 
 Include:
-- **Summary** - Brief summary of changes (required)
-- **Features** - Key capabilities added (for `feat` PRs)
-- **Changes** - What was modified (for `fix`/`refactor` PRs)
-- **What** - Problem/issue being solved (optional)
+- **Summary** - Short summary of all the changes (required)
+- **Features** - Which features were added (if any)
+- **Fix** - What was fixed, which bugs (if any)
+- **Changes** - Which changes were made (if any)
 - **Verified** - What was tested and how (e.g. "built all packages, ran unit tests, tested in demo app")
+
+A PR can have just one of Features/Fix/Changes, or all of them. The
+[PR template](.github/PULL_REQUEST_TEMPLATE.md) pre-fills these sections.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of the `@domternal/*` packages receives
+security fixes.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Instead, use GitHub's private vulnerability reporting:
+[report a vulnerability](https://github.com/domternal/domternal/security/advisories/new)
+directly, or go to the repository's Security tab and click
+**Report a vulnerability**. This opens a private advisory that only you and
+the maintainer can see.
+
+Alternatively, email [info@domternal.dev](mailto:info@domternal.dev).
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, ideally with a minimal example
+- The affected package(s) and version(s)
+
+You will get an initial response within a few days. Please allow time for a fix
+to be released before any public disclosure.

--- a/packages/extension-block-controls/LICENSE
+++ b/packages/extension-block-controls/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/extension-block-menu/LICENSE
+++ b/packages/extension-block-menu/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/extension-math/LICENSE
+++ b/packages/extension-math/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/extension-toc/LICENSE
+++ b/packages/extension-toc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vanilla/LICENSE
+++ b/packages/vanilla/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domternal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,50 +367,50 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@25.2.3)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.55.1)(sass@1.97.3)(typescript@5.9.3)(yaml@2.8.2)))(tailwindcss@4.2.1)
       '@domternal/angular':
-        specifier: 0.11.1
-        version: 0.11.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.1(linkedom@0.18.12))
+        specifier: 0.11.2
+        version: 0.11.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.2(linkedom@0.18.12))
       '@domternal/core':
-        specifier: 0.11.1
-        version: 0.11.1(linkedom@0.18.12)
+        specifier: 0.11.2
+        version: 0.11.2(linkedom@0.18.12)
       '@domternal/extension-block-controls':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-code-block-lowlight':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)(lowlight@3.3.0)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)(lowlight@3.3.0)
       '@domternal/extension-details':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-emoji':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-image':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-mention':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-table':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/extension-toc':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)
       '@domternal/pm':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
       '@domternal/react':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@domternal/theme':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
       '@domternal/vanilla':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))
       '@domternal/vue':
-        specifier: 0.11.1
-        version: 0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
+        specifier: 0.11.2
+        version: 0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -1917,8 +1917,8 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@domternal/angular@0.11.1':
-    resolution: {integrity: sha512-HgYByz5Z55B4vp/x1uZafsVCOQlOs2Cf0nIWvOQTYoF+pb7lkn2KAgEofB3SekiREAgw6ajWWvYHR4/DRpA5HQ==}
+  '@domternal/angular@0.11.2':
+    resolution: {integrity: sha512-fGAnCdDvq4aR7xAUhWce5Rs0jXZTzDsN3GulJc7z3j22USZwKvydtrl13iuyvuYJbpX4JG77vSvCRZfGk4w+zw==}
     peerDependencies:
       '@angular/core': ^21.2.5
       '@angular/forms': ^21.2.5
@@ -1931,8 +1931,8 @@ packages:
       '@angular/forms': ^21.2.5
       '@domternal/core': '>=0.6.1'
 
-  '@domternal/core@0.11.1':
-    resolution: {integrity: sha512-U7QoHexYA1HXIfVRfyi9SFff9K4SxYav7XSiFcsDZXvjJHUIcSOu7VjjXimRLbaateXupFEvdiiwl+oyiXIx6A==}
+  '@domternal/core@0.11.2':
+    resolution: {integrity: sha512-BDqDSGfYTXciQ3p/Ml2X0Imyxo3D2kzrP4wyU9p36alB599WZo23qE994gfHt57nWnToj71AxSIp/y4TGTf91g==}
     engines: {node: '>=20'}
     peerDependencies:
       linkedom: ^0.18.0
@@ -1949,58 +1949,58 @@ packages:
       linkedom:
         optional: true
 
-  '@domternal/extension-block-controls@0.11.1':
-    resolution: {integrity: sha512-rXm+qDOP33krUR2p2HdMGreaSsk0rD4c919r2+9+Ccy2sGhQs/C2FrFE87ozlf6NP+mSf2FoW2pfKyERI9DMOg==}
+  '@domternal/extension-block-controls@0.11.2':
+    resolution: {integrity: sha512-0tsfpGfy+L71LDpiZrvpnvkEqOfFOQ0HdR+e9KcMTA68GZO7XZKhGqF/n0T+2lPFHIpVOz/8f8ESnSODSBiTMg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-code-block-lowlight@0.11.1':
-    resolution: {integrity: sha512-Y2HLazc6I+7T1Yz1mNrnaB9VTo8J603Wu0Tr9KDyNbnS2mfyKTFMA+QuDzQ7LeGUepzJW3NSqiD0q7iPO9iWJw==}
+  '@domternal/extension-code-block-lowlight@0.11.2':
+    resolution: {integrity: sha512-jUMAVYBacT8EdW4YDo5caybOmMMsc9+k5zafJs2FlYvxlwhwYIx8Ef1ZKJjkhJ3wJXTMVtwIu3VdpIBX+GT3Gw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
       lowlight: ^3.0.0
 
-  '@domternal/extension-details@0.11.1':
-    resolution: {integrity: sha512-PfsPIv8O2gIimsTLubJjijlWtEsQ0SoZwbAU6hK3gCOQcmrUcBGjBL9bcRIukWB4qjNYo2U9ufFh43gmybHAqg==}
+  '@domternal/extension-details@0.11.2':
+    resolution: {integrity: sha512-r9keKqNaPHua7cONLaOA/TR5RidK/DiOdJ5NCSj+XGKTGkfGaEVK+4uamY5+zYzQLk1YW9fD8eIFTOpqYy528Q==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-emoji@0.11.1':
-    resolution: {integrity: sha512-jPI1lbuA3ufKH6V857iqLTdD2OCRd4Gx5q73PbEVuHDD1vuJw+0RYR2ibKRvcl9+X71wlWVcxMAfBMSCb2q5pQ==}
+  '@domternal/extension-emoji@0.11.2':
+    resolution: {integrity: sha512-3+RpHiNA3uhWUnzyZD4Nc/+Bvd29Evl2fvr16i/HGCG7Hy56B2rTal+4jdEWuOxQelepQuNFOgqrRL7K7298ug==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-image@0.11.1':
-    resolution: {integrity: sha512-GOOnD5gKiTONeqppbwvnp4FoTVrlmEtnGa220BDsCRyAdtJ4y+q0eYCkuNtPbNTE0oQW/G94YWbBeFS7S5tqRg==}
+  '@domternal/extension-image@0.11.2':
+    resolution: {integrity: sha512-xdWj6CK25AEwNXxWuJBqshtGMytW+et0IQ9Rg0YFnbGJkcz3oz7xG3DDmhIxg9HZi3ZD9+n1vq2EnrXzVfUcNQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-mention@0.11.1':
-    resolution: {integrity: sha512-SgwOrLMK//woN7wfM4/Z4y1FyvTe6cp+nyO6OB9h2c/DS39K3y1sTK6B1MemJSZHsFZQGESIPwtNEghQPPW9sA==}
+  '@domternal/extension-mention@0.11.2':
+    resolution: {integrity: sha512-LIkNVJszteLCKuila7yNgo9SQeGbgJkqYIwSRvNWPrh65x0nKWvwGGkR84ss9H/Ve3DBpKeFJraklmRVwquZTw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-table@0.11.1':
-    resolution: {integrity: sha512-BzVKxf+NjpwraC13LruCASA2di0mC/UCDnKxxTnNmhr8DhB99FpvfH6jYZqL1EYel7uGHHYSRWF3N9+oAXAj6w==}
+  '@domternal/extension-table@0.11.2':
+    resolution: {integrity: sha512-omwvpgcjFknwNNDnclIDmgoueyJqnAUhjZ9Tj1YPrJQ3fyg3QWbPagAQdZYnBUUdRvD3x+TRkrQs1XZWNCRYgg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       '@domternal/pm': '>=0.11.0'
 
-  '@domternal/extension-toc@0.11.1':
-    resolution: {integrity: sha512-6myGr3z5AkHiGG/q1fDEcLtAJFhM4Z7L0JQaAwLYLZ0yxre0tADIMKjoRQSUdCywh43nTYFL5NpLDrae8GaPiQ==}
+  '@domternal/extension-toc@0.11.2':
+    resolution: {integrity: sha512-afVIFB89lbKmkXFWXjahgtzvcnSG7cZV3utHzj2yo+n6BDIYNmFGbvMpo7pFEs3044fLOXcdyZVrpmVK+P/Mhg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
@@ -2009,8 +2009,11 @@ packages:
   '@domternal/pm@0.11.1':
     resolution: {integrity: sha512-He15iQTo0sxKyITS64iC0pCQh2/J2diitg8w9JXK+879sPmDIEATNsyRWvEiAra7YoF58EI89bzi73JwNCRlJg==}
 
-  '@domternal/react@0.11.1':
-    resolution: {integrity: sha512-xzBDV5dU+PG9KwwXDQrwQ0RzGD76oJh5PwqUNvfd0XACYeDrQbAw1+TJ0fOIEmaQQq4GPq8VLkDt7POeeHnzvw==}
+  '@domternal/pm@0.11.2':
+    resolution: {integrity: sha512-qMcx7MSNe7/Hhs5qUQPlVPcDcVW8r6vIUDBSDKMH0Spzy22+pw8p1oSBDPSDASy1rM3ZtiGgASWtqFWhP+fEhQ==}
+
+  '@domternal/react@0.11.2':
+    resolution: {integrity: sha512-taXgF5pPGpA+jGJaJ48ePq8KpPQn2bwBGYl+K5yZiiEqgXdeIjLA6VxHkGjYuJtgeMMze3umrwND0FXp9hIgWA==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       react: '>=18'
@@ -2023,19 +2026,19 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  '@domternal/theme@0.11.1':
-    resolution: {integrity: sha512-OCUM7VtWWLXGXpeYpq+g87wEeTIfw7nEEhpFPEwvsnF28ppMI0j0Jz0IgywXNlHh131OMssyKAzMpGyGbA2aPg==}
+  '@domternal/theme@0.11.2':
+    resolution: {integrity: sha512-WcyIG9Ln8lKn/41kvdPzxtJ9BhvgeSmhYsnF10szz5PvK+PFTYzJizBV73yv9JxC1OAJa+qQbgdamZj+0WV1cg==}
 
   '@domternal/theme@0.6.2':
     resolution: {integrity: sha512-dOezxQwmakDBpx6sgwr6tGL/DP55Pu+NNDVsgUa5guTsYaWi7NS5LI0ymCdoSWnLI40oqKYClOo33ZPF4JB/Og==}
 
-  '@domternal/vanilla@0.11.1':
-    resolution: {integrity: sha512-Kbx+sDZs+pvTjPRY1ZasSL94PJ5gSt/75JZkLB2zYN+bh9qFi0a4Rw8ozh8mG6utE3KE/zj0/8HoLTPmruaNeQ==}
+  '@domternal/vanilla@0.11.2':
+    resolution: {integrity: sha512-ipFXXH2JNxcgaMuSC5CpXlr32Eq56/wkPQFIye6Y+n2RPSU3fl7f9f7GgrhYW0teIQnpnsBVpW0eA4XbFv0bEg==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
 
-  '@domternal/vue@0.11.1':
-    resolution: {integrity: sha512-zPLImpGiAPJgIV2itWK+WDiHZ0jrPDKIHD63wOJ4IBH/7m+f12ZD2NkBKdv4xVXdqOzAytaPcC7w9JpauWO/kg==}
+  '@domternal/vue@0.11.2':
+    resolution: {integrity: sha512-FZcO8OO0B5Q70bpoS/k9Tw0A2YtFHamTjajozwH1WUUhRNiL5TQLFxtimxm05FD3C4WZuVCw0EyA0oLSb2rN7A==}
     peerDependencies:
       '@domternal/core': '>=0.11.0'
       vue: '>=3.3'
@@ -9973,11 +9976,11 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@domternal/angular@0.11.1(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.1(linkedom@0.18.12))':
+  '@domternal/angular@0.11.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.11.2(linkedom@0.18.12))':
     dependencies:
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/forms': 21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
       tslib: 2.8.1
 
   '@domternal/angular@0.6.2(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@21.2.5(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(@domternal/core@0.6.2(linkedom@0.18.12))':
@@ -9987,9 +9990,9 @@ snapshots:
       '@domternal/core': 0.6.2(linkedom@0.18.12)
       tslib: 2.8.1
 
-  '@domternal/core@0.11.1(linkedom@0.18.12)':
+  '@domternal/core@0.11.2(linkedom@0.18.12)':
     dependencies:
-      '@domternal/pm': 0.11.1
+      '@domternal/pm': 0.11.2
       '@floating-ui/dom': 1.7.5
       linkifyjs: 4.3.2
     optionalDependencies:
@@ -10003,47 +10006,47 @@ snapshots:
     optionalDependencies:
       linkedom: 0.18.12
 
-  '@domternal/extension-block-controls@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-block-controls@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-code-block-lowlight@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)(lowlight@3.3.0)':
+  '@domternal/extension-code-block-lowlight@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)(lowlight@3.3.0)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
       hast-util-to-html: 9.0.5
       lowlight: 3.3.0
 
-  '@domternal/extension-details@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-details@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-emoji@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-emoji@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-image@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-image@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-mention@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-mention@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-table@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-table@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
-  '@domternal/extension-toc@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(@domternal/pm@0.11.1)':
+  '@domternal/extension-toc@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(@domternal/pm@0.11.2)':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
-      '@domternal/pm': 0.11.1
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
+      '@domternal/pm': 0.11.2
 
   '@domternal/pm@0.11.1':
     dependencies:
@@ -10060,9 +10063,24 @@ snapshots:
       prosemirror-transform: 1.10.5
       prosemirror-view: 1.41.5
 
-  '@domternal/react@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@domternal/pm@0.11.2':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.0
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.10.5
+      prosemirror-view: 1.41.5
+
+  '@domternal/react@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -10072,17 +10090,17 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@domternal/theme@0.11.1': {}
+  '@domternal/theme@0.11.2': {}
 
   '@domternal/theme@0.6.2': {}
 
-  '@domternal/vanilla@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))':
+  '@domternal/vanilla@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
 
-  '@domternal/vue@0.11.1(@domternal/core@0.11.1(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
+  '@domternal/vue@0.11.2(@domternal/core@0.11.2(linkedom@0.18.12))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      '@domternal/core': 0.11.1(linkedom@0.18.12)
+      '@domternal/core': 0.11.2(linkedom@0.18.12)
       vue: 3.5.32(typescript@5.9.3)
 
   '@domternal/vue@0.6.2(@domternal/core@0.6.2(linkedom@0.18.12))(vue@3.5.32(typescript@6.0.2))':


### PR DESCRIPTION
# Summary

Adds the MIT LICENSE file to the six packages that were missing it from their
npm tarballs, relinks the root lockfile to the published 0.11.2 packages, and
adds the standard GitHub community files: issue forms, a PR template, a code
of conduct, and a security policy.

# Changes

- LICENSE (copy of the root MIT license) added to extension-block-controls,
  extension-block-menu, extension-math, extension-toc, vanilla and vue so npm
  tarballs include it
- pnpm-lock.yaml relinked to the published 0.11.2 versions
- .github/ISSUE_TEMPLATE: bug report and feature request forms (required
  framework dropdown and version field, StackBlitz starter links for minimal
  repros) plus config.yml that disables blank issues and links Docs and Live
  examples
- .github/PULL_REQUEST_TEMPLATE.md: Summary / Features / Fix / Changes /
  Verified skeleton with CI-gate reminders as hidden HTML comments
- CODE_OF_CONDUCT.md: Contributor Covenant 2.1 with info@domternal.dev as the
  enforcement contact
- SECURITY.md: private vulnerability reporting via GitHub security advisories,
  with info@domternal.dev as a fallback channel
- CONTRIBUTING.md: PR description convention synced with the new template

# Verified

- All three issue form YAML files parse and follow GitHub's issue forms
  schema; the referenced labels (bug, enhancement) exist on the repo
- Every URL in the new files checked live (StackBlitz starters, domternal.dev
  pages, GitHub and Contributor Covenant links)
- Code of conduct text compared section by section against the official
  Contributor Covenant 2.1