### PR TITLE
feat(core): read-only editors refuse every editing affordance and command entry point

### DIFF
--- a/packages/core/src/FloatingMenuPlugin.ts
+++ b/packages/core/src/FloatingMenuPlugin.ts
@@ -273,6 +273,9 @@ export function createFloatingMenuPlugin(options: CreateFloatingMenuPluginOption
   // Final visibility: with requireExplicitTrigger on, both the trigger flag
   // AND shouldShow must be true; otherwise only shouldShow gates it.
   const isVisibleNow = (view: EditorView): boolean => {
+    // Read-only shows no insert menu; unconditional so a wrapper-supplied
+    // shouldShow cannot opt back in (matches the bubble menu gate).
+    if (!editor.isEditable) return false;
     const wantsShow = shouldShow({ editor, view, state: view.state });
     if (!requireExplicitTrigger) return wantsShow;
     const triggered = (pluginKey.getState(view.state) as FloatingMenuPluginState | undefined)?.triggered ?? false;

--- a/packages/core/src/ToolbarController.test.ts
+++ b/packages/core/src/ToolbarController.test.ts
@@ -18,6 +18,7 @@ function createMockEditor(
     toolbarItems: items,
     storage: {},
     isActive: () => false,
+    isEditable: true,
     commands: {},
     can: () => ({}),
     on: () => { /* stub */ },
@@ -719,6 +720,82 @@ describe('ToolbarController', () => {
       expect(() => { controller!.subscribe(); }).not.toThrow();
       // Treated as enabled when can() throws
       expect(controller.isDisabled(items[0] as ToolbarButton)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Read-only editors
+  // =========================================================================
+  describe('read-only editors', () => {
+    it('disables every button when the editor is not editable', () => {
+      const items: ToolbarItem[] = [
+        btn('bold', { command: 'toggleBold' }),
+        btn('italic', { command: 'toggleItalic' }),
+      ];
+      const editor = createMockEditor(items, {
+        isEditable: false,
+        // Commands would report themselves runnable; read-only must win anyway,
+        // since PM's editable prop blocks only typing, not dispatched commands.
+        can: () => ({ toggleBold: () => true, toggleItalic: () => true }),
+      });
+
+      controller = new ToolbarController(editor, vi.fn());
+      controller.subscribe();
+
+      expect(controller.disabledMap.get('bold')).toBe(true);
+      expect(controller.disabledMap.get('italic')).toBe(true);
+    });
+
+    it('keeps allowReadOnly buttons enabled in a read-only editor', () => {
+      const items: ToolbarItem[] = [
+        btn('bold', { command: 'toggleBold' }),
+        btn('versionHistory', { command: 'toggleVersionPanel', allowReadOnly: true }),
+      ];
+      const editor = createMockEditor(items, {
+        isEditable: false,
+        can: () => ({ toggleBold: () => true, toggleVersionPanel: () => true }),
+      });
+
+      controller = new ToolbarController(editor, vi.fn());
+      controller.subscribe();
+
+      expect(controller.disabledMap.get('bold')).toBe(true);
+      expect(controller.isDisabled(items[1] as ToolbarButton)).toBe(false);
+    });
+
+    it('disables emitEvent buttons in a read-only editor even outside a code block', () => {
+      // emitEvent buttons take the code-block path when editable; read-only
+      // must short-circuit to disabled before that.
+      const items: ToolbarItem[] = [
+        btn('link', { command: 'setLink', emitEvent: 'openLinkPopover' }),
+      ];
+      const editor = createMockEditor(items, {
+        isEditable: false,
+        isActive: () => false,
+      });
+
+      controller = new ToolbarController(editor, vi.fn());
+      controller.subscribe();
+
+      expect(controller.isDisabled(items[0] as ToolbarButton)).toBe(true);
+    });
+
+    it('re-enables buttons once the editor becomes editable again', () => {
+      const items: ToolbarItem[] = [btn('bold', { command: 'toggleBold' })];
+      const editor = createMockEditor(items, {
+        isEditable: false,
+        can: () => ({ toggleBold: () => true }),
+      });
+
+      controller = new ToolbarController(editor, vi.fn());
+      controller.subscribe();
+      expect(controller.disabledMap.get('bold')).toBe(true);
+
+      // isEditable is read fresh on every pass, so flipping it and re-running
+      // updateStates flips the disabled state back.
+      (editor as { isEditable: boolean }).isEditable = true;
+      controller.subscribe();
+      expect(controller.disabledMap.get('bold')).toBe(false);
     });
   });
 

--- a/packages/core/src/ToolbarController.test.ts
+++ b/packages/core/src/ToolbarController.test.ts
@@ -797,6 +797,25 @@ describe('ToolbarController', () => {
       controller.subscribe();
       expect(controller.disabledMap.get('bold')).toBe(false);
     });
+
+    it('disables a dropdown trigger and its sub-items in a read-only editor', () => {
+      const dd = dropdown('fontFamily', [
+        btn('fontFamily-Arial', { command: 'setFontFamily', commandArgs: ['Arial'] }),
+        btn('fontFamily-Georgia', { command: 'setFontFamily', commandArgs: ['Georgia'] }),
+      ]);
+      const editor = createMockEditor([dd], {
+        isEditable: false,
+        can: () => ({ setFontFamily: () => true }),
+      });
+
+      controller = new ToolbarController(editor, vi.fn());
+      controller.subscribe();
+
+      // can() reports the command runnable, so read-only is the only thing
+      // disabling the sub-items and (all sub-items disabled) the trigger.
+      expect(controller.disabledMap.get('fontFamily-Arial')).toBe(true);
+      expect(controller.disabledMap.get('fontFamily')).toBe(true);
+    });
   });
 
   // =========================================================================

--- a/packages/core/src/ToolbarController.ts
+++ b/packages/core/src/ToolbarController.ts
@@ -176,6 +176,9 @@ export class ToolbarController {
    * Executes a toolbar button's command.
    */
   executeCommand(item: ToolbarButton): void {
+    // Refuse the dispatch itself in a read-only editor: a wrapper that only
+    // visually dims, or a programmatic call, must not slip an edit through.
+    if (!this.editor.isEditable && item.allowReadOnly !== true) return;
     ToolbarController.executeItem(this.editor, item);
     this.updateActiveStates();
   }
@@ -470,31 +473,28 @@ export class ToolbarController {
     let nowDisabled = false;
 
     // Read-only disables every button without allowReadOnly: PM's editable
-    // prop only blocks typing, a dispatched command would still edit.
+    // prop only blocks typing, a dispatched command would still edit. Fall
+    // through to the shared change-detection tail instead of re-implementing it.
     if (!this.editor.isEditable && item.allowReadOnly !== true) {
-      if (!wasDisabled) {
-        this._disabledMap.set(item.name, true);
-        return true;
-      }
-      return false;
-    }
-
-    try {
-      if (item.emitEvent) {
-        // emitEvent buttons open a popover - can't do meaningful can() dry-run
-        // because the command needs user-provided args (href, src, etc.).
-        // Instead, check if cursor is in a code block where marks/inserts are blocked.
-        nowDisabled = this.editor.isActive('codeBlock');
-      } else if (canProxy) {
-        const canCmd = canProxy[item.command];
-        if (canCmd) {
-          nowDisabled = item.commandArgs?.length
-            ? !canCmd(...item.commandArgs)
-            : !canCmd();
+      nowDisabled = true;
+    } else {
+      try {
+        if (item.emitEvent) {
+          // emitEvent buttons open a popover - can't do meaningful can() dry-run
+          // because the command needs user-provided args (href, src, etc.).
+          // Instead, check if cursor is in a code block where marks/inserts are blocked.
+          nowDisabled = this.editor.isActive('codeBlock');
+        } else if (canProxy) {
+          const canCmd = canProxy[item.command];
+          if (canCmd) {
+            nowDisabled = item.commandArgs?.length
+              ? !canCmd(...item.commandArgs)
+              : !canCmd();
+          }
         }
+      } catch {
+        // Command dry-run may throw (e.g. buggy extension) - treat as enabled
       }
-    } catch {
-      // Command dry-run may throw (e.g. buggy extension) - treat as enabled
     }
 
     if (wasDisabled !== nowDisabled) {

--- a/packages/core/src/ToolbarController.ts
+++ b/packages/core/src/ToolbarController.ts
@@ -23,6 +23,8 @@ import type { ToolbarItem, ToolbarButton, ToolbarDropdown, ToolbarLayoutEntry } 
 export interface ToolbarControllerEditor {
   readonly toolbarItems: ToolbarItem[];
   readonly storage: Record<string, unknown>;
+  /** Read-only editors disable every button without allowReadOnly. */
+  readonly isEditable: boolean;
   isActive(
     nameOrAttributes: string | { name: string; attributes?: Record<string, unknown> },
     attributes?: Record<string, unknown>
@@ -466,6 +468,16 @@ export class ToolbarController {
   ): boolean {
     const wasDisabled = this._disabledMap.get(item.name) ?? false;
     let nowDisabled = false;
+
+    // Read-only disables every button without allowReadOnly: PM's editable
+    // prop only blocks typing, a dispatched command would still edit.
+    if (!this.editor.isEditable && item.allowReadOnly !== true) {
+      if (!wasDisabled) {
+        this._disabledMap.set(item.name, true);
+        return true;
+      }
+      return false;
+    }
 
     try {
       if (item.emitEvent) {

--- a/packages/core/src/extensions/BubbleMenu.test.ts
+++ b/packages/core/src/extensions/BubbleMenu.test.ts
@@ -455,6 +455,37 @@ describe('BubbleMenu', () => {
       expect(ps.to).toBe(12);
     });
 
+    it('read-only overrides a permissive shouldShow so the plugin stays hidden', () => {
+      menuElement = document.createElement('div');
+      document.body.appendChild(menuElement);
+
+      editor = new Editor({
+        extensions: [
+          Document,
+          Text,
+          Paragraph,
+          BubbleMenu.configure({ element: menuElement, shouldShow: () => true }),
+        ],
+        content: '<p>Hello world</p>',
+      });
+      editor.view.coordsAtPos = () => ({ left: 10, right: 50, top: 10, bottom: 30 });
+
+      // Editable: the permissive shouldShow shows the menu on a selection.
+      editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)));
+      expect((bubbleMenuPluginKey.getState(editor.state) as BubbleMenuPluginState).visible).toBe(true);
+
+      // Read-only: the plugin gate wins though shouldShow still returns true, so a
+      // wrapper's custom shouldShow cannot opt the menu back in.
+      editor.setEditable(false);
+      editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)));
+      expect((bubbleMenuPluginKey.getState(editor.state) as BubbleMenuPluginState).visible).toBe(false);
+
+      // Editable again: the gate lifts and the selection shows it once more.
+      editor.setEditable(true);
+      editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)));
+      expect((bubbleMenuPluginKey.getState(editor.state) as BubbleMenuPluginState).visible).toBe(true);
+    });
+
     it('returns empty plugins when no editor', () => {
       const element = document.createElement('div');
       const CustomBubbleMenu = BubbleMenu.configure({ element });

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -327,6 +327,14 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
           // Skip during IME composition
           if (view.composing) return;
 
+          // Read-only retracts an already-visible menu. The plugin `apply`
+          // reads editability one tick before updateState refreshes it, so the
+          // view side is the fresh-value backstop (like the block handle's).
+          if (!view.editable) {
+            hideMenu();
+            return;
+          }
+
           const state = pluginKey.getState(view.state) as
             | BubbleMenuPluginState
             | undefined;

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -215,10 +215,12 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
           suppressed = false;
         }
 
-        // Determine visibility
+        // Determine visibility. The read-only gate applies before any custom
+        // shouldShow (the wrappers build their own), which must not opt back in.
         const visible =
           !suppressed &&
           !selection.empty &&
+          editor.isEditable &&
           shouldShow({
             editor,
             view: editor.view,
@@ -273,8 +275,10 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
           if (mouseDown) return; // don't show during drag
           const { selection } = editor.view.state;
           const { from, to } = selection;
+          // Same unconditional read-only gate as the plugin state above.
           const show =
             !selection.empty &&
+            editor.isEditable &&
             shouldShow({
               editor,
               view: editor.view,

--- a/packages/core/src/nodes/Heading.ts
+++ b/packages/core/src/nodes/Heading.ts
@@ -258,7 +258,10 @@ export const Heading = Node.create<HeadingOptions>({
         key: new PluginKey('headingKeydownFix'),
         props: {
           handleDOMEvents: {
-            keydown(_view, event) {
+            keydown(view, event) {
+              // A handleDOMEvents keydown runs before PM's editable gate (unlike
+              // a keymap), so without this a read-only editor still changes level.
+              if (!view.editable) return false;
               if (!event.altKey || !(event.metaKey || event.ctrlKey)) return false;
               const level = codeToLevel[event.code];
               if (level === undefined) return false;

--- a/packages/core/src/types/Toolbar.ts
+++ b/packages/core/src/types/Toolbar.ts
@@ -93,6 +93,13 @@ export interface ToolbarButton {
 
   /** Bubble menu context name. When set, this item is included in the default bubble menu for this context. */
   bubbleMenu?: string;
+
+  /**
+   * Keep this button enabled in a read-only editor (view-only actions such
+   * as a history panel toggle); by default every button is disabled there.
+   * @default false
+   */
+  allowReadOnly?: boolean;
 }
 
 /**

--- a/packages/extension-block-controls/src/BlockHandle.ts
+++ b/packages/extension-block-controls/src/BlockHandle.ts
@@ -1128,6 +1128,11 @@ export function createBlockHandlePlugin(
       // Re-check the pin gate: a mousemove queued pre-open can fire after
       // `open()` and otherwise reposition the handle.
       if (editorEl.hasAttribute('data-block-context-menu-open')) return;
+      // Read-only shows no handle: every handle action edits the document.
+      if (!editor.isEditable) {
+        scheduleHide();
+        return;
+      }
       const initial = resolveBlockAtCoords(editor.view, coords.x, coords.y, nested);
       if (!initial) {
         scheduleHide();
@@ -1135,10 +1140,7 @@ export function createBlockHandlePlugin(
       }
       // Gap hovers resolve to an ancestor; descend to the nearest leaf row.
       const resolved = descendToNearestHoverItem(editor.view, initial, coords.y);
-      // Readonly editors keep the gutter position: an anchored handle
-      // overlaps the neighbouring container's text, unacceptable for a
-      // purely inert affordance (every button no-ops when not editable).
-      const anchorLeft = editor.isEditable ? initial.anchorLeft ?? null : null;
+      const anchorLeft = initial.anchorLeft ?? null;
       clearHideTimer();
       // Keep `updateHoverState` unconditional (it's a no-op when state already
       // matches): if a prior docChanged cleared `hoveredPos`, the next tick
@@ -1827,6 +1829,8 @@ export function createBlockHandlePlugin(
         // anchor key forces the next hover tick to repaint at fresh rects.
         update: (view, prevState) => {
           if (view.state.doc !== prevState.doc) currentAnchorKey = null;
+          // Retract a visible handle the moment the editor turns read-only.
+          if (!view.editable && root.hasAttribute('data-show')) hide();
         },
         destroy: () => {
           clearHideTimer();

--- a/packages/extension-details/src/Details.ts
+++ b/packages/extension-details/src/Details.ts
@@ -144,6 +144,10 @@ export const Details = Node.create<DetailsOptions>({
       toggle.addEventListener('click', () => {
         toggleDetailsContent();
 
+        // Read-only keeps the visual toggle (open a section to read it) but
+        // must not persist the open attribute, which is a document edit.
+        if (editor && !editor.view.editable) return;
+
         if (!options.persist) {
           if (editor) {
             editor.commands['focus']?.();

--- a/packages/extension-image/src/Image.ts
+++ b/packages/extension-image/src/Image.ts
@@ -389,6 +389,8 @@ export const Image = Node.create<ImageOptions>({
         const handle = document.createElement('div');
         handle.className = `dm-image-handle dm-image-handle-${corner}`;
         handle.addEventListener('mousedown', (e) => {
+          // Read-only allows no resize (the drag dispatches a setNodeMarkup).
+          if (!view.editable) return;
           e.preventDefault();
           e.stopPropagation();
 

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -717,7 +717,8 @@ export class TableView implements NodeView {
         ' Default';
       resetBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        setCellAttr('background', null)(this.view.state, this.view.dispatch);
+        // Refuse the edit if the editor went read-only while this was open.
+        if (this.view.editable) setCellAttr('background', null)(this.view.state, this.view.dispatch);
         this.closeDropdown();
       });
       palette.appendChild(resetBtn);
@@ -731,7 +732,7 @@ export class TableView implements NodeView {
         swatch.setAttribute('aria-label', color);
         swatch.addEventListener('click', (e) => {
           e.stopPropagation();
-          setCellAttr('background', color)(this.view.state, this.view.dispatch);
+          if (this.view.editable) setCellAttr('background', color)(this.view.state, this.view.dispatch);
           this.closeDropdown();
         });
         palette.appendChild(swatch);
@@ -765,7 +766,7 @@ export class TableView implements NodeView {
       for (const a of hAligns) {
         const isActive = curTextAlign === a.value || (!curTextAlign && a.value === 'left');
         dropdown.appendChild(this.createAlignItem(a.icon, a.label, isActive, () => {
-          setCellAttr('textAlign', a.value === 'left' ? null : a.value)(this.view.state, this.view.dispatch);
+          if (this.view.editable) setCellAttr('textAlign', a.value === 'left' ? null : a.value)(this.view.state, this.view.dispatch);
           this.closeDropdown();
         }));
       }
@@ -778,7 +779,7 @@ export class TableView implements NodeView {
       for (const a of vAligns) {
         const isActive = curVerticalAlign === a.value || (!curVerticalAlign && a.value === 'top');
         dropdown.appendChild(this.createAlignItem(a.icon, a.label, isActive, () => {
-          setCellAttr('verticalAlign', a.value === 'top' ? null : a.value)(this.view.state, this.view.dispatch);
+          if (this.view.editable) setCellAttr('verticalAlign', a.value === 'top' ? null : a.value)(this.view.state, this.view.dispatch);
           this.closeDropdown();
         }));
       }
@@ -872,6 +873,9 @@ export class TableView implements NodeView {
   }
 
   private execRowCmd(cmd: PMCommand): void {
+    // A dropdown left open across a switch to read-only must not still mutate
+    // (onRowClick already blocks opening a fresh one).
+    if (!this.view.editable) return;
     this.setCursorInCell(this.hoveredRow, 0);
     const state = this.view.state;
     if (cmd === deleteRow && isInTable(state)) {
@@ -885,6 +889,7 @@ export class TableView implements NodeView {
   }
 
   private execColCmd(cmd: PMCommand): void {
+    if (!this.view.editable) return;
     this.setCursorInCell(0, this.hoveredCol);
     if (this.constrainToContainer && (cmd === addColumnBefore || cmd === addColumnAfter)) {
       constrainedAddColumn(cmd, this.view, this.cellMinWidth, this.defaultCellMinWidth);

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -250,6 +250,18 @@ export class TableView implements NodeView {
       e.preventDefault();
       e.stopPropagation();
     });
+    // Read-only: swallow every toolbar action in one place (capture runs
+    // before the buttons' own click handlers).
+    toolbar.addEventListener(
+      'click',
+      (e) => {
+        if (!this.view.editable) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      },
+      { capture: true }
+    );
 
     // Color button (with dropdown)
     this.colorBtn = this.createToolbarButton(ICON_COLOR, 'Cell color', CHEVRON_DOWN);
@@ -523,6 +535,8 @@ export class TableView implements NodeView {
 
   /** Click on cell handle → create CellSelection for that cell. */
   private onCellHandleClick(): void {
+    // Read-only: cell selection chrome only leads to editing actions.
+    if (!this.view.editable) return;
     if (!this.cellHandleCell) return;
     this.dismissOverlays();
     const pos = this.view.posAtDOM(this.cellHandleCell, 0);
@@ -548,6 +562,7 @@ export class TableView implements NodeView {
   }
 
   private onColClick(): void {
+    if (!this.view.editable) return;
     this.suppressCellToolbar = true;
     this.hideCellToolbar();
     this.dismissOverlays();
@@ -556,6 +571,7 @@ export class TableView implements NodeView {
   }
 
   private onRowClick(): void {
+    if (!this.view.editable) return;
     this.suppressCellToolbar = true;
     this.hideCellToolbar();
     this.dismissOverlays();

--- a/packages/extension-table/src/TableView.ts
+++ b/packages/extension-table/src/TableView.ts
@@ -317,6 +317,12 @@ export class TableView implements NodeView {
 
   private onMouseMove(e: MouseEvent): void {
     if (this._resizeDragging) return;
+    // Read-only shows no table chrome: every handle action edits the table.
+    if (!this.view.editable) {
+      this.hideHandles();
+      this.hoveredCell = null;
+      return;
+    }
 
     const target = e.target;
     if (!(target instanceof HTMLElement)) return;

--- a/packages/theme/src/_image.scss
+++ b/packages/theme/src/_image.scss
@@ -184,3 +184,8 @@ $shadow: var(--dm-popover-shadow, 0 12px 28px -8px rgba(0, 0, 0, 0.22), 0 4px 10
     z-index: 10;
   }
 }
+
+// Read-only allows no resize: handles stay hidden even on a selected image.
+.ProseMirror[contenteditable='false'] .dm-image-handle {
+  display: none !important;
+}

--- a/packages/theme/src/_table-controls.scss
+++ b/packages/theme/src/_table-controls.scss
@@ -294,3 +294,15 @@
   background: var(--dm-border-color, #e0e0e0);
   margin: 0.25rem 0;
 }
+
+// Read-only editors show no table chrome; !important outranks the inline
+// display the show logic writes on the handles and toolbar.
+.ProseMirror[contenteditable='false'] {
+  .dm-table-col-handle,
+  .dm-table-row-handle,
+  .dm-table-cell-handle,
+  .dm-table-cell-toolbar,
+  .dm-table-controls-dropdown {
+    display: none !important;
+  }
+}

--- a/packages/theme/src/_table-controls.scss
+++ b/packages/theme/src/_table-controls.scss
@@ -301,8 +301,7 @@
   .dm-table-col-handle,
   .dm-table-row-handle,
   .dm-table-cell-handle,
-  .dm-table-cell-toolbar,
-  .dm-table-controls-dropdown {
+  .dm-table-cell-toolbar {
     display: none !important;
   }
 }


### PR DESCRIPTION
# Summary

When an editor is read-only (`editor.setEditable(false)`, e.g. while a version
preview is shown), every editing affordance and every toolbar-independent
command entry point now stands down, not just keyboard typing. ProseMirror's
`editable = false` only blocks DOM input; it does not stop a dispatched command
from mutating the document, nor does it hide the surrounding chrome (menus,
handles, popovers), nor does it gate custom `handleDOMEvents`. Each entry point
therefore gets an explicit read-only gate, applied in two layers: JS guards so
an interaction or command cannot start, and CSS so the handles never paint.

# Features

- **Toolbar**: buttons are disabled, and `executeCommand` refuses the dispatch
  itself so a wrapper that only visually dims cannot slip an edit through. A new
  `allowReadOnly?: boolean` toolbar-item flag lets a view-only control (such as a
  history panel toggle) opt out and stay live.
- **Bubble menu**: never shows in read-only, and an already-visible menu is
  retracted the moment the editor turns read-only. The gate is unconditional at
  the plugin, so a wrapper's custom `shouldShow` cannot opt it back in.
- **Floating / slash insert menu**: same unconditional gate, so a custom
  `shouldShow` cannot re-enable block insertion in a read-only editor.
- **Block drag handle** (Notion mode): stays hidden on hover and retracts if it
  was showing.
- **Table chrome**: cell/row/column handles, the cell toolbar and the
  colour/position dropdowns are hidden and their actions refuse, including a
  dropdown that was already open when the editor turned read-only.
- **Image resize**: handles are inert.
- **Heading shortcut**: `Cmd/Ctrl+Alt+[0-6]` no longer changes the level. It is a
  `handleDOMEvents.keydown`, which ProseMirror runs before its own editable
  check (unlike keymap shortcuts), so it needed an explicit gate.
- **Details toggle**: still expands and collapses (you can open a section to
  read it) but no longer persists the `open` attribute, which is a document edit.

# Changes

- `core` ToolbarController: disables every button when the editor is not editable
  unless the item sets `allowReadOnly`, and gates `executeCommand`;
  `ToolbarControllerEditor` exposes `isEditable` and `ToolbarButton` gains
  `allowReadOnly`.
- `core` BubbleMenu: an unconditional `isEditable` gate in the plugin `apply` and
  focus paths, plus a `view.update` retract for the read-only transition.
- `core` FloatingMenuPlugin: `isVisibleNow` gates on `editor.isEditable`.
- `core` Heading: the level-shortcut keydown returns early when `view.editable`
  is false.
- `extension-block-controls` BlockHandle: hover no-ops and the handle retracts
  when the view is not editable.
- `extension-table` TableView: hover chrome hides, and the cell/row/column
  handle, toolbar and dropdown actions refuse when the view is not editable.
- `extension-image` Image: the resize handle ignores mousedown read-only.
- `extension-details` Details: the persist dispatch is skipped read-only.
- `theme`: `.ProseMirror[contenteditable='false']` hides the table and image
  handles and toolbars so nothing paints even if a hover fires.

# Verified

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test:coverage`,
  `test:types-consumer`, `test:api-surface`, `test:css-vars`,
  `test:bundle-size`, the demo typechecks and package validation (publint + attw)
  all pass locally.
- Unit tests added: read-only disables every toolbar button and dropdown trigger,
  `allowReadOnly` buttons stay enabled and re-enable when the editor becomes
  editable, and the bubble menu's read-only gate overrides a permissive custom
  `shouldShow`.
- No public export changes (api-surface snapshot unchanged).