### PR TITLE
d12e7ff fix(react): stop every menu rewriting its icons on each render, so a press that outlives a transaction still fires

### DIFF
--- a/e2e/menu-click-during-transaction.spec.ts
+++ b/e2e/menu-click-during-transaction.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * A menu button must still fire when something dispatches an editor
+ * transaction during the same press.
+ *
+ * That is what any overlay closing on an outside press does, and it used to
+ * kill the click outright in React. The wrapper re-renders on the transaction
+ * and rewrites every button's `innerHTML`, because the
+ * `dangerouslySetInnerHTML` payload was a fresh object on each render, so the
+ * icon under the pointer is destroyed between mousedown and mouseup. With no
+ * element common to the two, the browser fires no click at all.
+ *
+ * The probe below stands in for the overlay: it dispatches a no-op transaction
+ * on any press outside the editor, which is exactly the timing that broke.
+ * Only React ever failed either body, so the value is in running both against
+ * all four demos.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const EDITOR = '.dm-editor .ProseMirror';
+
+async function openDemo(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(EDITOR);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 5000 },
+  );
+  await page.evaluate(() => {
+    const editor = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { setContent: (h: string, emit: boolean) => void }
+      | undefined;
+    editor?.setContent('<p>The sentence under the pointer.</p>', false);
+  });
+}
+
+/**
+ * Dispatches an empty transaction on every press outside the editor, the way
+ * a popover's outside-press listener does when it closes. Scoped to presses
+ * outside so it never interferes with ProseMirror's own mousedown handling.
+ */
+async function installOverlayProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const editor = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { view: { state: { tr: unknown }; dispatch: (tr: unknown) => void; dom: HTMLElement } }
+      | undefined;
+    if (!editor) throw new Error('no editor');
+    document.addEventListener(
+      'pointerdown',
+      (event) => {
+        const target = event.target as Node | null;
+        if (target && editor.view.dom.contains(target)) return;
+        editor.view.dispatch(editor.view.state.tr);
+      },
+      true,
+    );
+  });
+}
+
+/** ProseMirror only reads a selectionchange while it holds DOM focus. */
+async function selectFirstWords(page: Page): Promise<void> {
+  await page.evaluate((selector) => {
+    const paragraph = document.querySelector(`${selector} p`);
+    if (!paragraph?.firstChild) throw new Error('no paragraph');
+    const range = document.createRange();
+    range.setStart(paragraph.firstChild, 0);
+    range.setEnd(paragraph.firstChild, 12);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const editorEl = document.querySelector(selector);
+    if (editorEl instanceof HTMLElement) editorEl.focus();
+  }, EDITOR);
+}
+
+function boldIsActive(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () =>
+      (
+        (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+          | { isActive: (n: string) => boolean }
+          | undefined
+      )?.isActive('bold') ?? false,
+  );
+}
+
+for (const target of demoTargets) {
+  test(`${target.name}: a bubble menu button fires when a press dispatches a transaction`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await installOverlayProbe(page);
+    await selectFirstWords(page);
+
+    const menu = page.locator('.dm-bubble-menu');
+    await expect(menu).toHaveAttribute('data-show', '');
+    await menu.locator('[aria-label="Bold"]').click();
+
+    await expect.poll(() => boldIsActive(page)).toBe(true);
+    // Still there to press again, rather than suppressed until the reader
+    // picks a different range.
+    await expect(menu).toHaveAttribute('data-show', '');
+  });
+
+  test(`${target.name}: a toolbar button fires when the press outlives a frame`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await installOverlayProbe(page);
+    await selectFirstWords(page);
+
+    const bold = page.locator('.dm-toolbar [aria-label="Bold"]');
+    await expect(bold).toBeVisible();
+    const box = await bold.boundingBox();
+    if (!box) throw new Error('no box');
+
+    // Held across several frames, the way a real click is. The toolbar defers
+    // its re-render by one frame, which hides the problem from an instant
+    // synthetic click but not from a person pressing the button.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(150);
+    await page.mouse.up();
+
+    await expect.poll(() => boldIsActive(page)).toBe(true);
+  });
+}

--- a/packages/react/src/DomternalFloatingMenu.tsx
+++ b/packages/react/src/DomternalFloatingMenu.tsx
@@ -26,6 +26,7 @@ import type {
   IconSet,
 } from '@domternal/core';
 import { useCurrentEditor } from './EditorContext.js';
