### PR TITLE
fix(extension-block-controls): retract a stale block handle when its hovered block is deleted

### DIFF
--- a/e2e/block-handle-stale-hover.spec.ts
+++ b/e2e/block-handle-stale-hover.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * The block handle must not linger after the block it points at is deleted.
+ *
+ * A doc change that removes the hovered block clears `hoveredPos` but leaves the
+ * handle shown at a stale row, where the next pointer move hits the freeze gate
+ * in `onMouseMove` and locks onto the dead position: the root cause behind the
+ * BlockContextMenu-Delete and matrix-sweep failures. The fix (BlockHandle.ts:
+ * the `view.update` retract plus the `onMouseMove` backstop) is guarded here
+ * across all four demos.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const handleSelector = '.dm-block-handle';
+
+async function goNotion(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
+}
+
+async function setContent(page: Page, html: string): Promise<void> {
+  await page.evaluate((h) => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { setContent: (h: string, emit: boolean) => void; commands: { focus: () => void } }
+      | undefined;
+    ed?.setContent(h, false);
+    ed?.commands.focus();
+  }, html);
+}
+
+async function showHandleOn(page: Page, target: DemoTarget, text: string): Promise<void> {
+  await page.locator(`${target.editorSelector} > p`, { hasText: text }).hover();
+  await expect(page.locator(handleSelector)).toHaveAttribute('data-show', '');
+  await page.waitForTimeout(20);
+}
+
+async function blockTop(page: Page, target: DemoTarget, text: string): Promise<number> {
+  const box = await page.locator(`${target.editorSelector} > p`, { hasText: text }).boundingBox();
+  if (!box) throw new Error(`no box for "${text}"`);
+  return box.y;
+}
+
+async function handleTop(page: Page): Promise<number> {
+  const box = await page.locator(handleSelector).boundingBox();
+  if (!box) throw new Error('no handle box');
+  return box.y;
+}
+
+for (const target of demoTargets) {
+  test.describe(`${target.name} block handle stale hover`, () => {
+    test('the handle retracts when its hovered block is deleted, freeing the next hover', async ({
+      page,
+    }) => {
+      await goNotion(page, target);
+      await setContent(page, '<p>Alpha</p><p>Bravo</p><p>Charlie</p>');
+
+      // Hover the middle block: the handle appears on Bravo's row.
+      await showHandleOn(page, target, 'Bravo');
+      expect(Math.abs((await handleTop(page)) - (await blockTop(page, target, 'Bravo')))).toBeLessThan(24);
+
+      // Delete Bravo (the hovered block). The handle must retract rather than
+      // hang at Bravo's old row.
+      await setContent(page, '<p>Alpha</p><p>Charlie</p>');
+      await expect(page.locator(handleSelector)).not.toHaveAttribute('data-show', '');
+
+      // The next hover must resolve fresh: on the buggy build the stale handle
+      // froze the pointer, so hovering Charlie left the handle where Bravo was.
+      await showHandleOn(page, target, 'Charlie');
+      expect(Math.abs((await handleTop(page)) - (await blockTop(page, target, 'Charlie')))).toBeLessThan(24);
+    });
+  });
+}

