### PR TITLE
chore: add context7.json for Context7 library verification and config

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Domternal",
+  "description": "Framework-agnostic headless rich text editor toolkit built on ProseMirror, with native Angular, React, Vue, and Vanilla components, Notion-style block UX, and a tree-shakeable extension model. MIT licensed. Full guides and API reference at https://domternal.dev/v1.",
+  "excludeFolders": [
+    "apps",
+    "examples",
+    "tests",
+    "e2e",
+    "scripts",
+    ".github"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md"
+  ],
+  "rules": [
+    "The editor is framework-agnostic and headless. The core is @domternal/core; framework wrappers are @domternal/angular, @domternal/react, @domternal/vue, and @domternal/vanilla.",
+    "Import editor primitives and built-in extensions from @domternal/core. Optional features live in separate @domternal/extension-* packages (table, image, math, emoji, mention, markdown, block-controls, toc, details, code-block-lowlight).",
+    "Use StarterKit for a batteries-included schema; wire Document/Text/Paragraph and marks by hand only for a minimal headless setup.",
+    "Commands are chainable: editor.chain().focus().toggleBold().run().",
+    "Notion-style block UX (slash menu, drag-to-reorder, block context menu, smart paste) comes from @domternal/extension-block-controls.",
+    "Styling is opt-in via @domternal/theme (CSS custom properties) and is separate from the headless core.",
+    "Extensions are tree-shakeable: register only what you use; the bundler strips the rest.",
+    "Full guides, per-extension API, and the changelog live at https://domternal.dev/v1."
+  ],
+  "url": "https://context7.com/domternal/domternal",
+  "public_key": "pk_qcFQ33vRUsKAajRBwhDgx"
+}


### PR DESCRIPTION
## Summary

Adds a `context7.json` at the repo root so the Context7 library entry for Domternal is owned and configured as code rather than through the Context7 web dashboard.

## Changes

- Ownership verification fields (`url`, `public_key`) so Context7 can confirm control of the repository.
- Parsing config: a description pointing to the full docs at domternal.dev, exclusion of non-doc folders and long meta files so only the package READMEs are indexed, and rules describing the `@domternal/*` package layout, import conventions, and StarterKit/chained-command usage for accurate LLM answers.

## Verified

Static config file with no build or runtime impact; JSON is well-formed. Context7 verifies ownership from `main` after merge.