### PR TITLE
fix: preserve marks through input rules, scope Code exclusion to a formatting group, and stop the React bubble menu swallowing clicks

### DIFF
--- a/apps/demo-angular/e2e/notion-demo.spec.ts
+++ b/apps/demo-angular/e2e/notion-demo.spec.ts
@@ -4064,10 +4064,15 @@ test.describe('Table of Contents - hover expansion', () => {
     // (setTimeout is clamped under load, can drift well past 120ms).
     await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 2500 });
 
-    // Card opacity is now 1 and rows are pointer-events:auto.
+    // Card opacity is now 1 and rows are pointer-events:auto. Polled, not
+    // read once: the state flips when the card STARTS fading in, so a single
+    // read lands mid-transition and sees whatever fraction it caught.
     const card = page.locator('.dm-toc-outline-card');
-    const opacity = await card.evaluate((node) => window.getComputedStyle(node).opacity);
-    expect(parseFloat(opacity)).toBeGreaterThan(0.9);
+    await expect
+      .poll(async () =>
+        parseFloat(await card.evaluate((node) => window.getComputedStyle(node).opacity))
+      )
+      .toBeGreaterThan(0.9);
   });
 
   test('rows render full heading text with per-level indent (h1 < h2 < h3)', async ({ page }) => {

--- a/apps/demo-react/e2e/notion-demo.spec.ts
+++ b/apps/demo-react/e2e/notion-demo.spec.ts
@@ -4064,10 +4064,15 @@ test.describe('Table of Contents - hover expansion', () => {
     // (setTimeout is clamped under load, can drift well past 120ms).
     await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 2500 });
 
-    // Card opacity is now 1 and rows are pointer-events:auto.
+    // Card opacity is now 1 and rows are pointer-events:auto. Polled, not
+    // read once: the state flips when the card STARTS fading in, so a single
+    // read lands mid-transition and sees whatever fraction it caught.
     const card = page.locator('.dm-toc-outline-card');
-    const opacity = await card.evaluate((node) => window.getComputedStyle(node).opacity);
-    expect(parseFloat(opacity)).toBeGreaterThan(0.9);
+    await expect
+      .poll(async () =>
+        parseFloat(await card.evaluate((node) => window.getComputedStyle(node).opacity))
+      )
+      .toBeGreaterThan(0.9);
   });
 
   test('rows render full heading text with per-level indent (h1 < h2 < h3)', async ({ page }) => {

--- a/apps/demo-vanilla/e2e/notion-demo.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-demo.spec.ts
@@ -4064,10 +4064,15 @@ test.describe('Table of Contents - hover expansion', () => {
     // (setTimeout is clamped under load, can drift well past 120ms).
     await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 2500 });
 
-    // Card opacity is now 1 and rows are pointer-events:auto.
+    // Card opacity is now 1 and rows are pointer-events:auto. Polled, not
+    // read once: the state flips when the card STARTS fading in, so a single
+    // read lands mid-transition and sees whatever fraction it caught.
     const card = page.locator('.dm-toc-outline-card');
-    const opacity = await card.evaluate((node) => window.getComputedStyle(node).opacity);
-    expect(parseFloat(opacity)).toBeGreaterThan(0.9);
+    await expect
+      .poll(async () =>
+        parseFloat(await card.evaluate((node) => window.getComputedStyle(node).opacity))
+      )
+      .toBeGreaterThan(0.9);
   });
 
   test('rows render full heading text with per-level indent (h1 < h2 < h3)', async ({ page }) => {

--- a/apps/demo-vue/e2e/notion-demo.spec.ts
+++ b/apps/demo-vue/e2e/notion-demo.spec.ts
@@ -4069,10 +4069,15 @@ test.describe('Table of Contents - hover expansion', () => {
     // (setTimeout is clamped under load, can drift well past 120ms).
     await expect(outline).toHaveAttribute('data-state', 'expanded', { timeout: 2500 });
 
-    // Card opacity is now 1 and rows are pointer-events:auto.
+    // Card opacity is now 1 and rows are pointer-events:auto. Polled, not
+    // read once: the state flips when the card STARTS fading in, so a single
+    // read lands mid-transition and sees whatever fraction it caught.
     const card = page.locator('.dm-toc-outline-card');
-    const opacity = await card.evaluate((node) => window.getComputedStyle(node).opacity);
-    expect(parseFloat(opacity)).toBeGreaterThan(0.9);
+    await expect
+      .poll(async () =>
+        parseFloat(await card.evaluate((node) => window.getComputedStyle(node).opacity))
+      )
+      .toBeGreaterThan(0.9);
   });
 
   test('rows render full heading text with per-level indent (h1 < h2 < h3)', async ({ page }) => {

--- a/packages/core/src/Mark.test.ts
+++ b/packages/core/src/Mark.test.ts
@@ -357,6 +357,16 @@ describe('Mark', () => {
         expect(spec.spanning).toBe(false);
       });
 
+      it('includes keepOnDuplicate in spec', () => {
+        const mark = Mark.create({
+          name: 'anchor',
+          keepOnDuplicate: false,
+        });
+        const spec = mark.createMarkSpec();
+
+        expect(spec['keepOnDuplicate']).toBe(false);
+      });
+
       it('excludes undefined properties from spec', () => {
         const mark = Mark.create({ name: 'bold' });
         const spec = mark.createMarkSpec();
@@ -365,6 +375,7 @@ describe('Mark', () => {
         expect(spec.excludes).toBeUndefined();
         expect(spec.group).toBeUndefined();
         expect(spec.spanning).toBeUndefined();
+        expect(spec['keepOnDuplicate']).toBeUndefined();
       });
     });
 

--- a/packages/core/src/Mark.ts
+++ b/packages/core/src/Mark.ts
@@ -214,6 +214,8 @@ export class Mark<Options = unknown, Storage = unknown> extends Extension<
     if (this.config.group !== undefined) spec.group = this.config.group;
     if (this.config.spanning !== undefined)
       spec.spanning = this.config.spanning;
+    if (this.config.keepOnDuplicate !== undefined)
+      spec['keepOnDuplicate'] = this.config.keepOnDuplicate;
 
     // Attributes - convert AttributeSpecs to ProseMirror attrs
     const attributeSpecs = callOrReturn(this.config.addAttributes, this);

--- a/packages/core/src/extensions/BubbleMenu.test.ts
+++ b/packages/core/src/extensions/BubbleMenu.test.ts
@@ -749,6 +749,57 @@ describe('BubbleMenu', () => {
       overlay.remove();
     });
 
+    it('mousedown on an svg icon inside an overlay does not hide menu', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document, Text, Paragraph,
+          BubbleMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p>Hello</p>',
+      });
+
+      // An icon is an SVG node, not an HTMLElement.
+      const overlay = document.createElement('div');
+      overlay.setAttribute('data-dm-editor-ui', '');
+      const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      overlay.appendChild(icon);
+      document.body.appendChild(overlay);
+
+      element.setAttribute('data-show', '');
+      icon.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+      expect(element.hasAttribute('data-show')).toBe(true);
+      overlay.remove();
+    });
+
+    it('mousedown whose target was detached mid-gesture leaves the menu alone', () => {
+      const element = document.createElement('div');
+      editor = new Editor({
+        element: host,
+        extensions: [
+          Document, Text, Paragraph,
+          BubbleMenu.configure({ element, shouldShow: () => true }),
+        ],
+        content: '<p>Hello</p>',
+      });
+
+      // A wrapper re-rendering on the pointerdown transaction replaces the
+      // icon before mousedown arrives, so the browser reports a node that is
+      // inside nothing at all.
+      const icon = document.createElement('span');
+      element.appendChild(icon);
+      const detach = (): void => { icon.remove(); };
+      document.addEventListener('mousedown', detach, { capture: true });
+
+      element.setAttribute('data-show', '');
+      icon.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      document.removeEventListener('mousedown', detach, { capture: true });
+
+      expect(element.hasAttribute('data-show')).toBe(true);
+    });
+
     it('mousedown on a non-overlay element outside both surfaces hides menu', () => {
       const element = document.createElement('div');
       element.setAttribute('data-show', '');

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -175,6 +175,10 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
   const onDocumentMousedown = (e: MouseEvent): void => {
     const target = e.target as Node | null;
     if (!target) return;
+    // A target that left the document between pointerdown and mousedown says
+    // nothing about where the click landed, and every check below reads it as
+    // "outside". Hiding on that guess swallows the click that follows.
+    if (!target.isConnected) return;
     // Click inside bubble menu - ignore (handled by onMenuMousedown)
     if (element.contains(target)) return;
     // Click inside editor - let ProseMirror handle selection change
@@ -183,7 +187,8 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
     // [data-dm-editor-ui]) - treat as part of the bubble menu's interaction
     // surface so the menu doesn't dismiss while the user is operating its
     // own dropdown. Matches the whitelist `onBlur` already uses below.
-    if (target instanceof HTMLElement && target.closest('[data-dm-editor-ui]')) return;
+    // `Element`, not `HTMLElement`: icons are SVG nodes.
+    if (target instanceof Element && target.closest('[data-dm-editor-ui]')) return;
     // Outside everything - hide and suppress until selection changes
     hideMenu();
     suppressed = true;

--- a/packages/core/src/extensions/Highlight.test.ts
+++ b/packages/core/src/extensions/Highlight.test.ts
@@ -6,6 +6,7 @@ import { TextSelection } from '@domternal/pm/state';
 import { Highlight, DEFAULT_HIGHLIGHT_COLORS } from './Highlight.js';
 import { TextColor } from './TextColor.js';
 import { TextStyle } from '../marks/TextStyle.js';
+import { Bold } from '../marks/Bold.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
 import { Paragraph } from '../nodes/Paragraph.js';
@@ -525,6 +526,29 @@ describe('Highlight', () => {
       const match = ['====', ''] as RegExpMatchArray;
       const result = (rule.handler)(editor.state, match, 1, 5);
       expect(result).toBeNull();
+    });
+
+    it('keeps the marks of the matched text', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, TextStyle, Bold, Highlight],
+        content: '<p><strong>==word==</strong></p>',
+      });
+
+      const highlightExt = editor.extensionManager.extensions.find((e) => e.name === 'highlight')!;
+      const rules = (highlightExt as any).config.addInputRules!.call({
+        ...highlightExt,
+        options: highlightExt.options,
+      } as any)!;
+
+      const rule = rules[0]!;
+      const match = ['==word==', 'word'] as RegExpMatchArray;
+      const result = (rule.handler)(editor.state, match, 1, 9);
+      expect(result).not.toBeNull();
+      const textNode = result.doc.firstChild?.firstChild;
+      const names = textNode?.marks
+        .map((mark: { type: { name: string } }) => mark.type.name)
+        .sort();
+      expect(names).toEqual(['bold', 'textStyle']);
     });
   });
 });