--- a/packages/extension-block-controls/src/BlockHandle.test.ts
+++ b/packages/extension-block-controls/src/BlockHandle.test.ts
@@ -331,10 +331,8 @@ describe('BlockHandle DOM integration', () => {
   });
 
   it('retracts a shown handle when its hovered block is deleted', () => {
-    // The apply reducer clears hoveredPos when the hovered block is deleted, but
-    // the handle DOM stays shown at a now-stale spot. The plugin view.update
-    // must retract it, else the next pointer move locks onto the dead handle via
-    // the freeze gate and a handle click bails on the null pos.
+    // A shown handle whose hovered block is deleted is stale; view.update must
+    // retract it, else the next hover's freeze gate locks onto the dead handle.
     const ed = makeEditor('<p>A</p><p>B</p>');
     const handle = host?.querySelector('.dm-block-handle') as HTMLElement | null;
     if (!handle) throw new Error('handle missing');
@@ -784,6 +782,40 @@ describe('BlockHandle hover resolution', () => {
 
     const state = blockHandlePluginKey.getState(editor!.state);
     expect(state?.hoveredPos).toBe(5);
+  });
+
+  it('the mousemove backstop drops a handle left shown with no hovered block', () => {
+    // The context-menu path deletes the pinned block then closes without a
+    // transaction (no view.update), so the next move must drop the stale handle
+    // before the freeze gate. rAF stubbed and never ticked: the backstop is sync.
+    installRafStub();
+    makeEditor('<p>One</p><p>Two</p>');
+    const handle = host?.querySelector('.dm-block-handle') as HTMLElement | null;
+    if (!handle) throw new Error('handle missing');
+    // Stale: shown handle, hovered block gone (a meta-only null, so update()'s
+    // doc-change guard cannot be what retracts it here).
+    handle.setAttribute('data-show', '');
+    editor!.view.dispatch(editor!.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: null }));
+    expect(handle.hasAttribute('data-show')).toBe(true);
+
+    const hoverEl = host?.querySelector<HTMLElement>('.ProseMirror');
+    hoverEl?.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 155, bubbles: true, cancelable: true }));
+    expect(handle.hasAttribute('data-show')).toBe(false);
+  });
+
+  it('the mousemove backstop leaves the handle alone while the context menu is open', () => {
+    // The menu pins the handle as its anchor; the backstop must respect that.
+    installRafStub();
+    makeEditor('<p>One</p><p>Two</p>');
+    const handle = host?.querySelector('.dm-block-handle') as HTMLElement | null;
+    if (!handle) throw new Error('handle missing');
+    handle.setAttribute('data-show', '');
+    host?.setAttribute('data-block-context-menu-open', '');
+    editor!.view.dispatch(editor!.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: null }));
+
+    const hoverEl = host?.querySelector<HTMLElement>('.ProseMirror');
+    hoverEl?.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 155, bubbles: true, cancelable: true }));
+    expect(handle.hasAttribute('data-show')).toBe(true);
   });
 
   it('mode A: cursor in inter-block gap snaps to the closest block (closest-by-Y fallback)', () => {

--- a/packages/extension-block-controls/src/BlockHandle.test.ts
+++ b/packages/extension-block-controls/src/BlockHandle.test.ts
@@ -329,6 +329,39 @@ describe('BlockHandle DOM integration', () => {
     host?.dispatchEvent(new Event('dm:dismiss-overlays'));
     expect(handle.hasAttribute('data-show')).toBe(false);
   });
+
+  it('retracts a shown handle when its hovered block is deleted', () => {
+    // The apply reducer clears hoveredPos when the hovered block is deleted, but
+    // the handle DOM stays shown at a now-stale spot. The plugin view.update
+    // must retract it, else the next pointer move locks onto the dead handle via
+    // the freeze gate and a handle click bails on the null pos.
+    const ed = makeEditor('<p>A</p><p>B</p>');
+    const handle = host?.querySelector('.dm-block-handle') as HTMLElement | null;
+    if (!handle) throw new Error('handle missing');
+
+    // Simulate hovering the second paragraph (pos 3): plugin state + visible DOM.
+    ed.view.dispatch(ed.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: 3 }));
+    handle.setAttribute('data-show', '');
+
+    // Delete that paragraph (positions 3..6): hoveredPos clears, handle retracts.
+    ed.view.dispatch(ed.state.tr.delete(3, 6));
+    expect(blockHandlePluginKey.getState(ed.state)?.hoveredPos).toBe(null);
+    expect(handle.hasAttribute('data-show')).toBe(false);
+  });
+
+  it('keeps a shown handle while the context menu is open even if its block is deleted', () => {
+    // The retract must NOT fire while the menu pins the handle as its anchor;
+    // the onMouseMove backstop drops the stale handle on the next move instead.
+    const ed = makeEditor('<p>A</p><p>B</p>');
+    const handle = host?.querySelector('.dm-block-handle') as HTMLElement | null;
+    if (!handle) throw new Error('handle missing');
+    ed.view.dispatch(ed.state.tr.setMeta(blockHandlePluginKey, { hoveredPos: 3 }));
+    handle.setAttribute('data-show', '');
+    host?.setAttribute('data-block-context-menu-open', '');
+
+    ed.view.dispatch(ed.state.tr.delete(3, 6));
+    expect(handle.hasAttribute('data-show')).toBe(true);
+  });
 });
 
 /**

--- a/packages/extension-block-controls/src/BlockHandle.ts
+++ b/packages/extension-block-controls/src/BlockHandle.ts
@@ -1106,12 +1106,10 @@ export function createBlockHandlePlugin(
     // Freeze the handle while the drag button is pressed; moving it would slide
     // the button out from under the cursor before the browser commits to a drag.
     if (dragPressActive) return;
-    // A handle still shown after its block was deleted is stale (hoveredPos was
-    // cleared, but the DOM stayed up). This catches the case `update` cannot:
-    // the context menu deletes the pinned block and then closes WITHOUT a
-    // transaction, so no plugin update runs to retract it. Drop it before the
-    // freeze gate below (hide() clears pointerOnHandle too) so this move
-    // re-resolves onto the block now under the cursor instead of locking on.
+    // Drop a handle left shown after its block was deleted (hoveredPos cleared)
+    // before the freeze gate can lock onto it, so this move re-resolves. Catches
+    // what `update` cannot: the context menu deletes the pinned block then closes
+    // without a transaction, so no plugin update runs. hide() clears pointerOnHandle.
     if (
       root.hasAttribute('data-show') &&
       !editorEl.hasAttribute('data-block-context-menu-open') &&
@@ -1844,13 +1842,10 @@ export function createBlockHandlePlugin(
           if (view.state.doc !== prevState.doc) currentAnchorKey = null;
           // Retract a visible handle the moment the editor turns read-only.
           if (!view.editable && root.hasAttribute('data-show')) hide();
-          // A doc change that deleted the hovered block clears `hoveredPos` (see
-          // the apply reducer) but leaves the handle shown at a now-stale spot.
-          // If the next pointer move lands on that stale handle it hits the
-          // freeze gate, which returns before re-resolving, so the handle never
-          // recovers and a handle click bails on the null pos. Retract it so the
-          // next hover resolves fresh; hide() also clears pointerOnHandle. Not
-          // while the context menu is open, which legitimately pins the handle.
+          // A doc change that deletes the hovered block clears `hoveredPos` but
+          // leaves the handle shown at a stale spot, where the next hover's freeze
+          // gate would lock onto it. Retract it so the next hover resolves fresh
+          // (hide() clears pointerOnHandle). Not while the context menu pins it.
           if (
             view.state.doc !== prevState.doc &&
             root.hasAttribute('data-show') &&

--- a/packages/extension-block-controls/src/BlockHandle.ts
+++ b/packages/extension-block-controls/src/BlockHandle.ts
@@ -1106,6 +1106,19 @@ export function createBlockHandlePlugin(
     // Freeze the handle while the drag button is pressed; moving it would slide
     // the button out from under the cursor before the browser commits to a drag.
     if (dragPressActive) return;
+    // A handle still shown after its block was deleted is stale (hoveredPos was
+    // cleared, but the DOM stayed up). This catches the case `update` cannot:
+    // the context menu deletes the pinned block and then closes WITHOUT a
+    // transaction, so no plugin update runs to retract it. Drop it before the
+    // freeze gate below (hide() clears pointerOnHandle too) so this move
+    // re-resolves onto the block now under the cursor instead of locking on.
+    if (
+      root.hasAttribute('data-show') &&
+      !editorEl.hasAttribute('data-block-context-menu-open') &&
+      (pluginKey.getState(editor.view.state)?.hoveredPos ?? null) === null
+    ) {
+      hide();
+    }
     // Edge-triggered freeze while the pointer is ON the visible handle: an
     // anchored handle overlaps the neighbouring container's edge, so
     // re-resolving would flip the target and yank the buttons away mid-reach.
@@ -1831,6 +1844,21 @@ export function createBlockHandlePlugin(
           if (view.state.doc !== prevState.doc) currentAnchorKey = null;
           // Retract a visible handle the moment the editor turns read-only.
           if (!view.editable && root.hasAttribute('data-show')) hide();
+          // A doc change that deleted the hovered block clears `hoveredPos` (see
+          // the apply reducer) but leaves the handle shown at a now-stale spot.
+          // If the next pointer move lands on that stale handle it hits the
+          // freeze gate, which returns before re-resolving, so the handle never
+          // recovers and a handle click bails on the null pos. Retract it so the
+          // next hover resolves fresh; hide() also clears pointerOnHandle. Not
+          // while the context menu is open, which legitimately pins the handle.
+          if (
+            view.state.doc !== prevState.doc &&
+            root.hasAttribute('data-show') &&
+            (pluginKey.getState(view.state)?.hoveredPos ?? null) === null &&
+            !editorEl?.hasAttribute('data-block-context-menu-open')
+          ) {
+            hide();
+          }
         },
         destroy: () => {
           clearHideTimer();


### PR DESCRIPTION
# Summary

The block handle could stay frozen after the block it points at was deleted, so
drag-target resolution read a dead position and a click on the handle did
nothing. It now retracts the moment its block is gone, so the next hover
resolves fresh.

# Fix

A doc change that removes the hovered block clears the plugin's `hoveredPos`, but
the handle stayed shown at its old row. The next pointer move then landed on that
stale handle and hit the `onMouseMove` freeze gate, which returns before
re-resolving, so the handle locked onto a dead position and a handle click bailed
on the null pos. This was the root cause behind the BlockContextMenu-Delete and
matrix-sweep e2e failures.

Fixed in `BlockHandle.ts` with two retracts:
- `view.update`: drops the handle when a doc change left it shown with no hovered
  block (not while the context menu legitimately pins it).
- `onMouseMove` backstop: drops a stale handle before the freeze gate, covering
  the context-menu case where the menu deletes the block then closes without a
  transaction (so no plugin update runs).

# Verified

- New unit tests for both retracts and the context-menu guard (block-controls
  suite green).
- New cross-framework matrix guard `e2e/block-handle-stale-hover.spec.ts`, green
  on all four demos.
- The previously-failing per-app specs (notion-block-resolution,
  notion-nested-drag) now pass on react, vanilla, vue and angular.
- typecheck + lint clean.