### PR TITLE
fix(core): shrink slash, emoji, and mention menus to the available viewport space instead of flipping over content

### DIFF
--- a/e2e/suggestion-available-height.spec.ts
+++ b/e2e/suggestion-available-height.spec.ts
@@ -5,16 +5,8 @@
  * Regression coverage for a reported bug: with less than its full CSS
  * max-height free below the caret, a menu flipped fully above the caret even
  * when there was plenty of room for a scrollable menu, covering the content
- * above (on the docs site it escaped the demo box over the page chrome).
- *
- * The fix (packages/core positionFloating.ts + theme): an opt-in `size`
- * middleware runs BEFORE `flip` and writes the available space to the
- * `--dm-available-height` CSS custom property, which the theme consumes via
- * `max-height: min(22rem, var(--dm-available-height, 100vh))`. The menu now
- * stays below the caret and scrolls internally while at least 160px fit
- * there; only under that minimum does it flip above, capped to the space
- * above. The emoji and mention dropdowns additionally became scrollable
- * (they previously had no max-height at all) with keyboard scroll-follow.
+ * above. Menus must shrink and scroll below the caret while at least 160px
+ * fit there, and flip above only under that minimum.
  *
  * Geometry used by the tests (viewport 800px tall, offset 4, padding 10):
  *   caret ~200  -> ~580px below: full-height menu below, internal scroll