--- a/packages/core/src/extensions/Highlight.ts
+++ b/packages/core/src/extensions/Highlight.ts
@@ -229,7 +229,11 @@ export const Highlight = Extension.create<HighlightOptions>({
           if (!content) return null;
 
           const { tr } = state;
-          tr.replaceWith(start, end, state.schema.text(content));
+          // Preserve the marks the matched text already had (stored marks
+          // first, like Transaction.insertText) so highlighting inside
+          // commented or formatted text does not strip those marks.
+          const marks = tr.storedMarks ?? tr.doc.resolve(start).marksAcross(tr.doc.resolve(end));
+          tr.replaceWith(start, end, state.schema.text(content, marks));
           tr.addMark(
             start,
             start + content.length,

--- a/packages/core/src/extensions/Typography.test.ts
+++ b/packages/core/src/extensions/Typography.test.ts
@@ -9,6 +9,7 @@ import { Typography } from './Typography.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
 import { Paragraph } from '../nodes/Paragraph.js';
+import { Bold } from '../marks/Bold.js';
 import { Editor } from '../Editor.js';
 
 describe('Typography', () => {
@@ -395,6 +396,46 @@ describe('Typography', () => {
       const tr = callHandler(rules[21], ed.state, ["'hello'", 'hello'], 1, 8);
       expect(tr).toBeTruthy();
       expect(tr.doc.textContent).toContain('\u2018');
+    });
+
+    describe('mark preservation', () => {
+      function createBoldEditor(content: string): Editor {
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, Bold, Typography],
+          content,
+        });
+        return editor;
+      }
+
+      it('ellipsis replacement keeps the marks of the replaced text', () => {
+        const ed = createBoldEditor('<p><strong>xx rest</strong></p>');
+        const rules = getRules();
+        const tr = callHandler(rules[1], ed.state, ['xx'], 1, 3);
+        expect(tr).toBeTruthy();
+        const textNode = tr.doc.firstChild?.firstChild;
+        expect(textNode?.text?.startsWith('\u2026')).toBe(true);
+        expect(textNode?.marks.some((mark: { type: { name: string } }) => mark.type.name === 'bold')).toBe(true);
+      });
+
+      it('smart double quotes keep the marks of the replaced text', () => {
+        const ed = createBoldEditor('<p><strong>"hello" rest</strong></p>');
+        const rules = getRules();
+        const tr = callHandler(rules[20], ed.state, ['"hello"', 'hello'], 1, 8);
+        expect(tr).toBeTruthy();
+        const textNode = tr.doc.firstChild?.firstChild;
+        expect(tr.doc.textContent).toContain('\u201c');
+        expect(textNode?.marks.some((mark: { type: { name: string } }) => mark.type.name === 'bold')).toBe(true);
+      });
+
+      it('smart single quotes with prefix keep the marks of the replaced text', () => {
+        const ed = createBoldEditor('<p><strong>a \'hello\' rest</strong></p>');
+        const rules = getRules();
+        const tr = callHandler(rules[21], ed.state, [" 'hello'", 'hello'], 2, 10);
+        expect(tr).toBeTruthy();
+        const textNode = tr.doc.firstChild?.firstChild;
+        expect(tr.doc.textContent).toContain('\u2018');
+        expect(textNode?.marks.some((mark: { type: { name: string } }) => mark.type.name === 'bold')).toBe(true);
+      });
     });
   });
 

