### PR TITLE
feat(core): construction-time dispatch and a history toggle for collaborative editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Thumbs.db
 
 .nx/cache
 .nx/workspace-data
+
+# Angular CLI build cache (library and demo app builds)
+.angular/

--- a/packages/angular/src/lib/editor.component.ts
+++ b/packages/angular/src/lib/editor.component.ts
@@ -50,6 +50,11 @@ export class DomternalEditorComponent implements ControlValueAccessor, OnDestroy
 
   // === Inputs ===
   readonly extensions = input<AnyExtension[]>([]);
+  /**
+   * Whether the built-in History extension is included. Disable it when an
+   * extension brings its own undo/redo, such as collaborative editing.
+   */
+  readonly history = input(true);
   readonly content = input<Content>('');
   readonly editable = input(true);
   readonly autofocus = input<FocusPosition>(false);
@@ -194,9 +199,12 @@ export class DomternalEditorComponent implements ControlValueAccessor, OnDestroy
     const initialContent = this._pendingContent ?? this.content();
     this._pendingContent = null;
 
+    const defaults = this.history()
+      ? DEFAULT_EXTENSIONS
+      : DEFAULT_EXTENSIONS.filter((extension) => extension.name !== 'history');
     this._editor = new Editor({
       element: this.editorRef().nativeElement,
-      extensions: [...DEFAULT_EXTENSIONS, ...this.extensions()],
+      extensions: [...defaults, ...this.extensions()],
       content: initialContent,
       editable: this.editable(),
       autofocus: this.autofocus(),

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -180,6 +180,55 @@ describe('Editor', () => {
     });
   });
 
+  describe('plugin view dispatch during EditorView construction', () => {
+    // EditorView's constructor initializes plugin views, and a plugin view may
+    // dispatch synchronously before `editor.view` is assigned. y-prosemirror's
+    // ySyncPlugin does exactly this to render remote content on first bind.
+    const InitDispatcher = Extension.create({
+      name: 'initDispatcher',
+      addProseMirrorPlugins() {
+        return [
+          new Plugin({
+            view(view) {
+              view.dispatch(view.state.tr.insertText('from plugin view init', 1));
+              return {};
+            },
+          }),
+        ];
+      },
+    });
+
+    it('applies a transaction dispatched while the view is constructed', () => {
+      const element = document.createElement('div');
+      const onTransaction = vi.fn();
+      const onUpdate = vi.fn();
+
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, InitDispatcher],
+        element,
+        content: '',
+        onTransaction,
+        onUpdate,
+      });
+
+      expect(editor.view).toBeDefined();
+      expect(editor.getText()).toBe('from plugin view init');
+
+      // Construction-time transactions are initial state, not updates.
+      expect(onTransaction).not.toHaveBeenCalled();
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      // Dispatch flows through the editor normally once construction is done.
+      editor.view.dispatch(
+        editor.state.tr.insertText(' and more', editor.state.doc.content.size - 1)
+      );
+      expect(onTransaction).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      expect(editor.getText()).toBe('from plugin view init and more');
+      element.remove();
+    });
+  });
+
   describe('getters', () => {
     beforeEach(() => {
       editor = new Editor({

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -199,6 +199,39 @@ describe('Editor', () => {
       },
     });
 
+    it('exposes editor.view to plugin code during construction-time dispatch', () => {
+      // extension-details reads editor.view.composing in appendTransaction,
+      // which runs inside the state.apply of a construction-time dispatch.
+      let sawComposing: boolean | null = null;
+      const ViewReader = Extension.create({
+        name: 'viewReader',
+        addProseMirrorPlugins() {
+          const editor = this.editor as Editor;
+          return [
+            new Plugin({
+              appendTransaction: () => {
+                sawComposing = editor.view.composing;
+                return null;
+              },
+            }),
+            new Plugin({
+              view(view) {
+                view.dispatch(view.state.tr.insertText('boot', 1));
+                return {};
+              },
+            }),
+          ];
+        },
+      });
+
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, ViewReader],
+      });
+
+      expect(sawComposing).toBe(false);
+      expect(editor.getText()).toBe('boot');
+    });
+
     it('applies a transaction dispatched while the view is constructed', () => {
       const element = document.createElement('div');
       const onTransaction = vi.fn();

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -3,6 +3,7 @@ import { Schema } from '@domternal/pm/model';
 import { Plugin, TextSelection } from '@domternal/pm/state';
 import { Editor } from './Editor.js';
 import { Extension } from './Extension.js';
+import { ExtensionConfigurationError } from './ExtensionConfigurationError.js';
 import { Document } from './nodes/Document.js';
 import { Text } from './nodes/Text.js';
 import { Paragraph } from './nodes/Paragraph.js';
@@ -226,6 +227,40 @@ describe('Editor', () => {
       expect(onUpdate).toHaveBeenCalledTimes(1);
       expect(editor.getText()).toBe('from plugin view init and more');
       element.remove();
+    });
+  });
+
+  describe('ExtensionConfigurationError', () => {
+    it('fails editor construction instead of being isolated', () => {
+      const Fatal = Extension.create({
+        name: 'fatal',
+        addProseMirrorPlugins() {
+          throw new ExtensionConfigurationError('fatal is misconfigured');
+        },
+      });
+
+      expect(
+        () =>
+          new Editor({
+            extensions: [Document, Text, Paragraph, Fatal],
+          })
+      ).toThrow('fatal is misconfigured');
+    });
+
+    it('keeps isolating plain errors from the same hook', () => {
+      const Broken = Extension.create({
+        name: 'broken',
+        addProseMirrorPlugins() {
+          throw new Error('broken but not fatal');
+        },
+      });
+
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Broken],
+      });
+
+      expect(editor.isDestroyed).toBe(false);
+      expect(editor.getText()).toBe('');
     });
   });
 

