### PR TITLE
fix: drop $schema from context7.json so Context7 ownership claiming accepts the format

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "Domternal",
   "description": "Framework-agnostic headless rich text editor toolkit built on ProseMirror, with native Angular, React, Vue, and Vanilla components, Notion-style block UX, and a tree-shakeable extension model. MIT licensed. Full guides and API reference at https://domternal.dev/v1.",
   "excludeFolders": [


### PR DESCRIPTION
## Summary

Removes the `$schema` field from `context7.json` so Context7's ownership-claim validator accepts the file.

## Fix

The claim step requires `url` and `public_key` and allows known config fields, but rejects any unknown field. `$schema` is not on Context7's claim allowlist, so verification failed with "context7.json format is incorrect for claiming." Dropping that one line leaves the known config fields (`projectTitle`, `description`, `excludeFolders`, `excludeFiles`, `rules`) intact.

## Verified

JSON is well-formed; the file now contains only fields on Context7's allowlist plus the required `url` / `public_key`.