### PR TITLE
feat(core): lead the Notion-mode bubble menu with the Ask AI item

### DIFF
--- a/packages/core/src/utils/defaultBubbleContexts.test.ts
+++ b/packages/core/src/utils/defaultBubbleContexts.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Document } from '../nodes/Document.js';
+import { Text } from '../nodes/Text.js';
+import { Paragraph } from '../nodes/Paragraph.js';
+import { Editor } from '../Editor.js';
+import { defaultBubbleContexts } from './defaultBubbleContexts.js';
+
+describe('defaultBubbleContexts', () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+  });
+
+  function makeEditor(): Editor {
+    return new Editor({ extensions: [Document, Text, Paragraph], content: '<p>hi</p>' });
+  }
+
+  it('returns the minimal formatting set outside Notion mode', () => {
+    editor = makeEditor();
+    expect(defaultBubbleContexts(editor)['text']).toEqual([
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'code',
+      'mathInline',
+      '|',
+      'link',
+    ]);
+  });
+
+  it('leads the Notion-mode selection menu with ai, then link and textAlign', () => {
+    editor = makeEditor();
+    editor.view.dom.classList.add('dm-notion-mode');
+    const text = defaultBubbleContexts(editor)['text'] ?? [];
+    expect(text[0]).toBe('ai'); // "Ask AI" first
+    expect(text[1]).toBe('|'); // leading separator, collapses when ai is absent
+    expect(text).toContain('textAlign');
+  });
+
+  it('returns a fresh array each call (safe to mutate)', () => {
+    editor = makeEditor();
+    const a = defaultBubbleContexts(editor)['text'];
+    const b = defaultBubbleContexts(editor)['text'];
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/core/src/utils/defaultBubbleContexts.ts
+++ b/packages/core/src/utils/defaultBubbleContexts.ts
@@ -7,7 +7,10 @@ const NOTION_MODE_CLASS = 'dm-notion-mode';
 // selection-context equation), and is silently skipped when the extension is not
 // loaded (the bubble menu resolves names against the editor's actual items).
 const NOTION_TEXT_CONTEXT: readonly string[] = Object.freeze([
-  'bold', 'italic', 'underline', 'strike', 'code', 'mathInline',
+  // `ai` leads (Notion's "Ask AI"); skipped with its leading separator when
+  // the pro extension is absent, exactly like `mathInline`.
+  'ai',
+  '|', 'bold', 'italic', 'underline', 'strike', 'code', 'mathInline',
   '|', 'link',
   '|', 'textAlign',
 ]);
@@ -22,7 +25,8 @@ const STANDARD_TEXT_CONTEXT: readonly string[] = Object.freeze([
  * supplied one. Returns a richer item set when the editor (or any
  * ancestor) carries the `.dm-notion-mode` class - that class is the
  * project-wide signal that the host is rendering Notion-style UX, so
- * the bubble menu mirrors it by including `link` and `textAlign`.
+ * the bubble menu mirrors it by leading with `ai` and including `link`
+ * and `textAlign`.
  *
  * Consumers can always override by passing their own `contexts` prop.
  */


### PR DESCRIPTION
# Summary

In Notion mode, the default text-selection bubble menu now leads with the "Ask AI" item, matching the AI assistant's Notion-parity behavior. The `ai` entry (and its leading separator) is silently skipped when the Pro AI extension is not loaded, so the free build's menu is unchanged. Consumers that pass their own `contexts` prop are unaffected; only the built-in default changes.

# Features

- When the editor (or an ancestor) carries the `.dm-notion-mode` class, `defaultBubbleContexts` now returns a `text` context that starts with `ai` followed by a separator, so "Ask AI" is the first action on a text selection, exactly like Notion.
- The bubble menu resolves item names against the editor's actual registered items, so when the AI extension is absent the `ai` entry and its leading `|` collapse away, the same way `mathInline` already does. The standard (non-Notion) menu is untouched.

# Changes

- Updated the `defaultBubbleContexts` doc comment to note that the Notion menu now leads with `ai`.

# Verified

- New unit tests for `defaultBubbleContexts`: the set outside Notion mode is unchanged, the Notion-mode set leads with `ai` then the separator and still includes `textAlign`, and each call returns a fresh (safe-to-mutate) array.
- `packages/core`: unit tests pass, typecheck clean, lint clean on the changed files.