--- a/packages/core/src/Editor.test.ts
+++ b/packages/core/src/Editor.test.ts
@@ -248,6 +248,7 @@ describe('Editor', () => {
     });
 
     it('keeps isolating plain errors from the same hook', () => {
+      const onError = vi.fn();
       const Broken = Extension.create({
         name: 'broken',
         addProseMirrorPlugins() {
@@ -257,10 +258,37 @@ describe('Editor', () => {
 
       editor = new Editor({
         extensions: [Document, Text, Paragraph, Broken],
+        onError,
       });
 
       expect(editor.isDestroyed).toBe(false);
       expect(editor.getText()).toBe('');
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ context: 'broken.addProseMirrorPlugins' })
+      );
+    });
+
+    it('delivers construction-time hook errors to onError', () => {
+      const onError = vi.fn();
+      const BrokenBeforeCreate = Extension.create({
+        name: 'brokenBeforeCreate',
+        onBeforeCreate() {
+          throw new Error('setup failed');
+        },
+      });
+
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, BrokenBeforeCreate],
+        onError,
+      });
+
+      expect(editor.isDestroyed).toBe(false);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: 'brokenBeforeCreate.onBeforeCreate',
+          error: expect.objectContaining({ message: 'setup failed' }),
+        })
+      );
     });
   });
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -758,13 +758,10 @@ export class Editor extends EventEmitter<EditorEvents> {
   }
 
   /**
-   * Builds the dispatchTransaction prop for the EditorView. ProseMirror calls
-   * the prop with the view as `this`, which matters mid-construction: plugin
-   * views can dispatch synchronously inside EditorView's constructor (e.g. a
-   * collaborative binding rendering remote content) before `editor.view` is
-   * assigned. Those early transactions are applied straight to the view, like
-   * ProseMirror's default dispatch, and skip event emission because the
-   * editor is still assembling its initial state.
+   * Builds the dispatchTransaction prop. Plugin views can dispatch synchronously
+   * inside EditorView's constructor, before `editor.view` is assigned; ProseMirror
+   * binds the prop to the view, so those transactions are applied directly (like
+   * the default dispatch) and skip events: they are initial state, not updates.
    */
   private static buildViewDispatch(
     editor: Editor

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -637,6 +637,13 @@ export class Editor extends EventEmitter<EditorEvents> {
    * Creates the editor instance
    */
   private createEditor(): void {
+    // Wire the onError callback before extension setup: extension hook errors
+    // are isolated into 'error' events from step 2 onward (safeCall), and a
+    // listener registered any later misses construction-time errors.
+    this.on('error', (props) => {
+      this.options.onError?.(props);
+    });
+
     // 1. Emit beforeCreate - extensions can modify options in Step 2
     this.emit('beforeCreate', { editor: this });
     this.options.onBeforeCreate?.({ editor: this });
@@ -746,12 +753,7 @@ export class Editor extends EventEmitter<EditorEvents> {
       }, 0);
     }
 
-    // 11. Set up error event handler for onError callback
-    this.on('error', (props) => {
-      this.options.onError?.(props);
-    });
-
-    // 12. Emit create event and call extension onCreate hooks
+    // 11. Emit create event and call extension onCreate hooks
     this.emit('create', { editor: this });
     this.options.onCreate?.({ editor: this });
     this._extensionManager.callOnCreate();

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -697,7 +697,7 @@ export class Editor extends EventEmitter<EditorEvents> {
     const nodeViews = this._extensionManager.nodeViews;
     this.view = new EditorView(element, {
       state,
-      dispatchTransaction: this.dispatchTransaction.bind(this),
+      dispatchTransaction: Editor.buildViewDispatch(this),
       editable: () => this.options.editable ?? true,
       attributes: () => ({
         role: 'textbox',
@@ -755,6 +755,29 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.emit('create', { editor: this });
     this.options.onCreate?.({ editor: this });
     this._extensionManager.callOnCreate();
+  }
+
+  /**
+   * Builds the dispatchTransaction prop for the EditorView. ProseMirror calls
+   * the prop with the view as `this`, which matters mid-construction: plugin
+   * views can dispatch synchronously inside EditorView's constructor (e.g. a
+   * collaborative binding rendering remote content) before `editor.view` is
+   * assigned. Those early transactions are applied straight to the view, like
+   * ProseMirror's default dispatch, and skip event emission because the
+   * editor is still assembling its initial state.
+   */
+  private static buildViewDispatch(
+    editor: Editor
+  ): (transaction: Transaction) => void {
+    return function (this: EditorView, transaction: Transaction): void {
+      // The declared type says `view` is always set; mid-construction it is not.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!editor.view) {
+        this.updateState(this.state.apply(transaction));
+        return;
+      }
+      editor.dispatchTransaction(transaction);
+    };
   }
 
   /**

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -107,6 +107,11 @@ export class Editor extends EventEmitter<EditorEvents> {
   private _autofocusTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
+   * True while EditorView's constructor runs; see buildViewDispatch.
+   */
+  private _isViewConstructing = false;
+
+  /**
    * Creates a new Editor instance
    *
    * @param options - Editor configuration
@@ -702,6 +707,7 @@ export class Editor extends EventEmitter<EditorEvents> {
 
     // 7. Create EditorView
     const nodeViews = this._extensionManager.nodeViews;
+    this._isViewConstructing = true;
     this.view = new EditorView(element, {
       state,
       dispatchTransaction: Editor.buildViewDispatch(this),
@@ -733,6 +739,7 @@ export class Editor extends EventEmitter<EditorEvents> {
         },
       },
     });
+    this._isViewConstructing = false;
 
     // 8. Emit mount event - view is now attached to DOM element
     this.emit('mount', { editor: this, view: this.view });
@@ -762,16 +769,19 @@ export class Editor extends EventEmitter<EditorEvents> {
   /**
    * Builds the dispatchTransaction prop. Plugin views can dispatch synchronously
    * inside EditorView's constructor, before `editor.view` is assigned; ProseMirror
-   * binds the prop to the view, so those transactions are applied directly (like
-   * the default dispatch) and skip events: they are initial state, not updates.
+   * binds the prop to the view, so the instance is captured early (plugin code
+   * such as appendTransaction may read `editor.view` during the apply) and the
+   * transaction is applied directly, like the default dispatch, skipping events:
+   * it is initial state, not an update.
    */
   private static buildViewDispatch(
     editor: Editor
   ): (transaction: Transaction) => void {
     return function (this: EditorView, transaction: Transaction): void {
-      // The declared type says `view` is always set; mid-construction it is not.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!editor.view) {
+      if (editor._isViewConstructing) {
+        // The declared type says `view` is always set; mid-construction it is not.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        editor.view ??= this;
         this.updateState(this.state.apply(transaction));
         return;
       }

--- a/packages/core/src/ExtensionConfigurationError.ts
+++ b/packages/core/src/ExtensionConfigurationError.ts
@@ -1,0 +1,13 @@
+/**
+ * Fatal extension misconfiguration. Extension hook errors are normally
+ * isolated (turned into 'error' events) so one broken extension cannot crash
+ * the editor; this class opts out. Throw it from a creation-time hook when
+ * the extension cannot work at all, and `new Editor(...)` fails loudly
+ * instead of leaving a silently degraded editor running.
+ */
+export class ExtensionConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExtensionConfigurationError';
+  }
+}

--- a/packages/core/src/ExtensionManager.test.ts
+++ b/packages/core/src/ExtensionManager.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { Schema } from '@domternal/pm/model';
 import type { Plugin } from '@domternal/pm/state';
 import { ExtensionManager } from './ExtensionManager.js';
+import { ExtensionConfigurationError } from './ExtensionConfigurationError.js';
 import { Extension } from './Extension.js';
 import { Node } from './Node.js';
 import { Mark } from './Mark.js';
@@ -449,6 +450,23 @@ describe('ExtensionManager', () => {
         error: expect.objectContaining({ message: 'string error' }),
         context: 'test.context',
       });
+    });
+
+    it('rethrows ExtensionConfigurationError instead of isolating it', () => {
+      const emit = vi.fn();
+      const editorWithEmit = {
+        schema: validSchema,
+        emit,
+      };
+
+      const manager = new ExtensionManager({ schema: validSchema }, editorWithEmit);
+
+      expect(() =>
+        manager.safeCall(() => {
+          throw new ExtensionConfigurationError('fatal setup problem');
+        }, 'TestExt.addProseMirrorPlugins')
+      ).toThrow('fatal setup problem');
+      expect(emit).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/ExtensionManager.ts
+++ b/packages/core/src/ExtensionManager.ts
@@ -15,6 +15,7 @@ import type { NodeViewConstructor } from '@domternal/pm/view';
 import { keymap } from '@domternal/pm/keymap';
 import type { InputRule } from '@domternal/pm/inputrules';
 import { inputRulesPlugin as createInputRulesPlugin } from './helpers/inputRulesPlugin.js';
+import { ExtensionConfigurationError } from './ExtensionConfigurationError.js';
 
 import type { Command as PMCommand } from '@domternal/pm/state';
 
@@ -871,6 +872,11 @@ export class ExtensionManager {
 
       return result;
     } catch (error) {
+      // Fatal misconfiguration opts out of isolation, see ExtensionConfigurationError.
+      if (error instanceof ExtensionConfigurationError) {
+        throw error;
+      }
+
       const errorObj = error instanceof Error ? error : new Error(String(error));
 
       // Emit error event (Editor will call onError callback via event listener)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export { PluginKey } from '@domternal/pm/state';
 // === Core classes ===
 export { EventEmitter } from './EventEmitter.js';
 export { Editor } from './Editor.js';
+export { ExtensionConfigurationError } from './ExtensionConfigurationError.js';
 export {
   ExtensionManager,
   type ExtensionManagerOptions,

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -14,6 +14,12 @@ export const DEFAULT_EXTENSIONS: AnyExtension[] = [Document, Paragraph, Text, Ba
 export interface UseEditorOptions {
   /** Custom extensions to add to the editor. */
   extensions?: AnyExtension[];
+  /**
+   * Whether the built-in History extension is included. Disable it when an
+   * extension brings its own undo/redo, such as collaborative editing.
+   * @default true
+   */
+  history?: boolean;
   /** Initial editor content (HTML string or JSON). */
   content?: Content;
   /** Whether the editor is editable. @default true */
@@ -82,6 +88,7 @@ export interface UseEditorResult {
 export function useEditor(options: UseEditorOptions = {}, deps?: DependencyList): UseEditorResult {
   const {
     extensions = [],
+    history = true,
     content = '',
     editable = true,
     autofocus = false,
@@ -134,9 +141,12 @@ export function useEditor(options: UseEditorOptions = {}, deps?: DependencyList)
 
   /** Construct an editor, wire events, and register it in refs. */
   function buildEditorInstance(element: HTMLElement, initialContent: Content, focus: FocusPosition): Editor {
+    const defaults = history
+      ? DEFAULT_EXTENSIONS
+      : DEFAULT_EXTENSIONS.filter((extension) => extension.name !== 'history');
     const ed = new Editor({
       element,
-      extensions: [...DEFAULT_EXTENSIONS, ...extensions],
+      extensions: [...defaults, ...extensions],
       content: initialContent,
       editable,
       autofocus: focus,

--- a/packages/vanilla/src/editor/DomternalEditor.ts
+++ b/packages/vanilla/src/editor/DomternalEditor.ts
@@ -27,6 +27,12 @@ export const DEFAULT_EXTENSIONS: AnyExtension[] = [
 export interface DomternalEditorOptions {
   /** Custom extensions to add. Merged on top of `DEFAULT_EXTENSIONS`. */
   extensions?: AnyExtension[];
+  /**
+   * Whether the built-in History extension is included. Disable it when an
+   * extension brings its own undo/redo, such as collaborative editing.
+   * @default true
+   */
+  history?: boolean;
   /** Initial editor content (HTML string or JSON). */
   content?: Content;
   /** Whether the editor is editable. @default true */
@@ -136,9 +142,12 @@ export class DomternalEditor extends EventTarget {
     this.#onBlur = options.onBlur;
     this.#onDestroy = options.onDestroy;
 
+    const defaults = (options.history ?? true)
+      ? DEFAULT_EXTENSIONS
+      : DEFAULT_EXTENSIONS.filter((extension) => extension.name !== 'history');
     this.editor = new Editor({
       element: host,
-      extensions: [...DEFAULT_EXTENSIONS, ...(options.extensions ?? [])],
+      extensions: [...defaults, ...(options.extensions ?? [])],
       content: options.content ?? '',
       editable: options.editable ?? true,
       autofocus: options.autofocus ?? false,

--- a/packages/vue/src/useEditor.ts
+++ b/packages/vue/src/useEditor.ts
@@ -15,6 +15,12 @@ export const DEFAULT_EXTENSIONS: AnyExtension[] = [Document, Paragraph, Text, Ba
 export interface UseEditorOptions {
   /** Custom extensions to add to the editor. */
   extensions?: AnyExtension[];
+  /**
+   * Whether the built-in History extension is included. Disable it when an
+   * extension brings its own undo/redo, such as collaborative editing.
+   * @default true
+   */
+  history?: boolean;
   /** Initial editor content (HTML string or JSON). */
   content?: Content;
   /** Whether the editor is editable. @default true */
@@ -89,10 +95,13 @@ export function useEditor(options: UseEditorOptions = {}): {
   function createEditorInstance(element: HTMLElement, initialContent: Content, focus: FocusPosition): Editor {
     const extensions = options.extensions ?? [];
     const editable = options.editable ?? true;
+    const defaults = (options.history ?? true)
+      ? DEFAULT_EXTENSIONS
+      : DEFAULT_EXTENSIONS.filter((extension) => extension.name !== 'history');
 
     const ed = new Editor({
       element,
-      extensions: [...DEFAULT_EXTENSIONS, ...extensions],
+      extensions: [...defaults, ...extensions],
       content: initialContent,
       editable,
       autofocus: focus,

--- a/tests/api-surface/snapshots/core.txt
+++ b/tests/api-surface/snapshots/core.txt
@@ -87,6 +87,7 @@ EditorOptions
 EventEmitter
 Extension
 ExtensionConfig
+ExtensionConfigurationError
 ExtensionEditor
 ExtensionManager
 ExtensionManagerEditor


### PR DESCRIPTION
# Summary

Groundwork for third-party collaborative-editing extensions (Yjs-style CRDT), with no
Pro code in this repo. Two capabilities in the free core and the four wrappers, plus two
construction-time robustness fixes.

# Features

- `history` option on all four wrappers (`react`/`vue` `useEditor`, the Angular
  `history` input, vanilla options). Default `true`; set `false` to drop the built-in
  `History` so an extension can own undo/redo (a CRDT undo manager).
- `ExtensionConfigurationError` (new core export): throw it from a creation-time hook to
  fail `new Editor(...)` loudly instead of isolating the error into an `error` event.

# Fix

- Apply transactions dispatched during `EditorView` construction (plugin views seed the
  initial doc there); they were previously dropped.
- Expose `editor.view` to plugin code during that dispatch (was `undefined`).
- Wire `onError` before extension setup so construction-time hook errors reach it.

# Changes

- Ignore `.angular/` at the repo root; refresh the core api-surface snapshot.

# Verified

- api-surface check, `packages/core` typecheck, and `packages/core` tests pass (2549
  passed, new cases for construction-time dispatch and `ExtensionConfigurationError`).