--- a/packages/core/src/extensions/Typography.ts
+++ b/packages/core/src/extensions/Typography.ts
@@ -153,15 +153,16 @@ export const Typography = Extension.create<TypographyOptions>({
     if (this.options.smartQuotes) {
       const { openDoubleQuote, closeDoubleQuote, openSingleQuote, closeSingleQuote } = this.options;
 
+      // insertText (instead of replaceWith with a bare text node) inherits
+      // the replaced range's marks, so quoting inside marked text keeps the
+      // marks. The re-inserted prefix character carries the range's leading
+      // marks, which is what it had.
+
       // "text" → "text" (double quotes)
       rules.push(
         new InputRule(/"([^"]+)"$/, (state, match, start, end) => {
           const text = match[1] ?? '';
-          return state.tr.replaceWith(
-            start,
-            end,
-            state.schema.text(openDoubleQuote + text + closeDoubleQuote)
-          );
+          return state.tr.insertText(openDoubleQuote + text + closeDoubleQuote, start, end);
         })
       );
 
@@ -173,14 +174,12 @@ export const Typography = Extension.create<TypographyOptions>({
           const prefix = match[0].charAt(0);
           // If there's a prefix character (space, bracket, etc.), keep it
           const hasPrefix = prefix !== "'";
-          return state.tr.replaceWith(
+          return state.tr.insertText(
+            hasPrefix
+              ? prefix + openSingleQuote + text + closeSingleQuote
+              : openSingleQuote + text + closeSingleQuote,
             start,
-            end,
-            state.schema.text(
-              hasPrefix
-                ? prefix + openSingleQuote + text + closeSingleQuote
-                : openSingleQuote + text + closeSingleQuote
-            )
+            end
           );
         })
       );

--- a/packages/core/src/helpers/markInputRule.test.ts
+++ b/packages/core/src/helpers/markInputRule.test.ts
@@ -228,6 +228,143 @@ describe('markInputRule', () => {
     });
   });
 