--- a/e2e/suggestion-available-height.spec.ts
+++ b/e2e/suggestion-available-height.spec.ts
@@ -1,0 +1,290 @@
+/**
+ * Shrink-to-fit behavior of the caret-anchored suggestion menus (slash
+ * command, emoji, mention) across all four demos.
+ *
+ * Regression coverage for a reported bug: with less than its full CSS
+ * max-height free below the caret, a menu flipped fully above the caret even
+ * when there was plenty of room for a scrollable menu, covering the content
+ * above (on the docs site it escaped the demo box over the page chrome).
+ *
+ * The fix (packages/core positionFloating.ts + theme): an opt-in `size`
+ * middleware runs BEFORE `flip` and writes the available space to the
+ * `--dm-available-height` CSS custom property, which the theme consumes via
+ * `max-height: min(22rem, var(--dm-available-height, 100vh))`. The menu now
+ * stays below the caret and scrolls internally while at least 160px fit
+ * there; only under that minimum does it flip above, capped to the space
+ * above. The emoji and mention dropdowns additionally became scrollable
+ * (they previously had no max-height at all) with keyboard scroll-follow.
+ *
+ * Geometry used by the tests (viewport 800px tall, offset 4, padding 10):
+ *   caret ~200  -> ~580px below: full-height menu below, internal scroll
+ *   caret ~520  -> ~250px below: menu stays below, shrunk, scrolls
+ *   caret ~700  ->  ~80px below (< 160 minimum): menu flips above the caret
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+async function goNotion(page: Page, target: DemoTarget): Promise<void> {
+  await page.setViewportSize(VIEWPORT);
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
+}
+
+/** Fill the editor with enough empty paragraphs that the caret can be scrolled anywhere. */
+async function fillAndFocusEnd(page: Page, target: DemoTarget): Promise<void> {
+  await page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { setContent: (h: string, emit: boolean) => void; commands: { focus: (pos?: string) => void } }
+      | undefined;
+    ed?.setContent('<p></p>'.repeat(60), false);
+    ed?.commands.focus('end');
+  });
+  await page.click(target.editorSelector);
+  await page.evaluate(() => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { commands: { focus: (pos?: string) => void } }
+      | undefined;
+    ed?.commands.focus('end');
+  });
+  await page.waitForTimeout(150);
+}
+
+/**
+ * Scrolls so the caret sits at the given viewport y. Tries the window first,
+ * then the nearest scrollable ancestor (framework demos differ in which one
+ * actually scrolls). Returns the final caret top.
+ */
+async function placeCaretAt(page: Page, targetTop: number): Promise<number | null> {
+  const top = await page.evaluate((t) => {
+    function caretTop(): number | null {
+      const sel = window.getSelection();
+      if (!sel || !sel.rangeCount) return null;
+      let r: DOMRect | undefined = sel.getRangeAt(0).getClientRects()[0];
+      if (!r) {
+        const n = sel.focusNode;
+        const el = n instanceof Element ? n : n?.parentElement;
+        if (el) r = el.getBoundingClientRect();
+      }
+      return r ? r.top : null;
+    }
+    let top = caretTop();
+    if (top == null) return null;
+    window.scrollBy(0, top - t);
+    top = caretTop();
+    if (top != null && Math.abs(top - t) > 8) {
+      const sel = window.getSelection();
+      const n = sel?.focusNode;
+      let el: Element | null = n instanceof Element ? n : n?.parentElement ?? null;
+      while (el && el !== document.body) {
+        if (el.scrollHeight > el.clientHeight + 4) {
+          el.scrollTop += (caretTop() ?? t) - t;
+          break;
+        }
+        el = el.parentElement;
+      }
+      top = caretTop();
+    }
+    return top;
+  }, targetTop);
+  await page.waitForTimeout(250);
+  return top;
+}
+
+interface MenuBox {
+  top: number;
+  bottom: number;
+  height: number;
+  caretTop: number;
+  caretBottom: number;
+  side: 'below' | 'above' | 'overlap';
+  scrollable: boolean;
+  scrollTop: number;
+  availVar: string;
+}
+
+async function menuBox(page: Page, menuSelector: string): Promise<MenuBox | null> {
+  return page.evaluate((sel) => {
+    const menu = document.querySelector(sel);
+    if (!menu) return null;
+    const s = window.getSelection();
+    let cr: DOMRect | undefined = s && s.rangeCount ? s.getRangeAt(0).getClientRects()[0] : undefined;
+    if (!cr) {
+      const n = s?.focusNode;
+      const el = n instanceof Element ? n : n?.parentElement;
+      if (el) cr = el.getBoundingClientRect();
+    }
+    if (!cr) return null;
+    const r = menu.getBoundingClientRect();
+    return {
+      top: Math.round(r.top),
+      bottom: Math.round(r.bottom),
+      height: Math.round(r.height),
+      caretTop: Math.round(cr.top),
+      caretBottom: Math.round(cr.bottom),
+      side: (r.top >= cr.bottom ? 'below' : r.bottom <= cr.top + 1 ? 'above' : 'overlap') as
+        | 'below'
+        | 'above'
+        | 'overlap',
+      scrollable: menu.scrollHeight > menu.clientHeight,
+      scrollTop: menu.scrollTop,
+      availVar: (menu as HTMLElement).style.getPropertyValue('--dm-available-height'),
+    };
+  }, menuSelector);
+}
+
+/** Rect of the highlighted item, for keyboard scroll-follow assertions. */
+async function selectedItemVisible(
+  page: Page,
+  menuSelector: string,
+  selectedSelector: string,
+): Promise<{ visible: boolean; scrollTop: number } | null> {
+  return page.evaluate(
+    ({ menuSel, selSel }) => {
+      const menu = document.querySelector(menuSel);
+      const item = menu?.querySelector(selSel);
+      if (!menu || !item) return null;
+      const m = menu.getBoundingClientRect();
+      const s = item.getBoundingClientRect();
+      return {
+        visible: s.top >= m.top - 1 && s.bottom <= m.bottom + 1,
+        scrollTop: menu.scrollTop,
+      };
+    },
+    { menuSel: menuSelector, selSel: selectedSelector },
+  );
+}
+
+async function openMenuAt(
+  page: Page,
+  target: DemoTarget,
+  caretY: number,
+  trigger: string,
+): Promise<void> {
+  await fillAndFocusEnd(page, target);
+  const top = await placeCaretAt(page, caretY);
+  expect(top, `caret should sit near y=${String(caretY)}`).not.toBeNull();
+  expect(Math.abs((top ?? 0) - caretY)).toBeLessThanOrEqual(60);
+  await page.keyboard.type(trigger, { delay: 40 });
+  await page.waitForTimeout(350);
+}
+
+for (const target of demoTargets) {
+  test.describe(`${target.name}: suggestion menu available height`, () => {
+    test.beforeEach(async ({ page }) => {
+      await goNotion(page, target);
+    });
+
+    // ── Slash command menu ──────────────────────────────────────────────
+
+    test('slash menu opens below at full height with room to spare', async ({ page }) => {
+      await openMenuAt(page, target, 200, '/');
+      const box = await menuBox(page, '.dm-slash-command-menu');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('below');
+      // Full 22rem cap (352px border-box), NOT expanded to the larger
+      // available space: the inline variable must not lift the design cap.
+      expect(box?.height).toBeGreaterThanOrEqual(340);
+      expect(box?.height).toBeLessThanOrEqual(364);
+      expect(box?.scrollable).toBe(true);
+      expect(box?.bottom).toBeLessThanOrEqual(VIEWPORT.height);
+      expect(box?.availVar).not.toBe('');
+    });
+
+    test('slash menu shrinks and scrolls below the caret instead of flipping', async ({ page }) => {
+      await openMenuAt(page, target, 520, '/');
+      const box = await menuBox(page, '.dm-slash-command-menu');
+      expect(box).not.toBeNull();
+      // The reported bug: this used to flip fully above the caret.
+      expect(box?.side).toBe('below');
+      expect(box?.height).toBeLessThan(340);
+      expect(box?.height).toBeGreaterThanOrEqual(160);
+      expect(box?.scrollable).toBe(true);
+      expect(box?.bottom).toBeLessThanOrEqual(VIEWPORT.height);
+    });
+
+    test('slash menu flips above the caret only when below-space is under the minimum', async ({ page }) => {
+      await openMenuAt(page, target, 700, '/');
+      const box = await menuBox(page, '.dm-slash-command-menu');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('above');
+      expect(box?.bottom).toBeLessThanOrEqual(box?.caretTop ?? 0);
+      expect(box?.top).toBeGreaterThanOrEqual(0);
+      expect(box?.height).toBeGreaterThanOrEqual(160);
+    });
+
+    test('keyboard selection stays visible inside the shrunken slash menu', async ({ page }) => {
+      await openMenuAt(page, target, 520, '/');
+      for (let i = 0; i < 12; i++) await page.keyboard.press('ArrowDown');
+      await page.waitForTimeout(150);
+      const sel = await selectedItemVisible(page, '.dm-slash-command-menu', '[data-selected]');
+      expect(sel).not.toBeNull();
+      expect(sel?.visible).toBe(true);
+      expect(sel?.scrollTop).toBeGreaterThan(0);
+    });
+
+    // ── Emoji suggestions ───────────────────────────────────────────────
+
+    test('emoji suggestions shrink and scroll below the caret instead of flipping', async ({ page }) => {
+      await openMenuAt(page, target, 560, ':s');
+      const box = await menuBox(page, '.dm-emoji-suggestion');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('below');
+      // Previously this dropdown had no max-height at all and could not
+      // scroll; now it shrinks into the space and scrolls.
+      expect(box?.scrollable).toBe(true);
+      expect(box?.bottom).toBeLessThanOrEqual(VIEWPORT.height);
+      expect(box?.availVar).not.toBe('');
+    });
+
+    test('emoji suggestions flip above the caret when below-space is under the minimum', async ({ page }) => {
+      await openMenuAt(page, target, 700, ':s');
+      const box = await menuBox(page, '.dm-emoji-suggestion');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('above');
+      expect(box?.bottom).toBeLessThanOrEqual(box?.caretTop ?? 0);
+      expect(box?.top).toBeGreaterThanOrEqual(0);
+    });
+
+    test('keyboard selection stays visible inside the scrolled emoji list', async ({ page }) => {
+      await openMenuAt(page, target, 560, ':s');
+      for (let i = 0; i < 9; i++) await page.keyboard.press('ArrowDown');
+      await page.waitForTimeout(150);
+      const sel = await selectedItemVisible(
+        page,
+        '.dm-emoji-suggestion',
+        '.dm-emoji-suggestion-item--selected',
+      );
+      expect(sel).not.toBeNull();
+      expect(sel?.visible).toBe(true);
+      expect(sel?.scrollTop).toBeGreaterThan(0);
+    });
+
+    // ── Mention suggestions ─────────────────────────────────────────────
+
+    test('mention suggestions stay below the caret when they fit', async ({ page }) => {
+      await openMenuAt(page, target, 400, '@');
+      const box = await menuBox(page, '.dm-mention-suggestion');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('below');
+      expect(box?.bottom).toBeLessThanOrEqual(VIEWPORT.height);
+    });
+
+    test('mention suggestions flip above the caret when below-space is under the minimum', async ({ page }) => {
+      await openMenuAt(page, target, 700, '@');
+      const box = await menuBox(page, '.dm-mention-suggestion');
+      expect(box).not.toBeNull();
+      expect(box?.side).toBe('above');
+      expect(box?.bottom).toBeLessThanOrEqual(box?.caretTop ?? 0);
+      expect(box?.top).toBeGreaterThanOrEqual(0);
+    });
+  });
+}

