### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.14.0 (2026-07-26)
+
+### Features
+
+- feat(extension-block-controls): new `addBlockMenuItems()` hook. Any extension can contribute entries to the block handle menu the same way `addToolbarItems()` already works: an item declares a group (`primary`, `colors`, `turnInto`, `collaboration`), an optional order, and may report itself unavailable or disabled with a reason. Contributed entries keep the menu's `role="menuitem"`, roving tabindex and arrow-key navigation, a disabled item renders inert with `aria-disabled` and its reason as the title rather than disappearing, and a contributor that throws is skipped instead of taking the menu down. `ExtensionConfigBase` is exported from `@domternal/core` so the declaration merge resolves in a consuming package. (#140)
+- feat(core): read-only editors now refuse every editing affordance and command entry point. The toolbar hides behind a new `allowReadOnly` flag on toolbar items, block handles and table chrome are hidden, and the bubble menu, floating menu, heading shortcut, table dropdowns, details toggle and image resizing are all gated, closing the holes where a read-only document could still be edited. (#138)
+- feat(core): `table` joins the default `UniqueID` types, so a table is addressable by id like every other block. Naming the type is inert when the table extension is absent, exactly as `image` already was; without it a table was the one block the block menu could not Copy link and no id-anchored feature could name. (#140)
+
+### Fixes
+
+- fix(core): block ids now survive undo, moves and duplicates. The startup id sweep stays out of the undo stack, so the first undo no longer strips every id and lets the next sweep mint different ones; a block dragged within the document keeps its id, because `transformPasted` runs on the dragged slice before the source is deleted and made a plain move look like a paste; and when two nodes momentarily hold the same id the node that already had it keeps it, instead of the first in document order winning and renaming the original in favour of a copy pasted above it. Every id consumer benefits: `#hash` anchors, table-of-contents deep links and the block menu's Copy link all break silently when an id changes underneath them. (#140)
+- fix(core): the slash, emoji and mention menus shrink to the available viewport space instead of flipping over the content they were triggered from. (#134)
+- fix(extension-block-controls): a block handle whose hovered block is deleted now retracts, instead of freezing the next hover and handle click on a block that is gone. (#139)
+
 ## 0.13.0 (2026-07-19)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - feat(extension-markdown): new `@domternal/extension-markdown` package: GitHub-flavored Markdown import and export for the full schema. Markdown-looking plain-text pastes convert to rich content (opt-out), `insertMarkdown` and `setMarkdownContent` commands plus a headless parser/serializer API cover programmatic use, and serialization reports fidelity losses through a warnings channel. Tables, task lists, math, and fenced code round-trip; a currency guard keeps `$5 and $10` from parsing as math. (#125)
 - feat(core): plugin views can dispatch transactions while the editor is constructed, so collaborative bindings apply their initial sync immediately. The framework wrappers gain a `history: false` option for editors that bring their own undo, `onError` is wired before extension setup so construction-time errors reach it, and the new `ExtensionConfigurationError` escapes extension error isolation for fatal misconfiguration. (#124)
 
-### Chores
+### Fixes
 
 - All packages now ship a LICENSE file in the npm tarball, and the repository gains issue forms, a pull request template, a code of conduct, and a security policy. (#123)
 
@@ -150,12 +150,9 @@
 
 ## 0.7.5 (2026-06-03)
 
-### Changes
-
-- fix(core): `StarterKit` makes `ListIndent` opt-in (off by default). Tab on a paragraph that merely follows a list used to capture focus and pull the paragraph into the list; now Tab moves focus to the next field, which suits embedded / form usage. Opt back in with `StarterKit.configure({ listIndent: true })`. In-list Tab/Shift-Tab and block-menu drag-to-nest are unchanged. (#98)
-
 ### Fixes
 
+- fix(core): `StarterKit` makes `ListIndent` opt-in (off by default). Tab on a paragraph that merely follows a list used to capture focus and pull the paragraph into the list; now Tab moves focus to the next field, which suits embedded / form usage. Opt back in with `StarterKit.configure({ listIndent: true })`. In-list Tab/Shift-Tab and block-menu drag-to-nest are unchanged. (#98)
 - fix(core): extension instances are now cloned per editor, so several editors on one page no longer clobber each other. Previously creating a second editor repointed the first editor's node types at its own schema, and list `Enter` on the earlier editors dropped an indented child paragraph instead of a new list item. (#91)
 - fix(core): `SelectionDecoration` no longer keeps a ghost range when focus moves from one editor to another on the same page. The "editor UI" blur check is now scoped to the editor that lost focus, so a click into a different editor collapses its selection.
 
@@ -218,7 +215,7 @@
 
 ## 0.7.0 (2026-05-19)
 
-### Breaking changes
+### Breaking
 
 - `listItem`/`taskItem` schema is now Notion-strict (`paragraph block*`). Existing content where the first child is not a paragraph may need migration.
 
@@ -284,7 +281,7 @@
 - `prefers-reduced-motion` guards on TOC tick highlight, card slide, drop-indicator transition. (#78, #80)
 - Forced-colors mode guard on TOC outline. (#78)
 
-### Tests / CI
+### Internal
 
 - Codecov integration with per-package flags and coverage badge. `publint` + `arethetypeswrong` validation extended to React, Vue, Vanilla, extension-block-menu, and extension-toc. (#72, #80)
 - E2E retries set to `2` in all demo Playwright configs. (#74)
@@ -304,9 +301,6 @@
 ### Fixes
 
 - fix(angular): `@domternal/angular@0.6.0` was published without compiled output (#66)
-
-### Improvements
-
 - chore: add automatic `pnpm build` to `prepublishOnly` hook in all packages to prevent publishing without dist
 
 ## 0.6.0 (2026-04-15)
@@ -321,7 +315,7 @@
 
 - fix(core): add `Backspace` handler to `TaskItem` - pressing Backspace at start of first task item now lifts it out of the task list (parity with `BulletList`/`OrderedList`)
 
-### Tests
+### Internal
 
 - 2014 E2E tests for Vue demo app: 1923 ported from demo-react (41 spec files across all extensions) + 91 Vue-specific tests covering v-model two-way binding, `<Domternal>` compound component, `useCurrentEditor()` provide/inject chain, `useEditorState` selector mode, and `VueNodeViewRenderer` lifecycle/reactivity/inject forwarding (22 tests via Callout demo extension)
 
@@ -340,7 +334,7 @@
 - fix(angular,react): selecting emoji category tab via keyboard focuses first emoji in that category
 - fix(theme): table dropdown hover fallback for dark mode
 
-### Tests
+### Internal
 
 - 26 new E2E tests (13 Angular + 13 React) for toolbar dropdown keyboard navigation, text color, font size, heading, ARIA attributes, and Enter on color swatch
 
@@ -376,7 +370,7 @@
 - Table dropdowns: `role="menu"` with `aria-label`, `role="menuitem"` on items, `role="separator"` on dividers
 - Dropdown menu items: `tabindex="-1"` for keyboard focusability (Angular + React)
 
-### Tests
+### Internal
 
 - 105 new E2E accessibility tests (56 Angular + 49 React) covering editor ARIA, bubble menu, dropdown keyboard nav, emoji picker, task checkbox, link/image popover, emoji/mention suggestions, focus-visible, and prefers-reduced-motion
 - 10 new E2E tests for SelectionDecoration blur behavior (5 Angular + 5 React)
@@ -410,7 +404,7 @@
 - `displayName` on all `Domternal` compound subcomponents for React DevTools
 - `DomternalEditorRef` exposes `isEditable`
 
-### Tests
+### Internal
 
 - 1856 E2E tests for React demo app (38 spec files covering all extensions, toolbar, bubble menu, emoji picker, tables, mentions, and more)
 - 60 React-specific E2E tests: bubble menu a11y, `aria-pressed` sync, active class updates, `useEditorState` reactive output, dark theme toggle, toolbar layout switch, context-aware bubble menu filtering
@@ -440,7 +434,7 @@
 - fix(theme): adjust blockquote spacing, remove link cursor override (#51)
 - fix(theme): add dark mode styles for mention dropdown (#52)
 
-### Tests
+### Internal
 
 - 195 new E2E tests: mention (81), horizontal rule, image (38), emoji (27), details (11), blockquote input rule, heading shortcuts, lists (#51, #52)
 
@@ -474,7 +468,7 @@ Initial public release.
 - `@domternal/extension-details` - Collapsible details/accordion blocks
 - `@domternal/extension-code-block-lowlight` - Syntax-highlighted code blocks powered by lowlight
 
-### Highlights
+### Features
 
 - Built on ProseMirror with clean extension API
 - Headless core works with any framework or vanilla JS/TS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,19 +78,7 @@ pnpm typecheck  # Run type checker
 
 NEW cross-framework behavior specs go into the root `e2e/` matrix suite (`pnpm test:e2e:matrix`): one spec runs against all four demo apps via `e2e/targets.ts`. The per-app suites under each demo app's `e2e/` directory are the legacy layout and remain for existing specs and for behavior specific to one framework wrapper.
 
-## Release
-
-1. Branch: `git checkout -b release/X.Y.Z` from main
-2. Bump `"version"` in all 18 `packages/*/package.json` + `domternal.dev/package.json`, and `VERSION` in `packages/core/src/index.ts` (a test enforces they match)
-3. Bump `peerDependencies` and `prepublishOnly` hook versions. For patch releases, keep the existing minimum compatible version. For minor/major releases, bump to `>=X.Y.0`.
-4. Update `CHANGELOG.md` and `domternal.dev` changelog
-5. Update all 19 READMEs (root + 18 packages)
-6. (skip) Verify: `pnpm test && pnpm build && pnpm typecheck && pnpm lint`
-7. Open the release PR and merge to main (manual), then tag `vX.Y.Z` on main and push with tags
-8. Publish in order: pm, core, theme, angular, react, vue, vanilla, then extensions
-9. Create GitHub release from tag with title `vX.Y.Z` and changelog entry as body (manual)
-
-### Changelog sections
+## Changelog
 
 `CHANGELOG.md` uses a fixed set of sections, in this order. Do not invent new
 ones: fourteen different names accumulated over thirty releases before this was
@@ -110,9 +98,5 @@ the release that used the other.
 Omit a section rather than writing "none". Chore commits that change no shipped
 artefact (repo config, workflows, planning) do not go in the changelog at all.
 
-### Publish notes
-
-- **Order matters**: pm first, core second, then the rest. Other packages depend on them.
-- **`prepublishOnly`** runs `pnpm build` automatically before every publish, so dist is always included.
-- **If publish fails** after `prepublishOnly` already stripped `devDependencies`, `postpublish` won't run. Restore manually: `git checkout packages/*/package.json`
-- **Tag on main**: always tag after merging to main, not on the release branch.
+A pull request does not edit `CHANGELOG.md` and does not bump any version. Say
+what changed in the PR description; it lands in the changelog at release time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,25 +78,7 @@ pnpm typecheck  # Run type checker
 
 NEW cross-framework behavior specs go into the root `e2e/` matrix suite (`pnpm test:e2e:matrix`): one spec runs against all four demo apps via `e2e/targets.ts`. The per-app suites under each demo app's `e2e/` directory are the legacy layout and remain for existing specs and for behavior specific to one framework wrapper.
 
-## Changelog
+## Releases
 
-`CHANGELOG.md` uses a fixed set of sections, in this order. Do not invent new
-ones: fourteen different names accumulated over thirty releases before this was
-written down, and a reader scanning for breaking changes under one name missed
-the release that used the other.
-
-| Section | What belongs in it |
-|---|---|
-| `Breaking` | Anything a consumer must change code for |
-| `Features` | New capability or new public API |
-| `Fixes` | Wrong behaviour that is now right, including packaging fixes |
-| `Packages` | A package published for the first time, or renamed |
-| `Accessibility` | Keyboard, screen reader, contrast, reduced motion |
-| `Docs` | README changes, which ship in the npm tarball |
-| `Internal` | Refactors, tests and CI. Visible to nobody who installs the package, so it goes last |
-
-Omit a section rather than writing "none". Chore commits that change no shipped
-artefact (repo config, workflows, planning) do not go in the changelog at all.
-
-A pull request does not edit `CHANGELOG.md` and does not bump any version. Say
-what changed in the PR description; it lands in the changelog at release time.
+Releases are handled by the maintainer, along with the `CHANGELOG.md` entry and
+every version bump.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,26 @@ NEW cross-framework behavior specs go into the root `e2e/` matrix suite (`pnpm t
 8. Publish in order: pm, core, theme, angular, react, vue, vanilla, then extensions
 9. Create GitHub release from tag with title `vX.Y.Z` and changelog entry as body (manual)
 
+### Changelog sections
+
+`CHANGELOG.md` uses a fixed set of sections, in this order. Do not invent new
+ones: fourteen different names accumulated over thirty releases before this was
+written down, and a reader scanning for breaking changes under one name missed
+the release that used the other.
+
+| Section | What belongs in it |
+|---|---|
+| `Breaking` | Anything a consumer must change code for |
+| `Features` | New capability or new public API |
+| `Fixes` | Wrong behaviour that is now right, including packaging fixes |
+| `Packages` | A package published for the first time, or renamed |
+| `Accessibility` | Keyboard, screen reader, contrast, reduced motion |
+| `Docs` | README changes, which ship in the npm tarball |
+| `Internal` | Refactors, tests and CI. Visible to nobody who installs the package, so it goes last |
+
+Omit a section rather than writing "none". Chore commits that change no shipped
+artefact (repo config, workflows, planning) do not go in the changelog at all.
+
 ### Publish notes
 
 - **Order matters**: pm first, core second, then the rest. Other packages depend on them.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -19,7 +19,7 @@ emoji picker, and Notion color picker auto-render from the extensions you load.
 pnpm add @domternal/angular @domternal/core @domternal/theme
 ```
 
-`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=0.13.0)
+`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=0.14.0)
 are peer dependencies. Add the theme ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme))
 to your global stylesheet (e.g. `styles.scss`):
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Angular components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "@angular/core": ">=17.1.0",
     "@angular/forms": ">=17.1.0",
     "@angular/platform-browser": ">=17.1.0",
-    "@domternal/core": ">=0.13.0"
+    "@domternal/core": ">=0.14.0"
   },
   "files": [
     "dist"
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
     "lint": "eslint src",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Framework-agnostic ProseMirror editor engine",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * Framework-agnostic ProseMirror editor engine
  */
 
-export const VERSION = '0.13.0';
+export const VERSION = '0.14.0';
 
 // === Type exports ===
 export type {

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-controls",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Notion-style block controls for the Domternal editor: BlockHandle (hover gutter + drag), SlashCommand, FloatingMenu, ContextMenu, keyboard reorder, and SmartPaste",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-block-menu/package.json
+++ b/packages/extension-block-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-menu",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "DEPRECATED: renamed to @domternal/extension-block-controls. This package is now a thin shim that re-exports it; removed in v1.0.0.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,15 +34,15 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {
     "@domternal/extension-block-controls": "workspace:*"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,15 +34,15 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {
     "hast-util-to-html": "^9.0.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0",
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0",
     "lowlight": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-markdown",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Bidirectional Markdown for Domternal: parse Markdown into the editor (paste, insert, setContent) and serialize documents back to GitHub-flavored Markdown, covering the full Notion-style schema",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,15 +34,15 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "dependencies": {
     "markdown-it": "^14.3.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-math",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "LaTeX math (inline + block) for Domternal editor with a pluggable renderer (KaTeX by default)",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0",
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0",
     "katex": "^0.16.0 || ^0.17.0"
   },
   "devDependencies": {

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -34,12 +34,12 @@
     "test:watch": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0",
-    "@domternal/pm": ">=0.13.0"
+    "@domternal/core": ">=0.14.0",
+    "@domternal/pm": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -130,18 +130,42 @@
   },
   "typesVersions": {
     "*": {
-      "commands": ["src/commands.d.ts"],
-      "dropcursor": ["src/dropcursor.d.ts"],
-      "gapcursor": ["src/gapcursor.d.ts"],
-      "history": ["src/history.d.ts"],
-      "inputrules": ["src/inputrules.d.ts"],
-      "keymap": ["src/keymap.d.ts"],
-      "model": ["src/model.d.ts"],
-      "schema-list": ["src/schema-list.d.ts"],
-      "state": ["src/state.d.ts"],
-      "tables": ["src/tables.d.ts"],
-      "transform": ["src/transform.d.ts"],
-      "view": ["src/view.d.ts"]
+      "commands": [
+        "src/commands.d.ts"
+      ],
+      "dropcursor": [
+        "src/dropcursor.d.ts"
+      ],
+      "gapcursor": [
+        "src/gapcursor.d.ts"
+      ],
+      "history": [
+        "src/history.d.ts"
+      ],
+      "inputrules": [
+        "src/inputrules.d.ts"
+      ],
+      "keymap": [
+        "src/keymap.d.ts"
+      ],
+      "model": [
+        "src/model.d.ts"
+      ],
+      "schema-list": [
+        "src/schema-list.d.ts"
+      ],
+      "state": [
+        "src/state.d.ts"
+      ],
+      "tables": [
+        "src/tables.d.ts"
+      ],
+      "transform": [
+        "src/transform.d.ts"
+      ],
+      "view": [
+        "src/view.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ and React 19.
 pnpm add @domternal/react @domternal/core react react-dom
 ```
 
-`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=0.13.0) are peer dependencies. Import the theme
+`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=0.14.0) are peer dependencies. Import the theme
 ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)) in your entry CSS for default styling:
 
 ```css

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "React components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "@domternal/core": ">=0.13.0"
+    "@domternal/core": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -37,7 +37,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Default themes and styles for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=0.13.0"
+    "@domternal/core": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -31,7 +31,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Vue 3 components for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -20,7 +20,7 @@
   ],
   "peerDependencies": {
     "vue": ">=3.3",
-    "@domternal/core": ">=0.13.0"
+    "@domternal/core": ">=0.14.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",
@@ -33,7 +33,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.13.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
+    "prepublishOnly": "pnpm build && node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8'));delete p.devDependencies;if(p.dependencies){for(const[k,v]of Object.entries(p.dependencies)){if(v==='workspace:*')p.dependencies[k]='>=0.14.0'}}require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n')\"",
     "postpublish": "git checkout package.json"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Release 0.14.0. Minor: two features with new public API, no breaking changes.
Contents are in `CHANGELOG.md`.

## Changes

Versions, peer ranges and `prepublishOnly` hooks move to 0.14.0.
`domternal.dev` stays pinned at 0.13.0: it resolves the packages from npm, so it
can only move after publish.

Two documentation changes ride along rather than being part of the release.
`CHANGELOG.md` settles on seven sections after fourteen names had accumulated
over thirty releases, with nothing deleted, only renamed and merged. The release
runbook moved out of `CONTRIBUTING.md`, which GitHub shows to anyone opening a
PR and which was carrying npm publish order and a step marked `(skip)`.

## Verified

Every CI step locally, including the frozen-lockfile install and the three demo
typechecks. The `VERSION` guard failed until `packages/core/src/index.ts` was
bumped alongside the manifests, which is what it was added for.