+  describe('mark preservation', () => {
+    // Dedicated schema: a non-inclusive attributed mark (like a comment
+    // thread anchor) and a mark that excludes everything (like inline code).
+    const pschema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: {
+          group: 'block',
+          content: 'inline*',
+          toDOM: () => ['p', 0],
+          parseDOM: [{ tag: 'p' }],
+        },
+        text: { group: 'inline' },
+      },
+      marks: {
+        bold: {
+          parseDOM: [{ tag: 'strong' }],
+          toDOM: () => ['strong', 0],
+        },
+        italic: {
+          parseDOM: [{ tag: 'em' }],
+          toDOM: () => ['em', 0],
+        },
+        exclusiveCode: {
+          excludes: '_',
+          parseDOM: [{ tag: 'code' }],
+          toDOM: () => ['code', 0],
+        },
+        note: {
+          attrs: { ids: { default: [] } },
+          inclusive: false,
+          parseDOM: [{ tag: 'span' }],
+          toDOM: () => ['span', 0],
+        },
+      },
+    });
+
+    function markNames(marks: readonly { type: { name: string } }[]): string[] {
+      return marks.map((mark) => mark.type.name).sort();
+    }
+
+    it('keeps the marks of the matched text when the rule fires', () => {
+      const italic = pschema.marks.italic.create();
+      const doc = pschema.node('doc', null, [
+        pschema.node('paragraph', null, [pschema.text('**test**', [italic])]),
+      ]);
+      const state = EditorState.create({ schema: pschema, doc });
+
+      const rule = markInputRule({ find: markInputRulePatterns.bold, type: pschema.marks.bold });
+      const match = markInputRulePatterns.bold.exec('**test**');
+      if (!match) throw new Error('Pattern should match');
+
+      const result = getHandler(rule)(state, match, 1, 9);
+      expect(result).not.toBeNull();
+      const textNode = result?.doc.firstChild?.firstChild;
+      expect(textNode?.text).toBe('test');
+      expect(markNames(textNode?.marks ?? [])).toEqual(['bold', 'italic']);
+    });
+
+    it('keeps a non-inclusive mark strictly inside its range', () => {
+      const note = pschema.marks.note.create({ ids: ['t1'] });
+      const doc = pschema.node('doc', null, [
+        pschema.node('paragraph', null, [
+          pschema.text('**test**', [note]),
+          pschema.text(' after', [note]),
+        ]),
+      ]);
+      const state = EditorState.create({ schema: pschema, doc });
+
+      const rule = markInputRule({ find: markInputRulePatterns.bold, type: pschema.marks.bold });
+      const match = markInputRulePatterns.bold.exec('**test**');
+      if (!match) throw new Error('Pattern should match');
+
+      const result = getHandler(rule)(state, match, 1, 9);
+      const textNode = result?.doc.firstChild?.firstChild;
+      expect(markNames(textNode?.marks ?? [])).toEqual(['bold', 'note']);
+      const noteMark = textNode?.marks.find((mark) => mark.type.name === 'note');
+      expect(noteMark?.attrs['ids']).toEqual(['t1']);
+    });
+
+    it('drops a non-inclusive mark at the exact end of its range', () => {
+      // No note-marked text follows the match, so this is the range end and
+      // the replacement behaves like typing there: the mark does not extend.
+      const note = pschema.marks.note.create({ ids: ['t1'] });
+      const doc = pschema.node('doc', null, [
+        pschema.node('paragraph', null, [
+          pschema.text('**test**', [note]),
+          pschema.text(' after'),
+        ]),
+      ]);
+      const state = EditorState.create({ schema: pschema, doc });
+
+      const rule = markInputRule({ find: markInputRulePatterns.bold, type: pschema.marks.bold });
+      const match = markInputRulePatterns.bold.exec('**test**');
+      if (!match) throw new Error('Pattern should match');
+
+      const result = getHandler(rule)(state, match, 1, 9);
+      const textNode = result?.doc.firstChild?.firstChild;
+      expect(markNames(textNode?.marks ?? [])).toEqual(['bold']);
+    });
+
+    it('still strips marks the new mark excludes', () => {
+      const bold = pschema.marks.bold.create();
+      const doc = pschema.node('doc', null, [
+        pschema.node('paragraph', null, [pschema.text('`x`', [bold])]),
+      ]);
+      const state = EditorState.create({ schema: pschema, doc });
+
+      const rule = markInputRule({
+        find: markInputRulePatterns.code,
+        type: pschema.marks.exclusiveCode,
+      });
+      const match = markInputRulePatterns.code.exec('`x`');
+      if (!match) throw new Error('Pattern should match');
+
+      const result = getHandler(rule)(state, match, 1, 4);
+      const textNode = result?.doc.firstChild?.firstChild;
+      expect(markNames(textNode?.marks ?? [])).toEqual(['exclusiveCode']);
+    });
+
+    it('prefers stored marks over the marks of the replaced range', () => {
+      const italic = pschema.marks.italic.create();
+      const doc = pschema.node('doc', null, [
+        pschema.node('paragraph', null, [pschema.text('**test**')]),
+      ]);
+      const state = EditorState.create({ schema: pschema, doc, storedMarks: [italic] });
+
+      const rule = markInputRule({ find: markInputRulePatterns.bold, type: pschema.marks.bold });
+      const match = markInputRulePatterns.bold.exec('**test**');
+      if (!match) throw new Error('Pattern should match');
+
+      const result = getHandler(rule)(state, match, 1, 9);
+      const textNode = result?.doc.firstChild?.firstChild;
+      expect(markNames(textNode?.marks ?? [])).toEqual(['bold', 'italic']);
+    });
+  });
+
   describe('markInputRulePatterns', () => {
     it('exports pre-built patterns', () => {
       expect(markInputRulePatterns.bold).toBeInstanceOf(RegExp);

--- a/packages/core/src/helpers/markInputRule.ts
+++ b/packages/core/src/helpers/markInputRule.ts
@@ -87,8 +87,14 @@ export function markInputRule(options: MarkInputRuleOptions): InputRule {
 
       const { tr } = state;
 
-      // Replace the matched text (including delimiters) with just the content
-      tr.replaceWith(start, end, state.schema.text(textContent));
+      // Replace the matched text (including delimiters) with just the content.
+      // The replacement carries the marks the matched text already had
+      // (stored marks first, like Transaction.insertText), so firing a rule
+      // inside commented or colored text does not strip those marks. Schema
+      // exclusion still applies when the new mark is added below: addToSet
+      // drops any preserved mark the new mark excludes.
+      const marks = tr.storedMarks ?? tr.doc.resolve(start).marksAcross(tr.doc.resolve(end));
+      tr.replaceWith(start, end, state.schema.text(textContent, marks));
 
       // Apply the mark to the inserted text
       tr.addMark(start, start + textContent.length, type.create(attributes ?? undefined));

--- a/packages/core/src/helpers/textInputRule.test.ts
+++ b/packages/core/src/helpers/textInputRule.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for textInputRule helper
+ *
+ * Same handler-direct approach as markInputRule.test.ts: full input rule
+ * integration needs DOM input events, so these tests call the handler with
+ * a hand-built state and assert on the returned transaction.
+ */
+import { describe, it, expect } from 'vitest';
+import { Schema } from '@domternal/pm/model';
+import type { Transaction } from '@domternal/pm/state';
+import { EditorState } from '@domternal/pm/state';
+import { textInputRule } from './textInputRule.js';
+
+describe('textInputRule', () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: {
+        group: 'block',
+        content: 'inline*',
+        toDOM: () => ['p', 0],
+        parseDOM: [{ tag: 'p' }],
+      },
+      text: { group: 'inline' },
+    },
+    marks: {
+      bold: {
+        parseDOM: [{ tag: 'strong' }],
+        toDOM: () => ['strong', 0],
+      },
+      italic: {
+        parseDOM: [{ tag: 'em' }],
+        toDOM: () => ['em', 0],
+      },
+      note: {
+        attrs: { ids: { default: [] } },
+        inclusive: false,
+        parseDOM: [{ tag: 'span' }],
+        toDOM: () => ['span', 0],
+      },
+    },
+  });
+
+  type InputRuleHandler = (
+    state: EditorState,
+    match: RegExpMatchArray,
+    start: number,
+    end: number
+  ) => Transaction | null;
+
+  function getHandler(rule: ReturnType<typeof textInputRule>): InputRuleHandler {
+
+    return (rule as any).handler as InputRuleHandler;
+  }
+
+  function stateWith(children: Parameters<typeof schema.node>[2]): EditorState {
+    const doc = schema.node('doc', null, [schema.node('paragraph', null, children)]);
+    return EditorState.create({ schema, doc });
+  }
+
+  const match = ['--'] as unknown as RegExpMatchArray;
+
+  it('creates a valid InputRule with a handler', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    expect(rule).toHaveProperty('match');
+    expect(typeof getHandler(rule)).toBe('function');
+  });
+
+  it('replaces the matched text', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    const state = stateWith([schema.text('--')]);
+
+    const result = getHandler(rule)(state, match, 1, 3);
+    expect(result?.docChanged).toBe(true);
+    expect(result?.doc.textContent).toBe('—');
+  });
+
+  it('passes undoable through to the rule', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—', undoable: false });
+
+    expect((rule as any).undoable).toBe(false);
+  });
+
+  it('keeps the marks of the replaced text', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    const bold = schema.marks.bold.create();
+    const state = stateWith([schema.text('--', [bold])]);
+
+    const result = getHandler(rule)(state, match, 1, 3);
+    const textNode = result?.doc.firstChild?.firstChild;
+    expect(textNode?.text).toBe('—');
+    expect(textNode?.marks.map((mark) => mark.type.name)).toEqual(['bold']);
+  });
+
+  it('keeps multiple marks of the replaced text', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    const bold = schema.marks.bold.create();
+    const italic = schema.marks.italic.create();
+    const state = stateWith([schema.text('--', [bold, italic])]);
+
+    const result = getHandler(rule)(state, match, 1, 3);
+    const names = result?.doc.firstChild?.firstChild?.marks.map((mark) => mark.type.name).sort();
+    expect(names).toEqual(['bold', 'italic']);
+  });
+
+  it('keeps a non-inclusive mark strictly inside its range', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    const note = schema.marks.note.create({ ids: ['t1'] });
+    const state = stateWith([schema.text('x--', [note]), schema.text('y', [note])]);
+
+    const result = getHandler(rule)(state, match, 2, 4);
+    // Identically marked neighbors merge into one node: the replacement
+    // inherited the note mark, so no hole splits the marked run.
+    const textNode = result?.doc.firstChild?.firstChild;
+    expect(result?.doc.firstChild?.childCount).toBe(1);
+    expect(textNode?.text).toBe('x—y');
+    expect(textNode?.marks.map((mark) => mark.type.name)).toEqual(['note']);
+  });
+
+  it('drops a non-inclusive mark at the exact end of its range', () => {
+    const rule = textInputRule({ find: /--$/, replace: '—' });
+    const note = schema.marks.note.create({ ids: ['t1'] });
+    const state = stateWith([schema.text('x--', [note])]);
+
+    const result = getHandler(rule)(state, match, 2, 4);
+    const paragraph = result?.doc.firstChild;
+    expect(paragraph?.childCount).toBe(2);
+    expect(paragraph?.child(1).text).toBe('—');
+    expect(paragraph?.child(1).marks).toHaveLength(0);
+  });
+});