--- a/packages/core/src/utils/positionFloating.test.ts
+++ b/packages/core/src/utils/positionFloating.test.ts
@@ -124,3 +124,89 @@ describe('positionFloatingOnce', () => {
     expect(cleanup).toBeDefined();
   });
 });
+
+describe('constrainHeight', () => {
+  let reference: HTMLElement;
+  let floating: HTMLElement;
+  let cleanup: (() => void) | null = null;
+
+  // computePosition resolves through microtasks; one macrotask settles it.
+  const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 25));
+
+  beforeEach(() => {
+    reference = document.createElement('div');
+    reference.getBoundingClientRect = () => new DOMRect(100, 100, 50, 30);
+    document.body.appendChild(reference);
+
+    floating = document.createElement('div');
+    floating.style.position = 'absolute';
+    document.body.appendChild(floating);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+    reference.remove();
+    floating.remove();
+  });
+
+  it('leaves --dm-available-height unset without the option', async () => {
+    cleanup = positionFloatingOnce(reference, floating);
+    await settle();
+    expect(floating.style.getPropertyValue('--dm-available-height')).toBe('');
+  });
+
+  it('writes --dm-available-height honoring the minHeight floor', async () => {
+    cleanup = positionFloatingOnce(reference, floating, {
+      placement: 'bottom-start',
+      constrainHeight: { minHeight: 160 },
+    });
+    await settle();
+    const value = floating.style.getPropertyValue('--dm-available-height');
+    expect(value).toMatch(/^\d+px$/);
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(160);
+  });
+
+  it('supports placements without an alignment', async () => {
+    cleanup = positionFloatingOnce(reference, floating, {
+      placement: 'bottom',
+      constrainHeight: { minHeight: 120 },
+    });
+    await settle();
+    const value = floating.style.getPropertyValue('--dm-available-height');
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(120);
+  });
+
+  it('supports top placements', async () => {
+    cleanup = positionFloatingOnce(reference, floating, {
+      placement: 'top-start',
+      constrainHeight: { minHeight: 100 },
+    });
+    await settle();
+    const value = floating.style.getPropertyValue('--dm-available-height');
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(100);
+  });
+
+  it('works with the fixed-strategy positionFloating as well', async () => {
+    floating.style.position = 'fixed';
+    cleanup = positionFloating(reference, floating, {
+      constrainHeight: { minHeight: 160 },
+    });
+    await settle();
+    const value = floating.style.getPropertyValue('--dm-available-height');
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(160);
+  });
+
+  it('respects a custom boundary element', async () => {
+    const boundary = document.createElement('div');
+    document.body.appendChild(boundary);
+    cleanup = positionFloatingOnce(reference, floating, {
+      boundary,
+      constrainHeight: { minHeight: 140 },
+    });
+    await settle();
+    const value = floating.style.getPropertyValue('--dm-available-height');
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(140);
+    boundary.remove();
+  });
+});

