### PR TITLE
feat(core): make block ids stable enough to anchor on, and let extensions contribute block menu items

### DIFF
--- a/packages/core/src/extensions/UniqueID.test.ts
+++ b/packages/core/src/extensions/UniqueID.test.ts
@@ -3,6 +3,8 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Fragment, Slice } from '@domternal/pm/model';
+import { Plugin } from '@domternal/pm/state';
+import { Extension } from '../Extension.js';
 import { UniqueID } from './UniqueID.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
@@ -496,6 +498,48 @@ describe('UniqueID', () => {
 
       expect(editor.state.doc.child(0).attrs['id']).toBe(stamped);
       expect(editor.state.doc.childCount).toBe(2);
+    });
+
+    it('the id sweep opts out of history ONLY when it rides along with nothing', async () => {
+      // Asserts the flag, not the result of an undo: prosemirror-history takes
+      // it per transaction and behaves either way, so an undo here cannot see
+      // the bug. Only y-prosemirror smears the last transaction's flag across
+      // the batch, and only collaborative undo loses the edit with the id.
+      const batches: (unknown[])[] = [];
+      const probe = Extension.create({
+        name: 'addToHistoryProbe',
+        addProseMirrorPlugins() {
+          return [
+            new Plugin({
+              appendTransaction(transactions) {
+                batches.push(transactions.map((tr) => tr.getMeta('addToHistory')));
+                return null;
+              },
+            }),
+          ];
+        },
+      });
+
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, History, UniqueID, probe],
+        content: '<p>First</p>',
+      });
+      // The startup sweep rides along with nothing, so it opts out.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(batches.at(-1)).toContain(false);
+
+      batches.length = 0;
+      const paragraph = editor.state.schema.nodes['paragraph']!.create(
+        null,
+        editor.state.schema.text('Second')
+      );
+      editor.view.dispatch(editor.state.tr.insert(editor.state.doc.content.size, paragraph));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(editor.state.doc.childCount).toBe(2);
+      expect(typeof editor.state.doc.child(1).attrs['id']).toBe('string');
+      // A batch carrying a real edit must not be marked.
+      expect(batches.at(-1)).not.toContain(false);
     });
 
     it('an internal MOVE drag keeps the block id, a copy drag does not', () => {

--- a/packages/core/src/extensions/UniqueID.test.ts
+++ b/packages/core/src/extensions/UniqueID.test.ts
@@ -8,6 +8,7 @@ import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
 import { Paragraph } from '../nodes/Paragraph.js';
 import { Heading } from '../nodes/Heading.js';
+import { History } from './History.js';
 import { Editor } from '../Editor.js';
 
 describe('UniqueID', () => {
@@ -142,20 +143,19 @@ describe('UniqueID', () => {
       expect(editor.getText()).toContain('Test content');
     });
 
-    // Note: This test requires addGlobalAttributes to be implemented in ExtensionManager
-    // Currently skipped as the attribute isn't being added to the schema
-    it.skip('assigns ID to new paragraphs', () => {
+    // The assignment sweep runs from the plugin view on a macrotask, so the
+    // attribute is present but still null on the tick the editor is built.
+    // Every consumer that resolves a block by id depends on this landing.
+    it('assigns ID to new paragraphs', async () => {
       editor = new Editor({
         extensions: [Document, Text, Paragraph, UniqueID],
         content: '<p>Test</p>',
       });
 
-      const doc = editor.state.doc;
-      const paragraph = doc.child(0);
+      expect('id' in editor.state.doc.child(0).attrs).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // ID should be assigned after initial transaction
-      expect(paragraph.attrs['id']).toBeDefined();
-      expect(typeof paragraph.attrs['id']).toBe('string');
+      expect(typeof editor.state.doc.child(0).attrs['id']).toBe('string');
     });
 
     it('preserves existing IDs', () => {
@@ -170,9 +170,7 @@ describe('UniqueID', () => {
       expect(paragraph.attrs['id']).toBe('existing-id');
     });
 
-    // Note: This test requires addGlobalAttributes to be implemented in ExtensionManager
-    // Currently skipped as the attribute isn't being added to the schema
-    it.skip('uses custom ID generator', () => {
+    it('uses custom ID generator', async () => {
       let counter = 0;
       const CustomUniqueID = UniqueID.configure({
         generateID: (): string => `custom-${String(++counter)}`,
@@ -182,6 +180,7 @@ describe('UniqueID', () => {
         extensions: [Document, Text, Paragraph, CustomUniqueID],
         content: '<p>First</p><p>Second</p>',
       });
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       const doc = editor.state.doc;
       expect(doc.child(0).attrs['id']).toMatch(/^custom-/);
@@ -466,6 +465,101 @@ describe('UniqueID', () => {
       expect(idB).not.toBe('anchor');
       expect(idB.length).toBeGreaterThan(0);
       expect(idA).not.toBe(idB);
+    });
+  });
+  describe('id stability (the guarantees every id consumer relies on)', () => {
+    let editor: Editor | undefined;
+
+    afterEach(() => {
+      if (editor && !editor.isDestroyed) editor.destroy();
+    });
+
+    it('the startup id sweep is not on the undo stack', async () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, History, UniqueID],
+        content: '<p>First</p><p>Second</p>',
+      });
+      // The sweep that stamps ids onto content that arrived without them runs
+      // from the plugin view on its own macrotask, so it is a transaction of
+      // its own rather than part of any user edit.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const stamped = editor.state.doc.child(0).attrs['id'] as string;
+      expect(typeof stamped).toBe('string');
+
+      // Undo with nothing to undo must be a no-op. If the sweep were on the
+      // stack, the user's first undo would silently strip the ids instead, the
+      // next sweep would mint DIFFERENT ones, and every reference to the old
+      // ids (a `#hash` anchor, a table-of-contents deep link, a copied block
+      // link) would break with no visible cause.
+      editor.commands.undo();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(editor.state.doc.child(0).attrs['id']).toBe(stamped);
+      expect(editor.state.doc.childCount).toBe(2);
+    });
+
+    it('an internal MOVE drag keeps the block id, a copy drag does not', () => {
+      const CustomUniqueID = UniqueID.configure({
+        types: ['paragraph'],
+        generateID: () => 'regenerated',
+      });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, CustomUniqueID],
+        content: '<p id="keep-me">Dragged</p>',
+      });
+
+      const plugin = editor.state.plugins.find((p) => p.props.transformPasted !== undefined);
+      const transformPasted = plugin!.props.transformPasted!;
+      const dragged = editor.state.schema.nodes['paragraph']!.create(
+        { id: 'keep-me' },
+        editor.state.schema.text('Dragged')
+      );
+      const slice = new Slice(Fragment.from(dragged), 0, 0);
+
+      // ProseMirror runs transformPasted on the dragged slice BEFORE deleting
+      // the source, so a plain move looks exactly like a duplicate. Keeping the
+      // id is what makes a move a move rather than a delete plus a re-create.
+      const view = editor.view as unknown as { dragging: { move: boolean } | null };
+      view.dragging = { move: true };
+      const moved = transformPasted.call(plugin!, slice, editor.view, false);
+      expect(moved.content.firstChild?.attrs['id']).toBe('keep-me');
+
+      // An alt-drag copy leaves `move` false and must still regenerate, or the
+      // document would carry the same id twice.
+      view.dragging = { move: false };
+      const copied = transformPasted.call(plugin!, slice, editor.view, false);
+      expect(copied.content.firstChild?.attrs['id']).toBe('regenerated');
+      view.dragging = null;
+    });
+
+    it('a duplicate landing ABOVE the original renames the copy, not the original', async () => {
+      let counter = 0;
+      const CustomUniqueID = UniqueID.configure({
+        types: ['paragraph'],
+        generateID: () => `fresh-${String(++counter)}`,
+      });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, CustomUniqueID],
+        content: '<p id="anchor">Original</p>',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Insert a copy carrying the same id at the very TOP, the case the old
+      // "first in document order wins" rule got backwards.
+      const copy = editor.state.schema.nodes['paragraph']!.create(
+        { id: 'anchor' },
+        editor.state.schema.text('Copy')
+      );
+      editor.view.dispatch(editor.state.tr.insert(0, copy));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const first = editor.state.doc.child(0);
+      const second = editor.state.doc.child(1);
+      expect(first.textContent).toBe('Copy');
+      expect(second.textContent).toBe('Original');
+      // The node that already held the id keeps it wherever it now sits.
+      expect(second.attrs['id']).toBe('anchor');
+      expect(first.attrs['id']).not.toBe('anchor');
     });
   });
 });

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -29,7 +29,7 @@ export const uniqueIDPluginKey = new PluginKey('uniqueID');
 export interface UniqueIDOptions {
   /**
    * Node types that should receive unique IDs.
-   * @default ['paragraph', 'heading', 'blockquote', 'codeBlock', 'bulletList', 'orderedList', 'taskList', 'listItem', 'taskItem', 'image', 'horizontalRule']
+   * @default ['paragraph', 'heading', 'blockquote', 'codeBlock', 'bulletList', 'orderedList', 'taskList', 'listItem', 'taskItem', 'image', 'horizontalRule', 'table']
    */
   types: string[];
 
@@ -69,6 +69,12 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
         'taskItem',
         'image',
         'horizontalRule',
+        // Listed even though it lives in a separate package, exactly as
+        // `image` already is: a global attribute only installs on types the
+        // schema actually has, so naming it is inert when the table extension
+        // is not loaded. Without it a table is the one block the block menu
+        // cannot Copy link, and the one an id-anchored feature cannot address.
+        'table',
       ],
       attributeName: 'id',
       generateID: generateUUID,
@@ -100,7 +106,24 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
     const { types, attributeName, generateID, filterDuplicates } = this.options;
     const editor = this.editor as Editor | null;
 
-    const transformPastedSlice = (slice: Slice): Slice => {
+    /**
+     * ProseMirror hands this the DRAGGED slice on an internal drag as well as
+     * pasted content, and it does so BEFORE the source is deleted, so a plain
+     * block move looks exactly like a duplicate: the original is still in the
+     * document, its id collides, and the moved block would land with a fresh
+     * one. That silently breaks every reference to the block (a `#hash` anchor,
+     * a table-of-contents deep link, a copied block link) for a gesture that
+     * changed no content at all.
+     *
+     * `view.dragging.move` is set at dragstart and distinguishes a move from a
+     * copy: a move deletes the source, so the collision is transient and the id
+     * must be kept. A copy drag (alt-drag) leaves `move` false and still
+     * regenerates, which is what we want. If a move somehow does not complete,
+     * `assignMissingIDs` is still the safety net and renames the duplicate.
+     */
+    const transformPastedSlice = (slice: Slice, view?: { dragging?: { move?: boolean } | null }): Slice => {
+      if (view?.dragging?.move === true) return slice;
+
       const existingIDs = new Set<string>();
 
       // Collect existing IDs in document
@@ -160,7 +183,70 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
     // Paste from outside the editor goes through `transformPasted`
     // (further down) and is handled there before this runs. This pass
     // is the safety net.
-    const assignMissingIDs = (doc: PMNode, tr: Transaction): void => {
+    /**
+     * Which node currently holds each id by right of having held it BEFORE this
+     * change, keyed by its position in the new document. Built by walking the
+     * old document and mapping each id-bearing node's position forward through
+     * the transactions that produced the new one.
+     *
+     * Without this, a collision is resolved by document order, so a copy that
+     * lands ABOVE its original keeps the id and the ORIGINAL is renamed. Every
+     * reference then silently points at the copy: a table-of-contents link
+     * jumps to the duplicate, and a block-anchored comment appears on prose it
+     * was never about. Position in the document is not evidence of ownership;
+     * having held the id already is.
+     */
+    const incumbentPositions = (
+      oldDoc: PMNode,
+      mapPos: (pos: number) => number
+    ): Map<string, number> => {
+      const incumbents = new Map<string, number>();
+      oldDoc.descendants((node, pos) => {
+        if (!types.includes(node.type.name)) return;
+        const id = node.attrs[attributeName] as string | undefined;
+        // First holder wins if the OLD document was itself inconsistent, which
+        // is the only case where document order is the right tie-break.
+        if (id && !incumbents.has(id)) incumbents.set(id, mapPos(pos));
+      });
+      return incumbents;
+    };
+
+    const assignMissingIDs = (
+      doc: PMNode,
+      tr: Transaction,
+      incumbents?: Map<string, number>
+    ): void => {
+      /**
+       * Which position keeps each CONTESTED id. Only ids carried by more than
+       * one node are contested, so an id that simply moved (a full setContent
+       * remaps every position) is never disturbed. The incumbent wins when its
+       * mapped position really is one of the occurrences; otherwise the mapping
+       * did not survive the change and document order decides, which is the
+       * old behaviour and still better than renaming every copy.
+       */
+      const winners = new Map<string, number>();
+      if (incumbents && incumbents.size > 0) {
+        const occurrences = new Map<string, number[]>();
+        doc.descendants((node, pos) => {
+          if (!types.includes(node.type.name)) return;
+          const id = node.attrs[attributeName] as string | undefined;
+          if (!id) return;
+          const list = occurrences.get(id);
+          if (list) list.push(pos);
+          else occurrences.set(id, [pos]);
+        });
+        for (const [id, positions] of occurrences) {
+          if (positions.length < 2) continue;
+          const incumbentPos = incumbents.get(id);
+          winners.set(
+            id,
+            incumbentPos !== undefined && positions.includes(incumbentPos)
+              ? incumbentPos
+              : positions[0]!
+          );
+        }
+      }
+
       const seen = new Set<string>();
       doc.descendants((node, pos) => {
         if (!types.includes(node.type.name)) return;
@@ -184,10 +270,17 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
           });
           return;
         }
-        if (seen.has(existingID)) {
-          // Collision: rename the second occurrence. The first
-          // occurrence keeps its id - "first wins" is the same rule
-          // most editors use when reconciling duplicate anchors.
+        // A node yields a CONTESTED id to whichever node held it before this
+        // change, so a copy pasted ABOVE its original no longer steals the
+        // original's identity. `seen` is left untouched so the winner still
+        // passes through cleanly below.
+        const winner = winners.get(existingID);
+        const yieldsToWinner = winner !== undefined && winner !== pos;
+
+        if (seen.has(existingID) || yieldsToWinner) {
+          // Collision: rename this occurrence. Without an incumbent to defer
+          // to, the first occurrence in document order keeps the id, which is
+          // the rule most editors use when reconciling duplicate anchors.
           let id = generateID();
           while (seen.has(id)) id = generateID();
           seen.add(id);
@@ -214,6 +307,8 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
             const tr = editorView.state.tr;
             assignMissingIDs(editorView.state.doc, tr);
             if (tr.docChanged) {
+              // Bookkeeping, not an edit the user made: see the appendTransaction below.
+              tr.setMeta('addToHistory', false);
               editorView.dispatch(tr);
             }
           }, 0);
@@ -225,14 +320,30 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
         },
 
         // Ensure new nodes get IDs
-        appendTransaction(transactions, _oldState, newState) {
+        appendTransaction(transactions, oldState, newState) {
           const docChanged = transactions.some((tr) => tr.docChanged);
           if (!docChanged) return null;
 
-          const tr = newState.tr;
-          assignMissingIDs(newState.doc, tr);
+          // Positions of the nodes that already held each id, carried forward
+          // through this batch, so a duplicate defers to the incumbent rather
+          // than to whichever copy happens to sit higher in the document.
+          const mapForward = (pos: number): number =>
+            transactions.reduce((p, transaction) => transaction.mapping.map(p), pos);
 
-          return tr.docChanged ? tr : null;
+          const tr = newState.tr;
+          assignMissingIDs(newState.doc, tr, incumbentPositions(oldState.doc, mapForward));
+          if (!tr.docChanged) return null;
+
+          // Assigning an id is bookkeeping the editor does for itself, never an
+          // edit the user made, so it must not join the undo stack. Without
+          // this, an id stamped as a side effect of typing rides along in that
+          // undo event: undo reverts the block to no id, the next sweep mints a
+          // DIFFERENT one, and every reference to the old id (a `#hash` anchor,
+          // a table-of-contents deep link, a copied block link) breaks with no
+          // visible cause. prosemirror-history captures appended transactions
+          // unless the appending plugin opts out, which is what this does.
+          tr.setMeta('addToHistory', false);
+          return tr;
         },
 
         // Handle paste - filter duplicates

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -107,19 +107,12 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
     const editor = this.editor as Editor | null;
 
     /**
-     * ProseMirror hands this the DRAGGED slice on an internal drag as well as
-     * pasted content, and it does so BEFORE the source is deleted, so a plain
-     * block move looks exactly like a duplicate: the original is still in the
-     * document, its id collides, and the moved block would land with a fresh
-     * one. That silently breaks every reference to the block (a `#hash` anchor,
-     * a table-of-contents deep link, a copied block link) for a gesture that
-     * changed no content at all.
+     * ProseMirror runs this on the DRAGGED slice too, before the source is
+     * deleted, so a plain block move looks like a duplicate and the moved block
+     * would land with a fresh id, breaking every reference to it.
      *
-     * `view.dragging.move` is set at dragstart and distinguishes a move from a
-     * copy: a move deletes the source, so the collision is transient and the id
-     * must be kept. A copy drag (alt-drag) leaves `move` false and still
-     * regenerates, which is what we want. If a move somehow does not complete,
-     * `assignMissingIDs` is still the safety net and renames the duplicate.
+     * `move` is false for a copy drag, which should still regenerate. If a move
+     * never completes, `assignMissingIDs` catches the duplicate.
      */
     const transformPastedSlice = (slice: Slice, view?: { dragging?: { move?: boolean } | null }): Slice => {
       if (view?.dragging?.move === true) return slice;
@@ -184,17 +177,11 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
     // (further down) and is handled there before this runs. This pass
     // is the safety net.
     /**
-     * Which node currently holds each id by right of having held it BEFORE this
-     * change, keyed by its position in the new document. Built by walking the
-     * old document and mapping each id-bearing node's position forward through
-     * the transactions that produced the new one.
-     *
-     * Without this, a collision is resolved by document order, so a copy that
-     * lands ABOVE its original keeps the id and the ORIGINAL is renamed. Every
-     * reference then silently points at the copy: a table-of-contents link
-     * jumps to the duplicate, and a block-anchored comment appears on prose it
-     * was never about. Position in the document is not evidence of ownership;
-     * having held the id already is.
+     * Where each id sat BEFORE this change, mapped forward into the new
+     * document. Resolving a collision by document order instead lets a copy
+     * pasted ABOVE its original keep the id and renames the original, so every
+     * reference silently follows the copy. Having held the id is ownership;
+     * position is not.
      */
     const incumbentPositions = (
       oldDoc: PMNode,
@@ -217,12 +204,10 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       incumbents?: Map<string, number>
     ): void => {
       /**
-       * Which position keeps each CONTESTED id. Only ids carried by more than
-       * one node are contested, so an id that simply moved (a full setContent
-       * remaps every position) is never disturbed. The incumbent wins when its
-       * mapped position really is one of the occurrences; otherwise the mapping
-       * did not survive the change and document order decides, which is the
-       * old behaviour and still better than renaming every copy.
+       * Which position keeps each CONTESTED id. Only ids held by more than one
+       * node are contested, so an id that merely moved (setContent remaps every
+       * position) is untouched. When the mapped position is not one of the
+       * occurrences the mapping did not survive, and document order decides.
        */
       const winners = new Map<string, number>();
       if (incumbents && incumbents.size > 0) {

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -319,15 +319,21 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
           assignMissingIDs(newState.doc, tr, incumbentPositions(oldState.doc, mapForward));
           if (!tr.docChanged) return null;
 
-          // Assigning an id is bookkeeping the editor does for itself, never an
-          // edit the user made, so it must not join the undo stack. Without
-          // this, an id stamped as a side effect of typing rides along in that
-          // undo event: undo reverts the block to no id, the next sweep mints a
-          // DIFFERENT one, and every reference to the old id (a `#hash` anchor,
-          // a table-of-contents deep link, a copied block link) breaks with no
-          // visible cause. prosemirror-history captures appended transactions
-          // unless the appending plugin opts out, which is what this does.
-          tr.setMeta('addToHistory', false);
+          // A sweep with nothing to ride along on stays out of the undo stack,
+          // or undo strips the ids, the next sweep mints different ones, and
+          // every reference to the old id breaks with no visible cause.
+          //
+          // ONLY then, though. A blanket opt-out reads correctly under
+          // prosemirror-history, which takes the flag per transaction, and is
+          // destructive under y-prosemirror, which takes it from the LAST
+          // transaction and stamps the batch's single Yjs transaction with it.
+          // This sweep is always last, so that drops the user's own edit out of
+          // collaborative undo: the block stays and Ctrl+Z does nothing.
+          const ridesAlongWithAnEdit = transactions.some(
+            (transaction) =>
+              transaction.docChanged && transaction.getMeta('addToHistory') !== false
+          );
+          if (!ridesAlongWithAnEdit) tr.setMeta('addToHistory', false);
           return tr;
         },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,11 @@ export type {
   GlobalAttributeSpec,
   GlobalAttributes,
   ExtensionConfig,
+  // Exported so a package that OWNS a new extension hook can declare it here
+  // by module augmentation, keeping the hook's types in the package that
+  // renders them instead of in core. `ExtensionConfig`, `NodeConfig` and
+  // `MarkConfig` are type aliases over this interface, so they all pick it up.
+  ExtensionConfigBase,
   // Attribute types
   AttributeSpec,
   AttributeSpecs,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -54,6 +54,7 @@ export type {
   GlobalAttributeSpec,
   GlobalAttributes,
   ExtensionConfig,
+  ExtensionConfigBase,
 } from './ExtensionConfig.js';
 
 // Attribute types

--- a/packages/extension-block-controls/src/BlockContextMenu.test.ts
+++ b/packages/extension-block-controls/src/BlockContextMenu.test.ts
@@ -13,8 +13,10 @@ import {
   UniqueID,
   BlockColor,
   Editor,
+  Extension,
 } from '@domternal/core';
 import { BlockContextMenu } from './BlockContextMenu.js';
+import type { BlockMenuItem } from './BlockContextMenu.js';
 
 const extensions = [Document, Text, Paragraph, Heading, Blockquote, CodeBlock, BulletList, OrderedList, TaskList, BlockContextMenu];
 
@@ -1420,5 +1422,134 @@ describe('BlockContextMenu Turn into - wrapper SOURCES (listItem / taskItem / bl
     findItemByLabel('Ordered list')?.click();
     expect(menu?.hasAttribute('data-show')).toBe(false);
     expect(focusSpy).toHaveBeenCalled();
+  });
+});
+
+describe('BlockContextMenu addBlockMenuItems hook', () => {
+  /**
+   * Declaring the hook on a plain Extension is itself the assertion that the
+   * module augmentation merged: if it had shadowed the core interface instead,
+   * this object literal would be an excess property and the file would not
+   * compile.
+   */
+  function contributor(items: BlockMenuItem[]): ReturnType<typeof Extension.create> {
+    return Extension.create({
+      name: 'menuContributor',
+      addBlockMenuItems: () => items,
+    });
+  }
+
+  function openWith(items: BlockMenuItem[], html = '<p>Target</p>'): Element | null {
+    host = document.createElement('div');
+    host.className = 'dm-editor';
+    document.body.appendChild(host);
+    editor = new Editor({
+      element: host,
+      extensions: [...extensions, contributor(items)],
+      content: html,
+    });
+    openContextMenu(0);
+    return host.querySelector('.dm-block-context-menu');
+  }
+
+  const base: BlockMenuItem = {
+    id: 'comment',
+    label: 'Comment',
+    icon: 'chatCircleText',
+    group: 'collaboration',
+    run: () => undefined,
+  };
+
+  it('renders a contributed item and passes it the target block', () => {
+    const seen: { blockPos: number; type: string; blockId: string | null }[] = [];
+    const menu = openWith([
+      {
+        ...base,
+        run: (ctx) => {
+          seen.push({ blockPos: ctx.blockPos, type: ctx.node.type.name, blockId: ctx.blockId });
+        },
+      },
+    ]);
+
+    const btn = menu?.querySelector<HTMLButtonElement>('[data-block-menu-item="comment"]');
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute('aria-label')).toBe('Comment');
+
+    btn?.click();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.type).toBe('paragraph');
+    // UniqueID is not loaded in this setup, so the id resolves to null rather
+    // than throwing or inventing one.
+    expect(seen[0]?.blockId).toBeNull();
+  });
+
+  it('the collaboration group renders last, after Turn into', () => {
+    const menu = openWith([base]);
+    const buttons = Array.from(
+      menu?.querySelectorAll('.dm-block-context-menu-item') ?? []
+    );
+    const labels = buttons.map((b) => b.getAttribute('aria-label'));
+    expect(labels).toContain('Comment');
+    // A contributor may place an item inside the menu but never reorder it.
+    expect(labels[labels.length - 1]).toBe('Comment');
+  });
+
+  it('isAvailable false hides the item entirely', () => {
+    const menu = openWith([{ ...base, isAvailable: () => false }]);
+    expect(menu?.querySelector('[data-block-menu-item="comment"]')).toBeNull();
+  });
+
+  it('isEnabled with a reason renders the item inert and explains why', () => {
+    let ran = 0;
+    const menu = openWith([
+      {
+        ...base,
+        isEnabled: () => ({ disabled: true, reason: 'This block is empty' }),
+        run: () => { ran += 1; },
+      },
+    ]);
+
+    const btn = menu?.querySelector<HTMLButtonElement>('[data-block-menu-item="comment"]');
+    // Rendered, not hidden: a vanished item teaches the user nothing.
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute('aria-disabled')).toBe('true');
+    expect(btn?.title).toBe('This block is empty');
+
+    btn?.click();
+    expect(ran).toBe(0);
+  });
+
+  it('orders within a group by order, then by registration', () => {
+    const menu = openWith([
+      { ...base, id: 'third', label: 'Third', order: 30 },
+      { ...base, id: 'first', label: 'First', order: 10 },
+      { ...base, id: 'second', label: 'Second', order: 10 },
+    ]);
+    const labels = Array.from(menu?.querySelectorAll('.dm-block-context-menu-item') ?? [])
+      .map((b) => b.getAttribute('aria-label'))
+      .filter((l) => l === 'First' || l === 'Second' || l === 'Third');
+    // Equal orders keep registration order rather than depending on collection.
+    expect(labels).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('a contributor that throws does not take the menu down', () => {
+    host = document.createElement('div');
+    host.className = 'dm-editor';
+    document.body.appendChild(host);
+    const Exploding = Extension.create({
+      name: 'explodingContributor',
+      addBlockMenuItems: () => { throw new Error('boom'); },
+    });
+    editor = new Editor({
+      element: host,
+      extensions: [...extensions, Exploding],
+      content: '<p>Target</p>',
+    });
+    openContextMenu(0);
+
+    const menu = host.querySelector('.dm-block-context-menu');
+    const labels = Array.from(menu?.querySelectorAll('.dm-block-context-menu-item') ?? [])
+      .map((b) => b.getAttribute('aria-label'));
+    expect(labels).toContain('Delete');
   });
 });

--- a/packages/extension-block-controls/src/BlockContextMenu.ts
+++ b/packages/extension-block-controls/src/BlockContextMenu.ts
@@ -10,7 +10,7 @@ import { Extension, defaultIcons, liftCurrentListItem, positionFloatingOnce, str
 import type { Editor } from '@domternal/core';
 import { Plugin, PluginKey, TextSelection, EditorState } from '@domternal/pm/state';
 import type { Transaction } from '@domternal/pm/state';
-import type { Attrs } from '@domternal/pm/model';
+import type { Attrs, Node as PMNode } from '@domternal/pm/model';
 import { Decoration, DecorationSet } from '@domternal/pm/view';
 import {
   deleteBlock,
@@ -33,6 +33,76 @@ interface BlockColorOptionsShape {
   types?: string[];
   bgColors?: string[];
   textColors?: string[];
+}
+
+/**
+ * Where a contributed item lands. A CLOSED set owned by this package and
+ * rendered in this order, so a contributor can place an item inside the menu
+ * but can never reorder the menu itself. `collaboration` is the trailing group,
+ * matching Notion, which keeps commenting apart from both the structural
+ * actions and the destructive ones.
+ */
+export type BlockMenuItemGroup = 'primary' | 'colors' | 'turnInto' | 'collaboration';
+
+const GROUP_ORDER: BlockMenuItemGroup[] = ['primary', 'colors', 'turnInto', 'collaboration'];
+
+/** What a contributed item is told about the block the menu was opened on. */
+export interface BlockMenuItemContext {
+  editor: Editor;
+  /** Position of the target block in the document. */
+  blockPos: number;
+  node: PMNode;
+  /**
+   * The block's `uniqueID` value, or null when UniqueID is not loaded or has
+   * not stamped this block. Resolved here so a contributor never has to know
+   * how the id is configured.
+   */
+  blockId: string | null;
+}
+
+/**
+ * A menu entry contributed by another extension through `addBlockMenuItems()`.
+ *
+ * Declarative on purpose: contributors describe an item and this package builds
+ * the button, so every entry keeps `role="menuitem"`, the roving tabindex, the
+ * arrow-key navigation and the mousedown-preventDefault that holds editor
+ * focus. Injecting DOM into the open menu would get all four wrong.
+ */
+export interface BlockMenuItem {
+  /** Stable across renders; used for dedupe and as a test handle. */
+  id: string;
+  label: string;
+  /** Key into the shared icon set, resolved the same way built-in items are. */
+  icon: string;
+  group: BlockMenuItemGroup;
+  /** Within the group, ascending. Defaults to 100; step by 10 to leave room. */
+  order?: number;
+  /** Hide the item entirely. Use for "this block can never take this action". */
+  isAvailable?: (context: BlockMenuItemContext) => boolean;
+  /**
+   * Show the item but refuse it, with a reason surfaced to the user. Prefer
+   * this over hiding when the action is normally possible here: an item that
+   * vanishes teaches nothing, while "Comment (this block is empty)" does.
+   */
+  isEnabled?: (context: BlockMenuItemContext) => true | { disabled: true; reason: string };
+  run: (context: BlockMenuItemContext) => void;
+}
+
+declare module '@domternal/core' {
+  // Type parameters must mirror the original declaration exactly for the
+  // augmentation to merge rather than shadow.
+  // The type parameters exist only to mirror the original declaration: an
+  // augmentation that omits them shadows the interface instead of merging.
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  interface ExtensionConfigBase<Options = unknown, Storage = unknown> {
+    /**
+     * Contribute entries to the block context menu, the same shape as
+     * `addToolbarItems()`. Declared here rather than in core because this
+     * package is the only thing that renders them, so core never learns a type
+     * it does not use.
+     */
+    addBlockMenuItems?: () => BlockMenuItem[];
+  }
 }
 
 /**
@@ -172,6 +242,36 @@ export function createBlockContextMenuPlugin(
   const uniqueIDGenerate: (() => string) | null = uniqueIDExt
     ? ((uniqueIDExt.options as UniqueIDOptionsShape).generateID ?? null)
     : null;
+
+  /**
+   * Items contributed by other extensions, collected once for the same reason
+   * the optional-extension reads above are: extensions are immutable for the
+   * editor's lifetime. Sorted by (group, order, registration) so equal orders
+   * stay in a deterministic sequence rather than depending on collection order.
+   * `isAvailable` and `isEnabled` are evaluated per OPEN, not here, because
+   * they depend on the block the menu was opened on.
+   */
+  const contributedItems: BlockMenuItem[] = editor.extensionManager.extensions
+    .flatMap((ext) => {
+      const add = (ext as unknown as { config: { addBlockMenuItems?: () => BlockMenuItem[] } })
+        .config.addBlockMenuItems;
+      if (typeof add !== 'function') return [];
+      try {
+        return add.call(ext);
+      } catch {
+        // One misbehaving contributor must not take the whole menu down.
+        return [];
+      }
+    })
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const groupDelta =
+        GROUP_ORDER.indexOf(a.item.group) - GROUP_ORDER.indexOf(b.item.group);
+      if (groupDelta !== 0) return groupDelta;
+      const orderDelta = (a.item.order ?? 100) - (b.item.order ?? 100);
+      return orderDelta !== 0 ? orderDelta : a.index - b.index;
+    })
+    .map(({ item }) => item);
 
   const blockColorExt = editor.extensionManager.extensions.find((ext) => ext.name === 'blockColor');
   const blockColorOpts = blockColorExt
@@ -397,6 +497,15 @@ export function createBlockContextMenuPlugin(
     const node = editor.view.state.doc.nodeAt(blockPos);
     if (!node) return;
 
+    const contributedContext: BlockMenuItemContext = {
+      editor,
+      blockPos,
+      node,
+      blockId: uniqueIDAttrName
+        ? (((node.attrs as Record<string, unknown>)[uniqueIDAttrName] as string | undefined) ?? null)
+        : null,
+    };
+
     // Primary actions section.
     const primaryGroup = document.createElement('div');
     primaryGroup.className = 'dm-block-context-menu-group';
@@ -421,6 +530,7 @@ export function createBlockContextMenuPlugin(
       }
     }
     root.appendChild(primaryGroup);
+    appendContributedGroup('primary', contributedContext);
 
     // Colors section: shown only when BlockColor is loaded and the block type
     // is in its `types` list. Renders bg + text swatch rows, each led by a "clear" swatch.
@@ -452,6 +562,7 @@ export function createBlockContextMenuPlugin(
         ),
       );
     }
+    appendContributedGroup('colors', contributedContext);
 
     // Turn into section. Two source modes:
     //   A. Textblock source (paragraph, heading, codeBlock): textblock AND
@@ -543,6 +654,11 @@ export function createBlockContextMenuPlugin(
         root.appendChild(group);
       }
     }
+    appendContributedGroup('turnInto', contributedContext);
+
+    // Trailing group, matching Notion, which keeps collaboration apart from
+    // both the structural actions and the destructive ones.
+    appendContributedGroup('collaboration', contributedContext);
   };
 
   /**
@@ -576,16 +692,64 @@ export function createBlockContextMenuPlugin(
     return btn;
   };
 
+  /**
+   * Renders the contributed items for one group, or nothing when none of them
+   * apply to this block. Disabled items are RENDERED, greyed and inert, with
+   * the reason on the button: an item that silently vanishes teaches the user
+   * nothing, while "Comment (this block is empty)" does. They stay in the
+   * roving tabindex so a keyboard user can reach the explanation.
+   */
+  const appendContributedGroup = (
+    group: BlockMenuItemGroup,
+    context: BlockMenuItemContext
+  ): void => {
+    const items = contributedItems.filter(
+      (item) => item.group === group && (item.isAvailable?.(context) ?? true)
+    );
+    if (items.length === 0) return;
+
+    const container = document.createElement('div');
+    container.className = 'dm-block-context-menu-group';
+    container.setAttribute('role', 'group');
+
+    for (const item of items) {
+      const enabled = item.isEnabled?.(context) ?? true;
+      const disabledReason = enabled === true ? null : enabled.reason;
+      const btn = makeItem(
+        item.label,
+        item.icon,
+        () => {
+          if (disabledReason !== null) return;
+          hide();
+          // Deliberately NOT refocusing the editor the way runAndClose does:
+          // a contributed item commonly opens a surface of its own (a comment
+          // composer) that wants the focus for itself.
+          item.run(context);
+        },
+        { 'data-block-menu-item': item.id }
+      );
+      if (disabledReason !== null) {
+        btn.setAttribute('aria-disabled', 'true');
+        btn.classList.add('dm-block-context-menu-item--disabled');
+        btn.title = disabledReason;
+      }
+      container.appendChild(btn);
+    }
+    root.appendChild(container);
+  };
+
   /** Builds a menuitem button (icon + label) and registers it for nav. */
   const makeItem = (
     label: string,
     iconKey: string,
     onClick: () => void,
+    attributes?: Record<string, string>,
   ): HTMLButtonElement => {
     const btn = createMenuButton({
       className: 'dm-block-context-menu-item',
       ariaLabel: label,
       onClick,
+      ...(attributes ? { attributes } : {}),
     });
 
     // Icon SVG is trusted (our phosphor set), but `label` may come from

--- a/packages/extension-block-controls/src/index.ts
+++ b/packages/extension-block-controls/src/index.ts
@@ -52,6 +52,9 @@ export type {
   BlockContextMenuOptions,
   CreateBlockContextMenuPluginOptions,
   TurnIntoTarget,
+  BlockMenuItem,
+  BlockMenuItemContext,
+  BlockMenuItemGroup,
 } from './BlockContextMenu.js';
 
 // Editor commands the Turn into menu routes to for wrapper (non-textblock)

--- a/tests/api-surface/snapshots/core.txt
+++ b/tests/api-surface/snapshots/core.txt
@@ -88,6 +88,7 @@ EditorOptions
 EventEmitter
 Extension
 ExtensionConfig
+ExtensionConfigBase
 ExtensionConfigurationError
 ExtensionEditor
 ExtensionManager

--- a/tests/api-surface/snapshots/extension-block-controls.txt
+++ b/tests/api-surface/snapshots/extension-block-controls.txt
@@ -7,6 +7,9 @@ BlockHandleOptions
 blockHandlePluginKey
 BlockHandlePluginState
 BlockMatcher
+BlockMenuItem
+BlockMenuItemContext
+BlockMenuItemGroup
 createBlockContextMenuPlugin
 CreateBlockContextMenuPluginOptions
 createBlockHandlePlugin


### PR DESCRIPTION
## Summary

Block ids become something a feature can safely anchor to, and the block handle
menu gains a public extension point. They belong together: an id is only useful
if it survives what a user does to a block, and a menu is only extensible if a
contributor can add to it without reaching into its DOM.

## Features

- **`addBlockMenuItems()`** on `extension-block-controls`, mirroring
  `addToolbarItems()`. Items declare a group and may report themselves disabled
  with a reason, which renders inert with `aria-disabled` rather than
  disappearing. Contributed entries keep the menu's `role="menuitem"`, roving
  tabindex and arrow-key navigation. A contributor that throws is skipped.
  `ExtensionConfigBase` is exported from `core` so the declaration merge
  resolves.
- **`table` in the default `UniqueID` types.** It was the one block the menu
  could not Copy link and no id-anchored feature could name. Inert when the
  table extension is absent, as `image` already was.

## Fix

Three paths minted a new id where the old one had to be kept:

- The startup sweep joined the user's history, so the first undo stripped every
  id and the next sweep minted different ones.
- A move drag looked like a paste, because `transformPasted` runs on the
  dragged slice before the source is deleted. A move is now left alone; a copy
  still regenerates.
- On a momentary duplicate, first-in-document-order won. That is backwards for
  a copy pasted above its original. The node that already held the id keeps it,
  and only contested ids consult the incumbent, so `setContent` remaps are
  unaffected.

`#hash` anchors, table-of-contents deep links and Copy link all break silently
when an id changes underneath them.

## Changes

The sweep opts out of history only when nothing history-worthy shares its
batch. An unconditional opt-out is correct under `prosemirror-history`, which
reads the flag per transaction, and destructive under `y-prosemirror`, which
takes it from the batch's last transaction and stamps the whole Yjs
transaction with it. The sweep is always last, so it would drop the user's edit
out of collaborative undo along with the id. Introduced and fixed within this
branch, so no released version is affected.

## Verified

- Unit suites for `core` and `extension-block-controls`, plus lint and
  typecheck
- API surface snapshots regenerated for four new exports
- Each fix proven load-bearing by reverting it and confirming the matching test
  fails. The history-flag test asserts the flag rather than an undo, because
  `prosemirror-history` behaves correctly either way and an undo-based test
  passes with the bug present
- Exercised end to end across all four demo apps in the Pro repo, where a real
  feature consumes both the hook and the ids