--- a/packages/core/src/helpers/textInputRule.ts
+++ b/packages/core/src/helpers/textInputRule.ts
@@ -39,7 +39,10 @@ export function textInputRule(options: TextInputRuleOptions): InputRule {
 
   return new InputRule(
     find,
-    (state, _match, start, end) => state.tr.replaceWith(start, end, state.schema.text(replace)),
+    // insertText inherits the replaced range's marks (stored marks first,
+    // then marksAcross), so a replacement inside marked text keeps the
+    // marks instead of punching an unmarked hole into them.
+    (state, _match, start, end) => state.tr.insertText(replace, start, end),
     undoable !== undefined ? { undoable } : {},
   );
 }

--- a/packages/core/src/marks/Bold.ts
+++ b/packages/core/src/marks/Bold.ts
@@ -37,6 +37,8 @@ export interface BoldOptions {
 export const Bold = Mark.create<BoldOptions>({
   name: 'bold',
 
+  group: 'formatting',
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/packages/core/src/marks/Code.test.ts
+++ b/packages/core/src/marks/Code.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { TextSelection } from '@domternal/pm/state';
 import { Code } from './Code.js';
 import { Bold } from './Bold.js';
+import { Link } from './Link.js';
 import { Document } from '../nodes/Document.js';
 import { Text } from '../nodes/Text.js';
 import { Paragraph } from '../nodes/Paragraph.js';
 import { Editor } from '../Editor.js';
+import { Mark } from '../Mark.js';
 
 describe('Code', () => {
   describe('configuration', () => {
@@ -21,8 +23,9 @@ describe('Code', () => {
       expect(Code.options).toEqual({ HTMLAttributes: {} });
     });
 
-    it('excludes all other marks', () => {
-      expect(Code.config.excludes).toBe('_');
+    it('excludes the formatting mark group', () => {
+      expect(Code.config.excludes).toBe('formatting');
+      expect(Code.config.group).toBe('formatting');
     });
 
     it('does not span across nodes', () => {
@@ -108,10 +111,85 @@ describe('Code', () => {
         content: '<p><code><strong>bold code</strong></code></p>',
       });
       const textNode = editor.state.doc.child(0).child(0);
-      // Code excludes all, so bold should be stripped
+      // Code excludes the formatting group, so bold should be stripped
       const markNames = textNode.marks.map((m) => m.type.name);
       expect(markNames).toContain('code');
       expect(markNames).not.toContain('bold');
+    });
+
+    it('constructs with a minimal schema (group excludes resolve safely)', () => {
+      // A name-list excludes would throw 'Unknown mark type' here; the
+      // group form must resolve to just [code] in a Code-only schema.
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Code],
+        content: '<p>hello</p>',
+      });
+      const codeType = editor.state.schema.marks['code'];
+      expect(codeType).toBeDefined();
+      expect(codeType?.excludes(codeType)).toBe(true);
+    });
+
+    it('semantic marks outside the formatting group survive setCode', () => {
+      const Note = Mark.create({
+        name: 'note',
+        isFormatting: false,
+        addAttributes() {
+          return { ids: { default: [] } };
+        },
+        parseHTML() {
+          return [{ tag: 'span[data-note]' }];
+        },
+        renderHTML() {
+          return ['span', { 'data-note': 'true' }, 0];
+        },
+      });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Code, Bold, Note],
+        content: '<p><span data-note="true">Hello</span> world</p>',
+      });
+      const { state } = editor;
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 1, 6)));
+      editor.commands.setCode();
+      const textNode = editor.state.doc.child(0).child(0);
+      const markNames = textNode.marks.map((m) => m.type.name).sort();
+      expect(markNames).toEqual(['code', 'note']);
+    });
+
+    it('links survive setCode', () => {
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Code, Link],
+        content: '<p><a href="https://example.com">Hello</a> world</p>',
+      });
+      const { state } = editor;
+      editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, 1, 6)));
+      editor.commands.setCode();
+      const textNode = editor.state.doc.child(0).child(0);
+      const markNames = textNode.marks.map((m) => m.type.name).sort();
+      expect(markNames).toEqual(['code', 'link']);
+    });
+
+    it('compiled schema excludes formatting marks but not semantic ones', () => {
+      const Note = Mark.create({
+        name: 'note',
+        isFormatting: false,
+        parseHTML() {
+          return [{ tag: 'span[data-note]' }];
+        },
+        renderHTML() {
+          return ['span', { 'data-note': 'true' }, 0];
+        },
+      });
+      editor = new Editor({
+        extensions: [Document, Text, Paragraph, Code, Bold, Note],
+        content: '<p>hello</p>',
+      });
+      const { marks } = editor.state.schema;
+      const codeType = marks['code'];
+      const boldType = marks['bold'];
+      const noteType = marks['note'];
+      if (!codeType || !boldType || !noteType) throw new Error('Schema is missing marks');
+      expect(codeType.excludes(boldType)).toBe(true);
+      expect(codeType.excludes(noteType)).toBe(false);
     });
 
     it('setCode applies code to selected text', () => {

--- a/packages/core/src/marks/Code.ts
+++ b/packages/core/src/marks/Code.ts
@@ -43,9 +43,14 @@ export const Code = Mark.create<CodeOptions>({
     };
   },
 
-  // Code mark is exclusive - it cannot be combined with other marks
-  // ProseMirror uses '_' to mean "exclude all marks"
-  excludes: '_',
+  // Code cannot be combined with other FORMATTING marks (bold, italic,
+  // color...), but semantic marks outside the group (link, a comment
+  // thread anchor) survive: code excludes the 'formatting' group instead
+  // of '_' (everything). Third-party formatting marks opt into the same
+  // exclusion by declaring group: 'formatting'. Code is in the group
+  // itself, which also keeps it self-exclusive.
+  group: 'formatting',
+  excludes: 'formatting',
 
   // Code should not span across multiple nodes
   spanning: false,

--- a/packages/core/src/marks/Italic.ts
+++ b/packages/core/src/marks/Italic.ts
@@ -37,6 +37,8 @@ export interface ItalicOptions {
 export const Italic = Mark.create<ItalicOptions>({
   name: 'italic',
 
+  group: 'formatting',
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/packages/core/src/marks/Strike.ts
+++ b/packages/core/src/marks/Strike.ts
@@ -36,6 +36,8 @@ export interface StrikeOptions {
 export const Strike = Mark.create<StrikeOptions>({
   name: 'strike',
 
+  group: 'formatting',
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/packages/core/src/marks/Subscript.ts
+++ b/packages/core/src/marks/Subscript.ts
@@ -34,6 +34,8 @@ export interface SubscriptOptions {
 export const Subscript = Mark.create<SubscriptOptions>({
   name: 'subscript',
 
+  group: 'formatting',
+
   // Mutual exclusion handled in toggle commands (not schema)
   // so can() dry-run works correctly for toolbar disabled state
   excludes: '',

--- a/packages/core/src/marks/Superscript.ts
+++ b/packages/core/src/marks/Superscript.ts
@@ -34,6 +34,8 @@ export interface SuperscriptOptions {
 export const Superscript = Mark.create<SuperscriptOptions>({
   name: 'superscript',
 
+  group: 'formatting',
+
   // Mutual exclusion handled in toggle commands (not schema)
   // so can() dry-run works correctly for toolbar disabled state
   excludes: '',

--- a/packages/core/src/marks/TextStyle.ts
+++ b/packages/core/src/marks/TextStyle.ts
@@ -36,6 +36,8 @@ export interface TextStyleOptions {
 export const TextStyle = Mark.create<TextStyleOptions>({
   name: 'textStyle',
 
+  group: 'formatting',
+
   // Lower priority so it renders after other marks
   priority: 101,
 

--- a/packages/core/src/marks/Underline.ts
+++ b/packages/core/src/marks/Underline.ts
@@ -34,6 +34,8 @@ export interface UnderlineOptions {
 export const Underline = Mark.create<UnderlineOptions>({
   name: 'underline',
 
+  group: 'formatting',
+
   addOptions() {
     return {
       HTMLAttributes: {},

--- a/packages/core/src/types/MarkConfig.ts
+++ b/packages/core/src/types/MarkConfig.ts
@@ -120,11 +120,21 @@ interface MarkSchemaProperties {
    * Marks that this mark excludes (cannot coexist with)
    *
    * - '_' excludes all marks
-   * - Space-separated mark names exclude specific marks
+   * - Space-separated mark names or group names exclude those marks
    * - Empty string or undefined means no exclusions
+   *
+   * Note: mark NAMES listed here must exist in the schema or schema
+   * compilation throws, so extensions meant to work in minimal setups
+   * should exclude by group. The core formatting marks (bold, italic,
+   * underline, strike, code, sub/superscript, textStyle) all declare
+   * group 'formatting', and Code excludes that group: a third-party
+   * formatting mark joins the exclusion by declaring the same group,
+   * while semantic marks (link, comment anchors) stay combinable with
+   * code by staying out of it.
    *
    * @example 'code' - excludes code mark
    * @example 'bold italic' - excludes bold and italic
+   * @example 'formatting' - excludes the formatting group
    * @example '_' - excludes all other marks
    */
   excludes?: string;
@@ -136,6 +146,18 @@ interface MarkSchemaProperties {
    * @example 'formatting', 'inline'
    */
   group?: string;
+
+  /**
+   * Whether block duplication keeps this mark on the copied content
+   *
+   * Set false for marks that reference identity-bearing external state
+   * (a comment thread anchor, a suggestion id): duplicating such a mark
+   * would make one identity point at two unrelated places, so block
+   * duplicate strips it from the copy instead.
+   *
+   * @default true
+   */
+  keepOnDuplicate?: boolean;
 
   /**
    * Whether this mark can span multiple nodes

--- a/packages/extension-block-controls/src/helpers/blockOperations.test.ts
+++ b/packages/extension-block-controls/src/helpers/blockOperations.test.ts
@@ -9,7 +9,9 @@ import {
   BlockColor,
   BulletList,
   ListItem,
+  Bold,
   Editor,
+  Mark,
 } from '@domternal/core';
 import {
   deleteBlock,
@@ -259,6 +261,51 @@ describe('blockOperations', () => {
       const tr = editor.state.tr;
       duplicateBlock(tr, 999);
       expect(tr.steps.length).toBe(0);
+      editor.destroy();
+    });
+
+    it('strips marks flagged keepOnDuplicate: false from the copy', () => {
+      const Anchor = Mark.create({
+        name: 'anchor',
+        keepOnDuplicate: false,
+        addAttributes() {
+          return { ids: { default: [] } };
+        },
+        parseHTML() {
+          return [{ tag: 'span[data-anchor]' }];
+        },
+        renderHTML() {
+          return ['span', { 'data-anchor': 'true' }, 0];
+        },
+      });
+      const editor = new Editor({
+        extensions: [Document, Text, Paragraph, Bold, Anchor],
+        content: '<p><strong><span data-anchor="true">Hello</span></strong></p>',
+      });
+      const first = findTopLevelBlock(editor.state.doc, 1);
+      const tr = editor.state.tr;
+      duplicateBlock(tr, first?.pos ?? 0);
+      editor.view.dispatch(tr);
+
+      const names = (index: number): string[] =>
+        editor.state.doc.child(index).child(0).marks.map((m) => m.type.name).sort();
+      expect(names(0)).toEqual(['anchor', 'bold']);
+      expect(names(1)).toEqual(['bold']);
+      editor.destroy();
+    });
+
+    it('keeps unflagged marks on the copy', () => {
+      const editor = new Editor({
+        extensions: [Document, Text, Paragraph, Bold],
+        content: '<p><strong>Hello</strong></p>',
+      });
+      const first = findTopLevelBlock(editor.state.doc, 1);
+      const tr = editor.state.tr;
+      duplicateBlock(tr, first?.pos ?? 0);
+      editor.view.dispatch(tr);
+
+      const copyMarks = editor.state.doc.child(1).child(0).marks.map((m) => m.type.name);
+      expect(copyMarks).toEqual(['bold']);
       editor.destroy();
     });
   });

--- a/packages/extension-block-controls/src/helpers/blockOperations.ts
+++ b/packages/extension-block-controls/src/helpers/blockOperations.ts
@@ -1,4 +1,4 @@
-import type { Attrs, NodeType } from '@domternal/pm/model';
+import type { Attrs, Fragment, Mark, Node as PMNode, NodeType } from '@domternal/pm/model';
 import type { Transaction } from '@domternal/pm/state';
 import { TextSelection } from '@domternal/pm/state';
 import { expandToEmptyWrappers } from './expandToEmptyWrappers.js';
@@ -59,9 +59,40 @@ export function deleteBlock(tr: Transaction, blockPos: number): Transaction {
 }
 
 /**
+ * Marks whose spec declares `keepOnDuplicate: false` reference identity
+ * outside the document (a comment thread anchor, a suggestion id); copying
+ * them along would make one identity point at two unrelated places, so
+ * `duplicateBlock` strips them from the copy.
+ */
+function stripDropOnDuplicateMarks(marks: readonly Mark[]): readonly Mark[] {
+  return marks.filter((mark) => mark.type.spec['keepOnDuplicate'] !== false);
+}
+
+function stripDropOnDuplicateNode(node: PMNode): PMNode {
+  const marks = stripDropOnDuplicateMarks(node.marks);
+  if (node.isText) {
+    return marks.length === node.marks.length ? node : node.mark(marks as Mark[]);
+  }
+  const content = stripDropOnDuplicateFragment(node.content);
+  if (marks.length === node.marks.length && content === node.content) return node;
+  return node.type.create(node.attrs, content, marks as Mark[]);
+}
+
+function stripDropOnDuplicateFragment(fragment: Fragment): Fragment {
+  // replaceChild returns the same fragment for an identical child, so an
+  // unchanged fragment keeps its identity (callers compare by reference).
+  let result = fragment;
+  fragment.forEach((child, _offset, index) => {
+    result = result.replaceChild(index, stripDropOnDuplicateNode(child));
+  });
+  return result;
+}
+
+/**
  * Duplicates the block at `blockPos`, inserting a copy immediately after it.
  * The copy preserves content, attrs, AND node-level marks (needed for
- * annotation / comment extensions that attach marks to blocks).
+ * annotation / comment extensions that attach marks to blocks), except marks
+ * declaring `keepOnDuplicate: false`, which are stripped throughout the copy.
  *
  * @param transformAttrs Optional mapper on the source attrs to produce the
  *   copy's attrs. Use it to regenerate unique IDs so the duplicate doesn't
@@ -79,7 +110,11 @@ export function duplicateBlock(
   const attrs = transformAttrs ? transformAttrs(node.attrs) : node.attrs;
   // `type.create(attrs, content, marks)` preserves all three; `node.copy(content)`
   // drops node marks, breaking block-level annotations.
-  const copy = node.type.create(attrs, node.content, node.marks);
+  const copy = node.type.create(
+    attrs,
+    stripDropOnDuplicateFragment(node.content),
+    stripDropOnDuplicateMarks(node.marks) as Mark[],
+  );
   tr.insert(blockEnd, copy);
   return tr;
 }

--- a/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
+++ b/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
@@ -96,6 +96,7 @@ export function DomternalBubbleMenu({
   // to the color picker and block context menu (positioning targets).
   const colorBtnRef = useRef<HTMLButtonElement>(null);
   const blockMenuBtnRef = useRef<HTMLButtonElement>(null);
+  const innerHtml = useInnerHtml();
 
   return (
     <div ref={menuRef} className="dm-bubble-menu" role="toolbar" aria-label="Text formatting">
@@ -133,7 +134,7 @@ export function DomternalBubbleMenu({
             title={btn.label}
             aria-label={btn.label}
             aria-pressed={active}
-            dangerouslySetInnerHTML={{ __html: getCachedHtml(btn.icon) }}
+            dangerouslySetInnerHTML={innerHtml(getCachedHtml(btn.icon))}
             onMouseDown={(e) => { e.preventDefault(); }}
             onClick={(e) => { executeCommand(btn, e); }}
           />
@@ -176,7 +177,7 @@ export function DomternalBubbleMenu({
               : 'More options'}
             aria-label="More options"
             aria-haspopup="menu"
-            dangerouslySetInnerHTML={{ __html: getCachedHtml('dotsThree') }}
+            dangerouslySetInnerHTML={innerHtml(getCachedHtml('dotsThree'))}
             onMouseDown={(e) => { e.preventDefault(); }}
             onClick={() => { if (blockMenuBtnRef.current) openBlockContextMenu(blockMenuBtnRef.current); }}
           />
@@ -185,6 +186,27 @@ export function DomternalBubbleMenu({
       {children}
     </div>
   );
+}
+
+/**
+ * Stable `dangerouslySetInnerHTML` payloads, keyed by the markup itself.
+ *
+ * React compares that prop by identity, so a fresh literal per render rewrites
+ * `innerHTML` and destroys the icon nodes. The menu re-renders on every
+ * transaction, so an overlay closing on pointerdown swaps the icon out
+ * mid-gesture, leaving mousedown and mouseup with no element in common and no
+ * click fired at all.
+ */
+function useInnerHtml(): (html: string) => { __html: string } {
+  const cache = useRef(new Map<string, { __html: string }>());
+  return (html: string): { __html: string } => {
+    let prop = cache.current.get(html);
+    if (prop === undefined) {
+      prop = { __html: html };
+      cache.current.set(html, prop);
+    }
+    return prop;
+  };
 }
 
 // ===== Bubble-menu-embedded dropdown =====
@@ -218,6 +240,7 @@ function BubbleDropdown({
   void activeVersion;
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const innerHtml = useInnerHtml();
 
   const dropdownActive = dropdown.items.some((sub) => isItemActive(sub));
   const activeChild = dropdown.dynamicIcon
@@ -281,7 +304,7 @@ function BubbleDropdown({
         aria-label={dropdown.label}
         title={dropdown.label}
         data-dropdown={dropdown.name}
-        dangerouslySetInnerHTML={{ __html: triggerHtml }}
+        dangerouslySetInnerHTML={innerHtml(triggerHtml)}
         onMouseDown={(e) => { e.preventDefault(); }}
         onClick={onToggle}
       />
@@ -303,7 +326,7 @@ function BubbleDropdown({
                 className={`dm-toolbar-dropdown-item${subActive ? ' dm-toolbar-dropdown-item--active' : ''}`}
                 role="menuitem"
                 aria-label={sub.label}
-                dangerouslySetInnerHTML={{ __html: subHtml }}
+                dangerouslySetInnerHTML={innerHtml(subHtml)}
                 onMouseDown={(e) => { e.preventDefault(); }}
                 onClick={() => { executeSubItem(sub); }}
               />


### PR DESCRIPTION
## Summary

Four independent ways a mark or a click was silently destroyed, plus two opt-in
schema flags. Touches `core`, `react` and `extension-block-controls`.

## Features

- **`formatting` mark group** on the eight core formatting marks. A third-party
  formatting mark joins the same exclusion set by declaring it.
- **`keepOnDuplicate` mark spec flag.** Set `false` on a mark that references
  identity outside the document and block duplicate strips it from the copy.
  Defaults to `true`, so existing marks are unaffected.

## Fix

- Input rules (`markInputRule`, `textInputRule`, Highlight, Typography smart
  quotes) replaced the matched range with a bare text node, stripping marks the
  text already had. They now carry them.
- Code excluded every other mark, so a link or annotation could not survive
  inline code. It now excludes the `formatting` group. This also avoids
  excluding by mark name, which throws on schemas that lack it.
- `duplicateBlock` copied identity-bearing marks into the copy.
- React: the first bubble menu click after an overlay closed on `pointerdown`
  did nothing at all. A fresh `dangerouslySetInnerHTML` literal per render made
  React destroy the icon under the pointer between `mousedown` and `mouseup`,
  so no `click` was ever fired. Core made it worse by reading the detached
  target as "outside" and hiding the menu until the selection changed.

## Changes

- The table of contents hover check in the per-app demo suites polled the
  animated opacity instead of reading it mid transition.

## Verified

Built all packages. Unit tests, lint and typecheck pass, with new coverage for
every fix except the React one. API surface unchanged. The React bug was caught
by a cross-framework run: it reproduced on React only, with vanilla, Angular and
Vue passing.