--- a/packages/core/src/utils/positionFloating.ts
+++ b/packages/core/src/utils/positionFloating.ts
@@ -9,8 +9,10 @@ import {
   flip,
   shift,
   offset,
+  size,
   hide,
   autoUpdate,
+  type Middleware,
   type Placement,
 } from '@floating-ui/dom';
 
@@ -31,6 +33,83 @@ export interface PositionFloatingOptions {
    * otherwise cover app chrome above the editor) pass the wrapper here.
    */
   boundary?: Element;
+  /**
+   * Shrink-to-fit for vertical placements. When set, the vertical space
+   * available to the floating element (in px) is written to the
+   * `--dm-available-height` CSS custom property on the element, and the
+   * stylesheet opts in with e.g.
+   * `max-height: min(22rem, var(--dm-available-height, 100vh))`.
+   * The element then stays on the preferred side and scrolls internally
+   * while at least `minHeight` px fit there; only below that threshold does
+   * it flip to the opposite side, where the same cap applies. Give the
+   * element `box-sizing: border-box` so the written value maps 1:1 to
+   * `max-height`.
+   */
+  constrainHeight?: {
+    /** Smallest useful height in px before flipping to the opposite side. */
+    minHeight: number;
+  };
+}
+
+const OPPOSITE_SIDE: Record<string, string> = {
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left',
+};
+
+function oppositePlacement(placement: Placement): Placement {
+  const [side = '', alignment] = placement.split('-');
+  const opposite = OPPOSITE_SIDE[side] ?? side;
+  return (alignment ? `${opposite}-${alignment}` : opposite) as Placement;
+}
+
+/** Builds the middleware chain shared by both positioning strategies. */
+function buildMiddleware(
+  options: PositionFloatingOptions | undefined,
+  placementOpt: Placement,
+): Middleware[] {
+  const paddingOpt = options?.padding ?? 10;
+  const overflowOpts = options?.boundary
+    ? { padding: paddingOpt, boundary: options.boundary }
+    : { padding: paddingOpt };
+  const constrain = options?.constrainHeight;
+  const middleware: Middleware[] = [offset(options?.offsetValue ?? 4)];
+  if (constrain) {
+    // `size` runs BEFORE `flip`: it shrinks the element to the space available
+    // on the current side, and since a dimension change re-runs the whole
+    // middleware chain, `flip` then measures the shrunken element. The element
+    // therefore stays on the preferred side (scrolling internally) while at
+    // least `minHeight` fits, and flips only below that threshold, where the
+    // re-run caps it to the opposite side's space. With `flip` first it would
+    // flip as soon as the full CSS max-height no longer fits, even when there
+    // is plenty of room for a scrollable menu.
+    middleware.push(
+      size({
+        ...overflowOpts,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.setProperty(
+            '--dm-available-height',
+            `${String(Math.max(constrain.minHeight, Math.floor(availableHeight)))}px`,
+          );
+        },
+      }),
+    );
+    // Restrict flip to the vertical axis: the default placement scan also
+    // treats a purely horizontal overflow as a reason to flip, which `shift`
+    // below already resolves by sliding the element.
+    middleware.push(
+      flip({
+        ...overflowOpts,
+        crossAxis: false,
+        fallbackPlacements: [oppositePlacement(placementOpt)],
+      }),
+    );
+  } else {
+    middleware.push(flip(overflowOpts));
+  }
+  middleware.push(shift(overflowOpts));
+  return middleware;
 }
 
 /**
@@ -74,16 +153,7 @@ export function positionFloating(
   options?: PositionFloatingOptions,
 ): () => void {
   const placementOpt = options?.placement ?? 'bottom';
-  const paddingOpt = options?.padding ?? 10;
-  const overflowOpts = options?.boundary
-    ? { padding: paddingOpt, boundary: options.boundary }
-    : { padding: paddingOpt };
-  const middleware = [
-    offset(options?.offsetValue ?? 4),
-    flip(overflowOpts),
-    shift(overflowOpts),
-    hide(),
-  ];
+  const middleware = [...buildMiddleware(options, placementOpt), hide()];
 
   const update = (): void => {
     void computePosition(
@@ -145,15 +215,7 @@ export function positionFloatingOnce(
   options?: PositionFloatingOptions,
 ): () => void {
   const placementOpt = options?.placement ?? 'bottom';
-  const paddingOpt = options?.padding ?? 10;
-  const overflowOpts = options?.boundary
-    ? { padding: paddingOpt, boundary: options.boundary }
-    : { padding: paddingOpt };
-  const middleware = [
-    offset(options?.offsetValue ?? 4),
-    flip(overflowOpts),
-    shift(overflowOpts),
-  ];
+  const middleware = buildMiddleware(options, placementOpt);
 
   const update = (): void => {
     void computePosition(

--- a/packages/core/src/utils/positionFloating.ts
+++ b/packages/core/src/utils/positionFloating.ts
@@ -34,16 +34,12 @@ export interface PositionFloatingOptions {
    */
   boundary?: Element;
   /**
-   * Shrink-to-fit for vertical placements. When set, the vertical space
-   * available to the floating element (in px) is written to the
-   * `--dm-available-height` CSS custom property on the element, and the
+   * Shrink-to-fit for vertical placements: writes the available space (px)
+   * to the `--dm-available-height` custom property on the element; the
    * stylesheet opts in with e.g.
-   * `max-height: min(22rem, var(--dm-available-height, 100vh))`.
-   * The element then stays on the preferred side and scrolls internally
-   * while at least `minHeight` px fit there; only below that threshold does
-   * it flip to the opposite side, where the same cap applies. Give the
-   * element `box-sizing: border-box` so the written value maps 1:1 to
-   * `max-height`.
+   * `max-height: min(22rem, var(--dm-available-height, 100vh))` plus
+   * `box-sizing: border-box`. The element stays on the preferred side while
+   * at least `minHeight` px fit there, then flips to the opposite side.
    */
   constrainHeight?: {
     /** Smallest useful height in px before flipping to the opposite side. */
@@ -76,14 +72,10 @@ function buildMiddleware(
   const constrain = options?.constrainHeight;
   const middleware: Middleware[] = [offset(options?.offsetValue ?? 4)];
   if (constrain) {
-    // `size` runs BEFORE `flip`: it shrinks the element to the space available
-    // on the current side, and since a dimension change re-runs the whole
-    // middleware chain, `flip` then measures the shrunken element. The element
-    // therefore stays on the preferred side (scrolling internally) while at
-    // least `minHeight` fits, and flips only below that threshold, where the
-    // re-run caps it to the opposite side's space. With `flip` first it would
-    // flip as soon as the full CSS max-height no longer fits, even when there
-    // is plenty of room for a scrollable menu.
+    // `size` runs BEFORE `flip`: a dimension change re-runs the middleware
+    // chain, so `flip` measures the shrunken element and fires only when even
+    // `minHeight` no longer fits on the preferred side. After a flip the
+    // re-run caps the element to the opposite side's space.
     middleware.push(
       size({
         ...overflowOpts,

--- a/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
+++ b/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
@@ -344,3 +344,18 @@ describe('createSlashSuggestionRenderer - mouse interaction', () => {
     renderer.onExit();
   });
 });
+
+describe('createSlashSuggestionRenderer - height constraint', () => {
+  it('opts into height constraining via --dm-available-height', async () => {
+    makeEditor();
+    const renderer = createSlashSuggestionRenderer();
+    renderer.onStart(makeProps([itemA, itemB]));
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const root = host?.querySelector<HTMLElement>('.dm-slash-command-menu');
+    const value = root?.style.getPropertyValue('--dm-available-height') ?? '';
+    expect(value).toMatch(/^\d+px$/);
+    expect(parseInt(value, 10)).toBeGreaterThanOrEqual(160);
+    renderer.onExit();
+  });
+});

--- a/packages/extension-block-controls/src/createSlashSuggestionRenderer.ts
+++ b/packages/extension-block-controls/src/createSlashSuggestionRenderer.ts
@@ -19,6 +19,10 @@ import type { SlashCommandProps, SlashCommandRenderer } from './SlashCommand.js'
 // the selection to screen readers as the user arrow-keys through items.
 let idCounter = 0;
 
+// Below this the menu flips above the caret instead of shrinking further:
+// three two-line rows plus the menu chrome.
+const MIN_MENU_HEIGHT = 160;
+
 export function createSlashSuggestionRenderer(): SlashCommandRenderer {
   let root: HTMLDivElement | null = null;
   let cleanupFloating: (() => void) | null = null;
@@ -175,7 +179,11 @@ export function createSlashSuggestionRenderer(): SlashCommandRenderer {
     cleanupFloating = positionFloatingOnce(
       virtualRef,
       root,
-      { placement: 'bottom-start', offsetValue: 4 },
+      {
+        placement: 'bottom-start',
+        offsetValue: 4,
+        constrainHeight: { minHeight: MIN_MENU_HEIGHT },
+      },
     );
   };
 

--- a/packages/extension-emoji/src/suggestionRenderer.test.ts
+++ b/packages/extension-emoji/src/suggestionRenderer.test.ts
@@ -381,4 +381,56 @@ describe('createEmojiSuggestionRenderer', () => {
       renderer.onExit();
     });
   });
+
+  describe('shrink-to-fit and scroll-follow', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('opts into height constraining via --dm-available-height', async () => {
+      const renderer = createEmojiSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const container = document.querySelector<HTMLElement>('.dm-emoji-suggestion')!;
+      const value = container.style.getPropertyValue('--dm-available-height');
+      expect(value).toMatch(/^\d+px$/);
+      expect(parseInt(value, 10)).toBeGreaterThanOrEqual(160);
+
+      renderer.onExit();
+    });
+
+    it('scrolls down to keep the keyboard selection visible', () => {
+      vi.spyOn(HTMLElement.prototype, 'offsetTop', 'get').mockReturnValue(300);
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(30);
+      vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(100);
+
+      const renderer = createEmojiSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      const container = document.querySelector<HTMLElement>('.dm-emoji-suggestion')!;
+      container.scrollTop = 0;
+
+      renderer.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+      // selected bottom (300 + 30) minus the 100px viewport
+      expect(container.scrollTop).toBe(230);
+      renderer.onExit();
+    });
+
+    it('scrolls up when the selection sits above the view', () => {
+      vi.spyOn(HTMLElement.prototype, 'offsetTop', 'get').mockReturnValue(300);
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(30);
+      vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(100);
+
+      const renderer = createEmojiSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      const container = document.querySelector<HTMLElement>('.dm-emoji-suggestion')!;
+      container.scrollTop = 400;
+
+      renderer.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+      expect(container.scrollTop).toBe(300);
+      renderer.onExit();
+    });
+  });
 });

