### PR TITLE
fix: reduce context7.json to url and public_key so ownership claiming passes

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,29 +1,4 @@
 {
-  "projectTitle": "Domternal",
-  "description": "Framework-agnostic headless rich text editor toolkit built on ProseMirror, with native Angular, React, Vue, and Vanilla components, Notion-style block UX, and a tree-shakeable extension model. MIT licensed. Full guides and API reference at https://domternal.dev/v1.",
-  "excludeFolders": [
-    "apps",
-    "examples",
-    "tests",
-    "e2e",
-    "scripts",
-    ".github"
-  ],
-  "excludeFiles": [
-    "CHANGELOG.md",
-    "CODE_OF_CONDUCT.md",
-    "SECURITY.md"
-  ],
-  "rules": [
-    "The editor is framework-agnostic and headless. The core is @domternal/core; framework wrappers are @domternal/angular, @domternal/react, @domternal/vue, and @domternal/vanilla.",
-    "Import editor primitives and built-in extensions from @domternal/core. Optional features live in separate @domternal/extension-* packages (table, image, math, emoji, mention, markdown, block-controls, toc, details, code-block-lowlight).",
-    "Use StarterKit for a batteries-included schema; wire Document/Text/Paragraph and marks by hand only for a minimal headless setup.",
-    "Commands are chainable: editor.chain().focus().toggleBold().run().",
-    "Notion-style block UX (slash menu, drag-to-reorder, block context menu, smart paste) comes from @domternal/extension-block-controls.",
-    "Styling is opt-in via @domternal/theme (CSS custom properties) and is separate from the headless core.",
-    "Extensions are tree-shakeable: register only what you use; the bundler strips the rest.",
-    "Full guides, per-extension API, and the changelog live at https://domternal.dev/v1."
-  ],
   "url": "https://context7.com/domternal/domternal",
   "public_key": "pk_qcFQ33vRUsKAajRBwhDgx"
 }


### PR DESCRIPTION
## Summary

Reduces `context7.json` to exactly `url` and `public_key`, the two-field payload Context7's ownership-claim step requires, so verification passes.

## Fix

Context7's claim verification requires the file to contain exactly `url` and `public_key` and rejects any additional field, even valid config fields. That is a stricter check than the general config schema, which is why removing only `$schema` was not enough: the remaining config fields (`projectTitle`, `description`, `excludeFolders`, `excludeFiles`, `rules`) also had to come out for the claim. Those parsing-config fields are re-added after ownership is verified, where they belong.

## Verified

JSON is well-formed and matches the exact two-field format shown in the claim dialog. Prior config is preserved in history (commit for PR #136) and will be restored once the library is claimed.