### PR TITLE
fix(extension-emoji): convert consecutive emoticons by keeping the trailing space and treating an atom as a leading boundary

### DIFF
--- a/e2e/emoji-emoticons.spec.ts
+++ b/e2e/emoji-emoticons.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Emoticon input-rule behavior across all four demos.
+ *
+ * Regression coverage for a reported bug: typing several emoticons in a row
+ * (e.g. "xD xD", ":) :)") left every other emoticon un-converted as literal
+ * text, producing an alternating "emoji, raw emoticon, emoji, raw emoticon"
+ * result.
+ *
+ * Two coupled defects caused it (both fixed in packages/extension-emoji):
+ *
+ *   1. The emoticon rule swallowed the space that triggered it. handleTextInput
+ *      returning a transaction suppresses the default space insertion and the
+ *      rule replaced only the emoticon glyphs, so "xD " became an emoji glued
+ *      to the cursor with no trailing space.
+ *
+ *   2. The emoticon pattern only allowed start-of-text or whitespace before the
+ *      emoticon. In the input-rule textBefore an atom node (emoji/mention/
+ *      image/inline-math) is the object-replacement char, which is neither, so
+ *      an emoticon typed immediately after an atom never converted.
+ *
+ * (1) glued the next emoticon to the emoji atom and (2) then blocked it. The
+ * fix keeps the trailing space and lets an atom act as a leading boundary.
+ *
+ * The controls at the end pin behavior that must NOT change (no trailing space
+ * -> no conversion, mid-word -> no conversion, code block -> no conversion,
+ * shortcodes unaffected).
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+async function goNotion(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
+}
+
+async function setContent(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { setContent: (h: string, emit: boolean) => void; commands: { focus: (pos?: string) => void } }
+      | undefined;
+    ed?.setContent(h, false);
+    ed?.commands.focus('end');
+  }, html);
+  await page.waitForTimeout(120);
+}
+
+async function focusEnd(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { commands: { focus: (pos?: string) => void } }
+      | undefined;
+    ed?.commands.focus('end');
+  });
+}
+
+/** Reset to an empty paragraph, then type char-by-char so each keystroke fires its own input event. */
+async function typeFresh(page: Page, target: DemoTarget, text: string): Promise<void> {
+  await setContent(page, '<p></p>');
+  await page.click(target.editorSelector);
+  await focusEnd(page);
+  await page.keyboard.type(text, { delay: 25 });
+  await page.waitForTimeout(200);
+}
+
+/** Flatten the first paragraph into a token stream of emoji names and raw text runs. */
+async function firstParaTokens(page: Page): Promise<Array<{ type: string; value: string }>> {
+  return page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { getJSON: () => { content?: Array<{ type: string; content?: Array<Record<string, unknown>> }> } }
+      | undefined;
+    const json = ed?.getJSON();
+    const para = json?.content?.find((n) => n.type === 'paragraph');
+    return (para?.content ?? []).map((n) => {
+      const node = n as { type: string; text?: string; attrs?: { name?: string } };
+      if (node.type === 'emoji') return { type: 'emoji', value: node.attrs?.name ?? '' };
+      if (node.type === 'text') return { type: 'text', value: node.text ?? '' };
+      return { type: node.type, value: '' };
+    });
+  });
+}
+
+function emojiSel(target: DemoTarget): string {
+  return `${target.editorSelector} span[data-type="emoji"]`;
+}
+
+async function firstParaText(page: Page, target: DemoTarget): Promise<string> {
+  return (await page.locator(`${target.editorSelector} p`).first().textContent()) ?? '';
+}
+
+for (const target of demoTargets) {
+  test.describe(`${target.name} - emoji emoticons`, () => {
+    test.beforeEach(async ({ page }) => {
+      await goNotion(page, target);
+    });
+
+    // ── The fix: sequences and trailing space ────────────────────────────────
+
+    test('a lone emoticon converts and keeps its trailing space', async ({ page }) => {
+      await typeFresh(page, target, 'xD ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(1);
+      await expect(page.locator(emojiSel(target)).first()).toHaveAttribute(
+        'data-name',
+        'face_with_tears_of_joy',
+      );
+      const tokens = await firstParaTokens(page);
+      expect(tokens.map((t) => t.type)).toEqual(['emoji', 'text']);
+      expect(tokens[1]?.value).toBe(' ');
+    });
+
+    test('two emoticons in a row both convert', async ({ page }) => {
+      await typeFresh(page, target, 'xD xD ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(2);
+      expect(await firstParaText(page, target)).not.toContain('xD');
+    });
+
+    test('three emoticons in a row all convert', async ({ page }) => {
+      await typeFresh(page, target, ':) :) :) ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(3);
+      expect(await firstParaText(page, target)).not.toContain(':)');
+    });
+
+    test('a mixed run converts every emoticon and leaves non-emoticon words alone', async ({ page }) => {
+      await typeFresh(page, target, 'xD xD lol :) ');
+      // xD, xD, :) convert; "lol" is not an emoticon and stays as text.
+      await expect(page.locator(emojiSel(target))).toHaveCount(3);
+      const text = await firstParaText(page, target);
+      expect(text).toContain('lol');
+      expect(text).not.toContain('xD');
+      expect(text).not.toContain(':)');
+    });
+
+    test('an emoticon typed right after an emoji atom converts', async ({ page }) => {
+      // Emoji atom set via HTML, cursor placed directly after it (no space).
+      await setContent(page, '<p><span data-type="emoji" data-name="red_heart">❤️</span></p>');
+      await page.click(target.editorSelector);
+      await focusEnd(page);
+      await page.keyboard.type('xD ', { delay: 25 });
+      await page.waitForTimeout(200);
+
+      await expect(page.locator(emojiSel(target))).toHaveCount(2);
+      await expect(page.locator(emojiSel(target)).nth(0)).toHaveAttribute('data-name', 'red_heart');
+      await expect(page.locator(emojiSel(target)).nth(1)).toHaveAttribute(
+        'data-name',
+        'face_with_tears_of_joy',
+      );
+      expect(await firstParaText(page, target)).not.toContain('xD');
+    });
+
+    test('multi-character emoticons convert', async ({ page }) => {
+      const cases: Array<[string, string]> = [
+        ['>:( ', 'angry_face'],
+        [":'( ", 'crying_face'],
+        [':-) ', 'slightly_smiling_face'],
+      ];
+      for (const [typed, name] of cases) {
+        await typeFresh(page, target, typed);
+        await expect(page.locator(emojiSel(target))).toHaveCount(1);
+        await expect(page.locator(emojiSel(target)).first()).toHaveAttribute('data-name', name);
+      }
+    });
+
+    test('emoticon after text and a space converts', async ({ page }) => {
+      await typeFresh(page, target, 'hi :) ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(1);
+      const text = await firstParaText(page, target);
+      expect(text).toContain('hi');
+      expect(text).not.toContain(':)');
+    });
+
+    test('Backspace right after conversion restores the typed emoticon', async ({ page }) => {
+      await typeFresh(page, target, 'xD ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(1);
+      await page.keyboard.press('Backspace');
+      await page.waitForTimeout(150);
+      await expect(page.locator(emojiSel(target))).toHaveCount(0);
+      expect(await firstParaText(page, target)).toContain('xD');
+    });
+
+    // ── Controls: behavior that must NOT change ──────────────────────────────
+
+    test('an emoticon without a trailing space does not convert', async ({ page }) => {
+      await typeFresh(page, target, ':)');
+      await expect(page.locator(emojiSel(target))).toHaveCount(0);
+      expect(await firstParaText(page, target)).toContain(':)');
+    });
+
+    test('an emoticon glued to a letter (mid-word) does not convert', async ({ page }) => {
+      await typeFresh(page, target, 'haxD ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(0);
+      expect(await firstParaText(page, target)).toContain('xD');
+    });
+
+    test('an emoticon inside a code block stays literal', async ({ page }) => {
+      await setContent(page, '<pre><code>x</code></pre>');
+      await page.locator(`${target.editorSelector} pre code`).click();
+      await page.keyboard.press('End');
+      await page.keyboard.type(':) ', { delay: 25 });
+      await page.waitForTimeout(200);
+      await expect(page.locator(emojiSel(target))).toHaveCount(0);
+      expect(await page.locator(`${target.editorSelector} pre code`).textContent()).toContain(':)');
+    });
+
+    test('two shortcodes in a row still both convert (no regression)', async ({ page }) => {
+      await typeFresh(page, target, ':wave: :wave: ');
+      await expect(page.locator(emojiSel(target))).toHaveCount(2);
+    });
+  });
+}

--- a/packages/extension-emoji/src/Emoji.test.ts
+++ b/packages/extension-emoji/src/Emoji.test.ts
@@ -844,6 +844,114 @@ describe('input rules', () => {
   });
 });
 
+describe('emoticon input rule behavior (integration)', () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    if (editor && !editor.isDestroyed) editor.destroy();
+  });
+
+  const EmoticonEmoji = Emoji.configure({ enableEmoticons: true });
+
+  /** Type text char-by-char through the real handleTextInput / input-rule pipeline. */
+  function typeText(ed: Editor, text: string): void {
+    for (const ch of text) {
+      const { from, to } = ed.state.selection;
+      const handled = ed.view.someProp('handleTextInput', (f) =>
+        (f as (v: unknown, a: number, b: number, t: string) => boolean)(ed.view, from, to, ch),
+      );
+      if (!handled) {
+        ed.view.dispatch(ed.state.tr.insertText(ch, from, to));
+      }
+    }
+  }
+
+  /** Names of emoji nodes in document order. */
+  function emojiNames(ed: Editor): string[] {
+    const names: string[] = [];
+    ed.state.doc.descendants((node) => {
+      if (node.type.name === 'emoji') names.push(node.attrs['name'] as string);
+    });
+    return names;
+  }
+
+  function makeEditor(content: string): Editor {
+    const ed = new Editor({
+      extensions: [Document, Text, Paragraph, EmoticonEmoji],
+      content,
+    });
+    ed.view.dispatch(ed.state.tr.setSelection(TextSelection.atEnd(ed.state.doc)));
+    return ed;
+  }
+
+  // Defect 1: the converted emoticon must keep the space that triggered it.
+  it('a converted emoticon keeps its trailing space', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, 'xD ');
+    const para = editor.state.doc.child(0);
+    expect(para.childCount).toBe(2);
+    expect(para.child(0).type.name).toBe('emoji');
+    expect(para.child(0).attrs['name']).toBe('face_with_tears_of_joy');
+    expect(para.child(1).isText).toBe(true);
+    expect(para.child(1).text).toBe(' ');
+  });
+
+  // The reported bug: consecutive emoticons must all convert, none left as text.
+  it('two emoticons in a row both convert', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, 'xD xD ');
+    expect(emojiNames(editor)).toEqual([
+      'face_with_tears_of_joy',
+      'face_with_tears_of_joy',
+    ]);
+    expect(editor.getText()).not.toContain('xD');
+  });
+
+  it('three emoticons in a row all convert', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, ':) :) :) ');
+    expect(emojiNames(editor)).toEqual([
+      'slightly_smiling_face',
+      'slightly_smiling_face',
+      'slightly_smiling_face',
+    ]);
+    expect(editor.getText()).not.toContain(':)');
+  });
+
+  // Defect 2: an emoticon typed right after an atom (no space) must convert.
+  it('an emoticon typed right after an emoji atom converts', () => {
+    editor = makeEditor('<p><span data-type="emoji" data-name="red_heart">❤️</span></p>');
+    typeText(editor, 'xD ');
+    expect(emojiNames(editor)).toEqual(['red_heart', 'face_with_tears_of_joy']);
+    expect(editor.getText()).not.toContain('xD');
+  });
+
+  it('a non-emoticon word between emoticons stays as text', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, 'xD lol :) ');
+    expect(emojiNames(editor)).toEqual([
+      'face_with_tears_of_joy',
+      'slightly_smiling_face',
+    ]);
+    expect(editor.getText()).toContain('lol');
+  });
+
+  // Controls: behavior that must NOT change.
+  it('an emoticon without a trailing space does not convert', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, ':)');
+    expect(emojiNames(editor)).toEqual([]);
+    expect(editor.getText()).toContain(':)');
+  });
+
+  it('an emoticon glued to a letter (mid-word) does not convert', () => {
+    editor = makeEditor('<p></p>');
+    typeText(editor, 'haxD ');
+    expect(emojiNames(editor)).toEqual([]);
+    expect(editor.getText()).toContain('xD');
+  });
+});
+
 describe('default storage stubs (addStorage)', () => {
   it('default getFrequentlyUsed returns empty array before onCreate', () => {
     const storage = Emoji.config.addStorage?.call(Emoji) as any;

--- a/packages/extension-emoji/src/Emoji.ts
+++ b/packages/extension-emoji/src/Emoji.ts
@@ -321,8 +321,12 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
         const item = nameMap.get(emojiName);
         if (!item) continue;
 
-        // Match emoticon preceded by space or start of text, followed by space
-        const pattern = new RegExp(`(?:^|\\s)(${escapeRegex(emoticon)})\\s$`);
+        // Match an emoticon that ends the input (the trailing space triggers it)
+        // preceded by start-of-text, whitespace, or an atom node. The atom case
+        // matters because inputRulesPlugin renders leaf/atom nodes as the
+        // object-replacement char ￼ in textBefore; without it an emoticon
+        // typed right after an emoji (or mention/image) would never convert.
+        const pattern = new RegExp(`(?:^|[\\s\\ufffc])(${escapeRegex(emoticon)})\\s$`);
 
         rules.push(
           new InputRule(
@@ -336,7 +340,8 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
 
               const { tr } = state;
 
-              // Calculate the actual emoticon position (after the optional leading space)
+              // Locate the emoticon glyphs, skipping the optional leading
+              // boundary char (space or atom placeholder) the pattern matched.
               const fullMatch = match[0];
               const emoticonText = match[1];
               if (!emoticonText) return null;
@@ -344,11 +349,15 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
               const emoticonStart = start + fullMatch.indexOf(emoticonText);
               const emoticonEnd = emoticonStart + emoticonText.length;
 
+              // Replace the emoticon with the emoji AND re-add the trailing space
+              // that triggered the rule. handleTextInput suppresses the default
+              // space insertion, so without this the next emoticon would sit
+              // flush against this emoji atom and fail to convert.
               if (plainText) {
-                tr.replaceWith(emoticonStart, emoticonEnd, state.schema.text(item.emoji));
+                tr.replaceWith(emoticonStart, emoticonEnd, state.schema.text(`${item.emoji} `));
               } else if (nodeType) {
                 const node = nodeType.create({ name: item.name });
-                tr.replaceWith(emoticonStart, emoticonEnd, node);
+                tr.replaceWith(emoticonStart, emoticonEnd, [node, state.schema.text(' ')]);
               } else {
                 return null;
               }


### PR DESCRIPTION
# Summary

Typing emoticons in a row (`xD xD xD`, `:) :) :)`) converted only every other
one; the rest stayed as literal text.

# Fix

The emoticon input rule had two coupled bugs (`packages/extension-emoji/src/Emoji.ts`):

1. It swallowed the triggering space, gluing the emoji to the next emoticon. Now
   it re-inserts the space (`[emojiNode, " "]`).
2. Its pattern rejected anything but whitespace/start before the emoticon, so an
   emoticon after an atom (emoji/mention/image) never matched. Now the atom
   placeholder counts as a boundary (`(?:^|[\s\ufffc])`).

# Verified

Unit tests and the new `e2e/emoji-emoticons.spec.ts` matrix pass against all four
demos (vanilla, react, vue, angular); typecheck and build clean.