--- a/packages/extension-emoji/src/suggestionRenderer.ts
+++ b/packages/extension-emoji/src/suggestionRenderer.ts
@@ -26,6 +26,10 @@ import { positionFloatingOnce } from '@domternal/core';
 
 const MAX_ITEMS = 10;
 
+// Below this the dropdown flips above the caret instead of shrinking further:
+// about five rows plus the dropdown chrome.
+const MIN_MENU_HEIGHT = 160;
+
 /**
  * Creates a render factory for the emoji suggestion plugin.
  * Returns a function that produces a `SuggestionRenderer` instance.
@@ -98,6 +102,22 @@ export function createEmojiSuggestionRenderer(): () => SuggestionRenderer {
 
         container?.appendChild(btn);
       });
+
+      // Keep the keyboard selection visible in the scrollable list. Manual
+      // scrollTop math instead of `scrollIntoView`: that walks ancestors and
+      // would yank the page while the dropdown still sits at its natural flow
+      // position, before positioning runs.
+      const selected = container.querySelector<HTMLButtonElement>(
+        '.dm-emoji-suggestion-item--selected',
+      );
+      if (selected) {
+        const btnTop = selected.offsetTop;
+        const btnBottom = btnTop + selected.offsetHeight;
+        const viewTop = container.scrollTop;
+        const viewBottom = viewTop + container.clientHeight;
+        if (btnTop < viewTop) container.scrollTop = btnTop;
+        else if (btnBottom > viewBottom) container.scrollTop = btnBottom - container.clientHeight;
+      }
     }
 
     function updatePosition(): void {
@@ -115,6 +135,7 @@ export function createEmojiSuggestionRenderer(): () => SuggestionRenderer {
       cleanupFloating = positionFloatingOnce(virtualEl, container, {
         placement: 'bottom-start',
         offsetValue: 4,
+        constrainHeight: { minHeight: MIN_MENU_HEIGHT },
       });
     }
 

--- a/packages/extension-mention/src/mentionSuggestionRenderer.test.ts
+++ b/packages/extension-mention/src/mentionSuggestionRenderer.test.ts
@@ -404,4 +404,56 @@ describe('createMentionSuggestionRenderer', () => {
       renderer.onExit();
     });
   });
+
+  describe('shrink-to-fit and scroll-follow', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('opts into height constraining via --dm-available-height', async () => {
+      const renderer = createMentionSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const container = document.querySelector<HTMLElement>('.dm-mention-suggestion')!;
+      const value = container.style.getPropertyValue('--dm-available-height');
+      expect(value).toMatch(/^\d+px$/);
+      expect(parseInt(value, 10)).toBeGreaterThanOrEqual(160);
+
+      renderer.onExit();
+    });
+
+    it('scrolls down to keep the keyboard selection visible', () => {
+      vi.spyOn(HTMLElement.prototype, 'offsetTop', 'get').mockReturnValue(300);
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(30);
+      vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(100);
+
+      const renderer = createMentionSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      const container = document.querySelector<HTMLElement>('.dm-mention-suggestion')!;
+      container.scrollTop = 0;
+
+      renderer.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+      // selected bottom (300 + 30) minus the 100px viewport
+      expect(container.scrollTop).toBe(230);
+      renderer.onExit();
+    });
+
+    it('scrolls up when the selection sits above the view', () => {
+      vi.spyOn(HTMLElement.prototype, 'offsetTop', 'get').mockReturnValue(300);
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(30);
+      vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(100);
+
+      const renderer = createMentionSuggestionRenderer()();
+      renderer.onStart(makeProps());
+      const container = document.querySelector<HTMLElement>('.dm-mention-suggestion')!;
+      container.scrollTop = 400;
+
+      renderer.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+      expect(container.scrollTop).toBe(300);
+      renderer.onExit();
+    });
+  });
 });

--- a/packages/extension-mention/src/mentionSuggestionRenderer.ts
+++ b/packages/extension-mention/src/mentionSuggestionRenderer.ts
@@ -27,6 +27,10 @@ import { positionFloatingOnce } from '@domternal/core';
 
 const MAX_ITEMS = 8;
 
+// Below this the dropdown flips above the caret instead of shrinking further:
+// about five rows plus the dropdown chrome.
+const MIN_MENU_HEIGHT = 160;
+
 /**
  * Creates a render factory for the mention suggestion plugin.
  * Returns a function that produces a `MentionSuggestionRenderer` instance.
@@ -93,6 +97,22 @@ export function createMentionSuggestionRenderer(): () => MentionSuggestionRender
 
         container?.appendChild(btn);
       });
+
+      // Keep the keyboard selection visible in the scrollable list. Manual
+      // scrollTop math instead of `scrollIntoView`: that walks ancestors and
+      // would yank the page while the dropdown still sits at its natural flow
+      // position, before positioning runs.
+      const selected = container.querySelector<HTMLButtonElement>(
+        '.dm-mention-suggestion-item--selected',
+      );
+      if (selected) {
+        const btnTop = selected.offsetTop;
+        const btnBottom = btnTop + selected.offsetHeight;
+        const viewTop = container.scrollTop;
+        const viewBottom = viewTop + container.clientHeight;
+        if (btnTop < viewTop) container.scrollTop = btnTop;
+        else if (btnBottom > viewBottom) container.scrollTop = btnBottom - container.clientHeight;
+      }
     }
 
     function updatePosition(): void {
@@ -110,6 +130,7 @@ export function createMentionSuggestionRenderer(): () => MentionSuggestionRender
       cleanupFloating = positionFloatingOnce(virtualEl, container, {
         placement: 'bottom-start',
         offsetValue: 4,
+        constrainHeight: { minHeight: MIN_MENU_HEIGHT },
       });
     }
 

--- a/packages/theme/src/_emoji-picker.scss
+++ b/packages/theme/src/_emoji-picker.scss
@@ -162,16 +162,13 @@
 
 .dm-emoji-suggestion {
   position: absolute;
-  // border-box so the border-box space the renderer measures maps 1:1 to
-  // max-height below.
+  // border-box so the measured available space maps 1:1 to max-height below.
   box-sizing: border-box;
   z-index: 100;
   min-width: 12rem;
   max-width: 18rem;
-  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
-  // renderer writes the space available below (or, flipped, above) the caret
-  // to `--dm-available-height`, so the list shrinks and scrolls instead of
-  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  // `positionFloatingOnce({ constrainHeight })` writes the space around the
+  // caret to `--dm-available-height`; plain 22rem cap when unset.
   max-height: min(22rem, var(--dm-available-height, 100vh));
   overflow-y: auto;
   padding: 0.25rem;
@@ -181,7 +178,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   animation: dm-fade-in 0.2s ease;
 
-  // Slim custom scrollbar - matches the slash-command menu styling.
+  // Slim custom scrollbar, matches the slash-command menu styling.
   scrollbar-width: thin;
   scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
 

--- a/packages/theme/src/_emoji-picker.scss
+++ b/packages/theme/src/_emoji-picker.scss
@@ -162,15 +162,44 @@
 
 .dm-emoji-suggestion {
   position: absolute;
+  // border-box so the border-box space the renderer measures maps 1:1 to
+  // max-height below.
+  box-sizing: border-box;
   z-index: 100;
   min-width: 12rem;
   max-width: 18rem;
+  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
+  // renderer writes the space available below (or, flipped, above) the caret
+  // to `--dm-available-height`, so the list shrinks and scrolls instead of
+  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  max-height: min(22rem, var(--dm-available-height, 100vh));
+  overflow-y: auto;
   padding: 0.25rem;
   background: var(--dm-surface, #f8f9fa);
   border: 1px solid var(--dm-border-color, #e0e0e0);
   border-radius: 0.25rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   animation: dm-fade-in 0.2s ease;
+
+  // Slim custom scrollbar - matches the slash-command menu styling.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.25rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
 }
 
 .dm-emoji-suggestion-item {

--- a/packages/theme/src/_mention.scss
+++ b/packages/theme/src/_mention.scss
@@ -28,15 +28,44 @@
 
 .dm-mention-suggestion {
   position: absolute;
+  // border-box so the border-box space the renderer measures maps 1:1 to
+  // max-height below.
+  box-sizing: border-box;
   z-index: 100;
   min-width: 12rem;
   max-width: 20rem;
+  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
+  // renderer writes the space available below (or, flipped, above) the caret
+  // to `--dm-available-height`, so the list shrinks and scrolls instead of
+  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  max-height: min(22rem, var(--dm-available-height, 100vh));
+  overflow-y: auto;
   padding: 0.25rem;
   background: var(--dm-surface, #f8f9fa);
   border: 1px solid var(--dm-border-color, #e0e0e0);
   border-radius: 0.25rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   animation: dm-fade-in 0.2s ease;
+
+  // Slim custom scrollbar - matches the slash-command menu styling.
+  scrollbar-width: thin;
+  scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 0.25rem 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18));
+    border-radius: 3px;
+    transition: background-color 0.15s;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--dm-scrollbar-thumb-hover, rgba(0, 0, 0, 0.28));
+  }
 }
 
 .dm-mention-suggestion-item {

--- a/packages/theme/src/_mention.scss
+++ b/packages/theme/src/_mention.scss
@@ -28,16 +28,13 @@
 
 .dm-mention-suggestion {
   position: absolute;
-  // border-box so the border-box space the renderer measures maps 1:1 to
-  // max-height below.
+  // border-box so the measured available space maps 1:1 to max-height below.
   box-sizing: border-box;
   z-index: 100;
   min-width: 12rem;
   max-width: 20rem;
-  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
-  // renderer writes the space available below (or, flipped, above) the caret
-  // to `--dm-available-height`, so the list shrinks and scrolls instead of
-  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  // `positionFloatingOnce({ constrainHeight })` writes the space around the
+  // caret to `--dm-available-height`; plain 22rem cap when unset.
   max-height: min(22rem, var(--dm-available-height, 100vh));
   overflow-y: auto;
   padding: 0.25rem;
@@ -47,7 +44,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   animation: dm-fade-in 0.2s ease;
 
-  // Slim custom scrollbar - matches the slash-command menu styling.
+  // Slim custom scrollbar, matches the slash-command menu styling.
   scrollbar-width: thin;
   scrollbar-color: var(--dm-scrollbar-thumb, rgba(0, 0, 0, 0.18)) transparent;
 

--- a/packages/theme/src/_slash-command.scss
+++ b/packages/theme/src/_slash-command.scss
@@ -20,11 +20,18 @@
 
 .dm-slash-command-menu {
   position: absolute;
+  // border-box so the border-box space the renderer measures maps 1:1 to
+  // max-height below.
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   min-width: 17rem;
-  max-height: 22rem;
+  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
+  // renderer writes the space available below (or, flipped, above) the caret
+  // to `--dm-available-height`, so the menu shrinks and scrolls instead of
+  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  max-height: min(22rem, var(--dm-available-height, 100vh));
   overflow-y: auto;
   padding: 0.375rem;
   background: var(--dm-toolbar-bg, var(--dm-bg, #ffffff));

--- a/packages/theme/src/_slash-command.scss
+++ b/packages/theme/src/_slash-command.scss
@@ -20,17 +20,14 @@
 
 .dm-slash-command-menu {
   position: absolute;
-  // border-box so the border-box space the renderer measures maps 1:1 to
-  // max-height below.
+  // border-box so the measured available space maps 1:1 to max-height below.
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   min-width: 17rem;
-  // Height contract with `positionFloatingOnce({ constrainHeight })`: the
-  // renderer writes the space available below (or, flipped, above) the caret
-  // to `--dm-available-height`, so the menu shrinks and scrolls instead of
-  // flipping over nearby content. Plain 22rem cap when the property is unset.
+  // `positionFloatingOnce({ constrainHeight })` writes the space around the
+  // caret to `--dm-available-height`; plain 22rem cap when unset.
   max-height: min(22rem, var(--dm-available-height, 100vh));
   overflow-y: auto;
   padding: 0.375rem;


### PR DESCRIPTION
## Summary

Caret-anchored menus (slash command, emoji, mention) now shrink to the space below the caret and scroll internally, flipping above only when fewer than 160px remain. Previously `flip()` threw the whole menu above the caret whenever its full max-height did not fit below, covering the content above it; the emoji and mention dropdowns had no max-height at all, so they could not shrink either.

## Changes

- New opt-in `constrainHeight: { minHeight }` option on `positionFloating`/`positionFloatingOnce`: `size` middleware runs before `flip` and writes the available space to `--dm-available-height`, which the theme consumes via `max-height: min(22rem, var(--dm-available-height, 100vh))`.
- Emoji and mention dropdowns gained `overflow-y` with a slim scrollbar and keyboard scroll-follow.
- Opt-in only: existing callers and the public API surface are unchanged.

## Verified

New matrix spec `e2e/suggestion-available-height.spec.ts` across all four demo apps; full e2e matrix, unit tests, build, typecheck, and lint green. Tested manually in the vanilla demo and on the docs site.