+import { useInnerHtml } from './useInnerHtml.js';
 
 export interface DomternalFloatingMenuProps {
   /** The editor instance. If omitted, uses EditorProvider context. */
@@ -280,6 +281,7 @@ function FloatingMenuItemButton({
   iconHtml,
   onClick,
 }: ItemButtonProps): ReactNode {
+  const innerHtml = useInnerHtml();
   const handleClick = useCallback((): void => { onClick(item); }, [item, onClick]);
   // Prevent mousedown from stealing editor focus before we run the command.
   const onMouseDown = useCallback((e: ReactMouseEvent): void => {
@@ -304,7 +306,7 @@ function FloatingMenuItemButton({
         <span
           className="dm-floating-menu-item-icon"
           aria-hidden="true"
-          dangerouslySetInnerHTML={{ __html: iconHtml }}
+          dangerouslySetInnerHTML={innerHtml(iconHtml)}
         />
       )}
       <span className="dm-floating-menu-item-label">{item.label}</span>

--- a/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
+++ b/packages/react/src/bubble-menu/DomternalBubbleMenu.tsx
@@ -9,6 +9,7 @@ import {
 import type { Editor, BubbleMenuOptions, IconSet, ToolbarButton, ToolbarDropdown } from '@domternal/core';
 import { positionFloatingOnce, refocusEditorAfterCommand } from '@domternal/core';
 import { useCurrentEditor } from '../EditorContext.js';
+import { useInnerHtml } from '../useInnerHtml.js';
 import { useBubbleMenu } from './useBubbleMenu.js';
 
 export interface DomternalBubbleMenuProps {
@@ -186,27 +187,6 @@ export function DomternalBubbleMenu({
       {children}
     </div>
   );
-}
-
-/**
- * Stable `dangerouslySetInnerHTML` payloads, keyed by the markup itself.
- *
- * React compares that prop by identity, so a fresh literal per render rewrites
- * `innerHTML` and destroys the icon nodes. The menu re-renders on every
- * transaction, so an overlay closing on pointerdown swaps the icon out
- * mid-gesture, leaving mousedown and mouseup with no element in common and no
- * click fired at all.
- */
-function useInnerHtml(): (html: string) => { __html: string } {
-  const cache = useRef(new Map<string, { __html: string }>());
-  return (html: string): { __html: string } => {
-    let prop = cache.current.get(html);
-    if (prop === undefined) {
-      prop = { __html: html };
-      cache.current.set(html, prop);
-    }
-    return prop;
-  };
 }
 
 // ===== Bubble-menu-embedded dropdown =====

--- a/packages/react/src/toolbar/ToolbarButton.tsx
+++ b/packages/react/src/toolbar/ToolbarButton.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { ToolbarButton as ToolbarButtonType } from '@domternal/core';
+import { useInnerHtml } from '../useInnerHtml.js';
 
 export interface ToolbarButtonProps {
   item: ToolbarButtonType;
@@ -24,6 +25,7 @@ export function ToolbarButton({
   onClick,
   onFocus,
 }: ToolbarButtonProps): ReactNode {
+  const innerHtml = useInnerHtml();
   return (
     <button
       type="button"
@@ -34,7 +36,7 @@ export function ToolbarButton({
       title={tooltip}
       tabIndex={tabIndex}
       disabled={isDisabled}
-      dangerouslySetInnerHTML={{ __html: iconHtml }}
+      dangerouslySetInnerHTML={innerHtml(iconHtml)}
       onMouseDown={(e) => { e.preventDefault(); }}
       onClick={(e) => { onClick(item, e); }}
       onFocus={() => { onFocus(item.name); }}

--- a/packages/react/src/toolbar/ToolbarDropdown.tsx
+++ b/packages/react/src/toolbar/ToolbarDropdown.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { ToolbarButton, ToolbarDropdown as ToolbarDropdownType } from '@domternal/core';
+import { useInnerHtml } from '../useInnerHtml.js';
 import { ToolbarDropdownPanel } from './ToolbarDropdownPanel.js';
 
 export interface ToolbarDropdownProps {
@@ -29,6 +30,7 @@ export function ToolbarDropdown({
   onItemClick,
   onFocus,
 }: ToolbarDropdownProps): ReactNode {
+  const innerHtml = useInnerHtml();
   return (
     <div className="dm-toolbar-dropdown-wrapper">
       <button
@@ -41,7 +43,7 @@ export function ToolbarDropdown({
         tabIndex={tabIndex}
         disabled={isDisabled}
         data-dropdown={dropdown.name}
-        dangerouslySetInnerHTML={{ __html: triggerHtml }}
+        dangerouslySetInnerHTML={innerHtml(triggerHtml)}
         onMouseDown={(e) => { e.preventDefault(); }}
         onClick={() => { onToggle(dropdown); }}
         onFocus={() => { onFocus(dropdown.name); }}

--- a/packages/react/src/toolbar/ToolbarDropdownPanel.tsx
+++ b/packages/react/src/toolbar/ToolbarDropdownPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { ToolbarButton, ToolbarDropdown } from '@domternal/core';
+import { useInnerHtml } from '../useInnerHtml.js';
 
 export interface ToolbarDropdownPanelProps {
   dropdown: ToolbarDropdown;
@@ -14,6 +15,8 @@ export function ToolbarDropdownPanel({
   getCachedItemContent,
   onItemClick,
 }: ToolbarDropdownPanelProps): ReactNode {
+  // Before the grid early return: hooks cannot sit behind a branch.
+  const innerHtml = useInnerHtml();
   if (dropdown.layout === 'grid') {
     return (
       <div
@@ -43,7 +46,7 @@ export function ToolbarDropdownPanel({
               role="menuitem"
               tabIndex={-1}
               aria-label={sub.label}
-              dangerouslySetInnerHTML={{ __html: getCachedItemContent(sub.icon, sub.label) }}
+              dangerouslySetInnerHTML={innerHtml(getCachedItemContent(sub.icon, sub.label))}
               onMouseDown={(e) => { e.preventDefault(); }}
               onClick={(e) => { onItemClick(sub, e); }}
             />
@@ -68,7 +71,7 @@ export function ToolbarDropdownPanel({
           tabIndex={-1}
           aria-label={sub.label}
           ref={(el: HTMLButtonElement | null) => { if (el && sub.style) el.setAttribute('style', sub.style); }}
-          dangerouslySetInnerHTML={{ __html: getCachedItemContent(sub.icon, sub.label, dropdown.displayMode) }}
+          dangerouslySetInnerHTML={innerHtml(getCachedItemContent(sub.icon, sub.label, dropdown.displayMode))}
           onMouseDown={(e) => { e.preventDefault(); }}
           onClick={(e) => { onItemClick(sub, e); }}
         />

--- a/packages/react/src/useInnerHtml.ts
+++ b/packages/react/src/useInnerHtml.ts
@@ -1,0 +1,28 @@
+import { useRef } from 'react';
+
+/**
+ * Stable `dangerouslySetInnerHTML` payloads, keyed by the markup itself.
+ *
+ * React compares that prop by identity, so a fresh literal per render rewrites
+ * `innerHTML` and destroys the icon nodes. These menus re-render on every
+ * editor transaction, so an overlay closing on pointerdown swaps the icon out
+ * mid-gesture, leaving mousedown and mouseup with no element in common and no
+ * click fired at all.
+ *
+ * The cache lives on a ref, so it dies with the component and is keyed by
+ * markup rather than by icon name: a trigger whose html varies with state
+ * (a dynamic icon, a label appended to it) still gets one object per variant.
+ */
+export function useInnerHtml(): (html: string) => { __html: string } {
+  const cache = useRef<Map<string, { __html: string }> | null>(null);
+  cache.current ??= new Map();
+  return (html: string): { __html: string } => {
+    const store = cache.current as Map<string, { __html: string }>;
+    let prop = store.get(html);
+    if (prop === undefined) {
+      prop = { __html: html };
+      store.set(html, prop);
+    }
+    return prop;
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #144, which fixed the bubble menu. The same fresh
`dangerouslySetInnerHTML` literal was still live in `ToolbarButton`,
`ToolbarDropdown`, `ToolbarDropdownPanel` and `DomternalFloatingMenu`; the
cache is now a shared `useInnerHtml` hook and no raw literal remains.

## Fix

The toolbar looked safe but was not. It defers its state sync by one animation
frame, which only moves the icon rewrite later; a real press lasts several
frames, so it still lands mid-gesture. The floating menu had no guard at all.
#144 has the full mechanism.

## Changes

- New matrix spec for both surfaces across the four demos. #144 shipped without
  one, so the bubble menu had no regression test either. The toolbar body holds
  the button down across frames on purpose: a fast click cannot reach the bug.

## Verified

Each fix reverted on its own to confirm its test fails, and on React only. Full
matrix green, typecheck and lint clean, API surface unchanged.