### PR TITLE
fix: render the bubble color trigger only while a notionColorOpen listener is live

### DIFF
--- a/e2e/color-trigger-guard.spec.ts
+++ b/e2e/color-trigger-guard.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * The trailing "A" trigger needs a live notionColorOpen listener (the picker
+ * panel); without one it used to render dead. Pins both halves per framework.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+async function goNotion(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
+}
+
+async function selectFirstWord(page: Page, target: DemoTarget): Promise<void> {
+  await page.evaluate((selector) => {
+    const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as {
+      setContent: (h: string, emit: boolean) => void;
+    };
+    ed.setContent('<p>guard probe text</p>', false);
+    const paragraph = document.querySelector(`${selector} p`);
+    if (!paragraph?.firstChild) throw new Error('no paragraph');
+    const range = document.createRange();
+    range.setStart(paragraph.firstChild, 0);
+    range.setEnd(paragraph.firstChild, 5);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const editorEl = document.querySelector(selector);
+    if (editorEl instanceof HTMLElement) editorEl.focus();
+  }, target.editorSelector);
+  await expect(page.locator('.dm-bubble-menu')).toHaveAttribute('data-show', '');
+}
+
+for (const target of demoTargets) {
+  test(`${target.name}: the color trigger shows while the picker listens and hides once nothing does`, async ({ page }) => {
+    await goNotion(page, target);
+    await selectFirstWord(page, target);
+
+    // Panel mounted: trigger present and functional.
+    const trigger = page.locator('.dm-ncp-trigger');
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    await expect(page.locator('.dm-notion-color-picker')).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    // Drop every listener (an app that never mounted the panel): trigger hides.
+    await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as {
+        off: (event: string) => void;
+      };
+      ed.off('notionColorOpen');
+    });
+    await selectFirstWord(page, target);
+    await expect(page.locator('.dm-ncp-trigger')).toHaveCount(0);
+  });
+}

--- a/packages/angular/src/lib/bubble-menu.component.ts
+++ b/packages/angular/src/lib/bubble-menu.component.ts
@@ -186,6 +186,8 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
 
   /** Internal - true when the NotionColorPicker extension is loaded; toggles the "A" color trigger. */
   readonly showColorPickerButton = signal(false);
+  /** notionColorPicker extension loaded (immutable per editor). */
+  private hasNotionColorPicker = false;
 
   /** Current text color CSS variable expression for the trigger glyph (null = default). */
   readonly currentTextColorVar = signal<string | null>(null);
@@ -492,9 +494,9 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
     this.showBlockMenuButton.set(
       editor.extensionManager.extensions.some((e) => e.name === 'blockContextMenu'),
     );
-    this.showColorPickerButton.set(
-      editor.extensionManager.extensions.some((e) => e.name === 'notionColorPicker'),
-    );
+    // Presence cached; the show decision needs a live listener (per sync below).
+    this.hasNotionColorPicker =
+      editor.extensionManager.extensions.some((e) => e.name === 'notionColorPicker');
 
     const items = this.items();
     const defaultItems = this.resolveNames(items ?? ['bold', 'italic', 'underline']);
@@ -535,6 +537,10 @@ export class DomternalBubbleMenuComponent implements OnDestroy {
   private syncTrailingButtonsState(editor: Editor): void {
     this.isNodeSelection.set(
       !!(editor.state.selection as unknown as SelectionShape).node,
+    );
+    // Hidden without a live notionColorOpen listener: the trigger would be dead.
+    this.showColorPickerButton.set(
+      this.hasNotionColorPicker && editor.listenerCount('notionColorOpen') > 0,
     );
     if (this.showColorPickerButton()) this.syncColorTriggerState(editor);
     if (this.showBlockMenuButton()) this.syncBlockMenuButtonState(editor);

--- a/packages/react/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/react/src/bubble-menu/useBubbleMenu.ts
@@ -381,7 +381,9 @@ export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResul
 
       setTrailing({
         isNodeSelection: isNode,
-        showColorPickerButton: hasNotionColorPicker,
+        // Hidden without a live notionColorOpen listener: the trigger would be dead.
+        showColorPickerButton:
+          hasNotionColorPicker && ed.listenerCount('notionColorOpen') > 0,
         showBlockMenuButton: hasBlockContextMenu,
         blockMenuButtonDisabled: blockMenuDisabled,
         currentTextColorVar: textVar,

--- a/packages/vanilla/src/bubble-menu/trailingState.ts
+++ b/packages/vanilla/src/bubble-menu/trailingState.ts
@@ -88,7 +88,9 @@ export function computeTrailingState(
 
   return {
     isNodeSelection: isNode,
-    showColorPickerButton: opts.hasNotionColorPicker,
+    // Hidden without a live notionColorOpen listener: the trigger would be dead.
+    showColorPickerButton:
+      opts.hasNotionColorPicker && editor.listenerCount('notionColorOpen') > 0,
     showBlockMenuButton: opts.hasBlockContextMenu,
     blockMenuButtonDisabled: blockMenuDisabled,
     currentTextColorVar: textVar,

--- a/packages/vue/src/bubble-menu/useBubbleMenu.ts
+++ b/packages/vue/src/bubble-menu/useBubbleMenu.ts
@@ -391,7 +391,9 @@ export function useBubbleMenu(options: UseBubbleMenuOptions): UseBubbleMenuResul
 
       trailing.value = {
         isNodeSelection: isNode,
-        showColorPickerButton: hasNotionColorPicker,
+        // Hidden without a live notionColorOpen listener: the trigger would be dead.
+        showColorPickerButton:
+          hasNotionColorPicker && currentEd.listenerCount('notionColorOpen') > 0,
         showBlockMenuButton: hasBlockContextMenu,
         blockMenuButtonDisabled: blockMenuDisabled,
         currentTextColorVar: textVar,


### PR DESCRIPTION
## Summary

`NotionColorPicker`'s bubble trigger does nothing on its own: its whole action is emitting `notionColorOpen`, which a picker panel is expected to answer. Any setup that loaded the extension without mounting that panel therefore showed a permanently inert "A" button in the bubble menu. All four wrappers now render it only while a listener is actually registered.

## Fix

The trigger appeared whenever the extension was loaded and the selection carried a `textStyle` mark, regardless of whether anything could respond to the click, so a toolbar-only or classic layout got a button that could never do anything.

The gate is `editor.listenerCount('notionColorOpen') > 0`, re-evaluated on every bubble sync, so registering a listener later reveals the trigger and dropping the last one hides it again.

## Changes

Consumers who render their own picker panel must register the `notionColorOpen` listener for the trigger to appear at all. This is now stated on the Notion Color Picker page.

## Verified

`pnpm typecheck`, `pnpm lint` and `pnpm test` clean. `e2e/color-trigger-guard.spec.ts` in the matrix suite covers all four frameworks: the trigger shows while a listener is live and disappears once the last one goes away.