### PR TITLE
feat: lead the menu with an ungrouped item, and fix menu presses across a render, the notion measure, block ids through a paste, and a dark canvas on paper

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Live examples
     url: https://domternal.dev/examples
     about: Try Domternal in the browser and open framework starters on StackBlitz.
+  - name: Domternal Pro support
+    url: https://domternal.dev/v1/pro/support/
+    about: Email support for subscribers, and where to send anything involving your own data or a security vulnerability.

--- a/.github/ISSUE_TEMPLATE/pro_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/pro_bug_report.yml
@@ -1,0 +1,82 @@
+name: Pro bug report
+description: Something in a Domternal Pro package does not work as expected
+title: "[PRO] "
+labels: ["bug", "pro"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The Pro packages are distributed privately, but their defects are tracked here so
+        there is one place to search. Before submitting, please search
+        [existing issues](https://github.com/domternal/domternal/issues?q=is%3Aissue+%5BPRO%5D).
+
+        **Do not paste confidential content.** Reduce the reproduction to synthetic content
+        first. If it only reproduces with a real document, with your data, or with a
+        collaboration update, email info@domternal.dev instead of filing here.
+
+        **Security vulnerabilities do not belong here.** Email info@domternal.dev. See
+        [Support](https://domternal.dev/v1/pro/support/).
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which Pro package?
+      options:
+        - "@domternal-pro/extension-collaboration"
+        - "@domternal-pro/extension-collaboration-caret"
+        - "@domternal-pro/extension-comments"
+        - "@domternal-pro/extension-version-history"
+        - "@domternal-pro/extension-ai"
+        - "@domternal-pro/extension-columns"
+        - "@domternal-pro/extension-export"
+        - "@domternal-pro/core"
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework
+      description: Which wrapper are you using?
+      options:
+        - React (@domternal/react)
+        - Vue (@domternal/vue)
+        - Angular (@domternal/angular)
+        - Vanilla JS (@domternal/vanilla)
+        - Not framework-specific
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: The versions of the @domternal-pro and @domternal packages you are using.
+      placeholder: "@domternal-pro/extension-comments 0.1.0, @domternal/core 0.14.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        The shortest steps or document that still shows it, with synthetic content only.
+    validations:
+      required: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # Angular CLI build cache (library and demo app builds)
 .angular/
+
+# pnpm content-addressable store, when it lands inside the repo
+.pnpm-store/

--- a/apps/demo-angular/e2e/notion-demo.spec.ts
+++ b/apps/demo-angular/e2e/notion-demo.spec.ts
@@ -619,6 +619,11 @@ test.describe('Notion-mode library class', () => {
         editorPadding: cs.getPropertyValue('--dm-editor-padding').trim(),
         blockHandleGutter: cs.getPropertyValue('--dm-block-handle-gutter').trim(),
         blockHandleLeft: cs.getPropertyValue('--dm-block-handle-left').trim(),
+        notionColumnWidth: cs.getPropertyValue('--dm-notion-column-width').trim(),
+        columnMaxWidth: (() => {
+          const pm = el.querySelector('.ProseMirror');
+          return pm ? getComputedStyle(pm).maxWidth : null;
+        })(),
         editorLineHeight: cs.getPropertyValue('--dm-editor-line-height').trim(),
         editorFontSize: cs.getPropertyValue('--dm-editor-font-size').trim(),
       };
@@ -629,11 +634,24 @@ test.describe('Notion-mode library class', () => {
     expect(styles.borderLeft).toBe('none');
     expect(styles.borderRadius).toBe('0px');
     expect(styles.boxShadow).toBe('none');
-    expect(styles.maxWidth).toBe('608px'); // 38rem at 16px base
+    // Uncapped on purpose; the measure moved onto the column, asserted below.
+    expect(styles.maxWidth).toBe('none');
+    expect(styles.notionColumnWidth).toBe('44rem');
     expect(styles.editorPadding).toBe('0');
     expect(styles.blockHandleGutter).toBe('0');
-    expect(styles.blockHandleLeft).toBe('-2.75rem');
+    // Not pinned as a string: the token is an unregistered custom property, so
+    // getPropertyValue returns the calc unevaluated and the exact spelling is
+    // browser-dependent. What the contract actually promises is that it is
+    // derived from the column and follows a panel push, so assert the shape
+    // and let the resolved 4px gap be proven by the layout specs.
+    // Not pinned as a literal: getPropertyValue substitutes var() first and
+    // the spelling is browser-dependent. The contract is that it is derived,
+    // not constant; the resolved 4px gap belongs to the layout specs.
+    expect(styles.blockHandleLeft).toContain('calc(');
+    expect(styles.blockHandleLeft).toContain('2.75rem');
     expect(styles.editorLineHeight).toBe('1.7');
+    // The measure now lives on the column, one level down.
+    expect(styles.columnMaxWidth).toBe('704px'); // 44rem at 16px base
     // Notion mode inherits classic body size; toggle shifts layout, not scale.
     expect(styles.editorFontSize).toBe('1rem');
   });

--- a/apps/demo-angular/e2e/notion-handle-edge-cases.spec.ts
+++ b/apps/demo-angular/e2e/notion-handle-edge-cases.spec.ts
@@ -312,20 +312,24 @@ test.describe('Default scoring rules - exclusions', () => {
 test.describe('Notion demo layout invariants', () => {
   test.beforeEach(async ({ page }) => { await goNotion(page); });
 
-  test('.dm-editor max-width matches the configured 38rem (608px)', async ({ page }) => {
-    const editorBox = await boxOf(page.locator('app-notion-demo .dm-editor'));
-    // 38rem at default 16px/rem = 608px. Allow a few px of slop for sub-
+  test('the reading column is capped at 44rem while the frame fills the page card', async ({ page }) => {
+    const columnBox = await boxOf(page.locator('app-notion-demo .ProseMirror'));
+    // 44rem at default 16px/rem = 704px. Allow a few px of slop for sub-
     // pixel rounding and scroll-bar inclusion in the bbox.
-    expect(editorBox.width).toBeLessThanOrEqual(608 + 4);
-    expect(editorBox.width).toBeGreaterThanOrEqual(608 - 4);
+    expect(columnBox.width).toBeLessThanOrEqual(704 + 4);
+    expect(columnBox.width).toBeGreaterThanOrEqual(704 - 4);
+
+    // The gap is the room a docked panel slides the column into.
+    const frameBox = await boxOf(page.locator('app-notion-demo .dm-editor'));
+    expect(frameBox.width).toBeGreaterThan(columnBox.width);
   });
 
-  test('.dm-editor is horizontally centered inside <app-notion-demo>', async ({ page }) => {
+  test('the reading column is horizontally centered inside <app-notion-demo>', async ({ page }) => {
     const host = await boxOf(page.locator('app-notion-demo'));
-    const editorBox = await boxOf(page.locator('app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('app-notion-demo .ProseMirror'));
 
-    const leftMargin = editorBox.x - host.x;
-    const rightMargin = (host.x + host.width) - (editorBox.x + editorBox.width);
+    const leftMargin = columnBox.x - host.x;
+    const rightMargin = (host.x + host.width) - (columnBox.x + columnBox.width);
     // Margins should be symmetric within a few px (centered).
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(4);
     // And both should be > 0 (actually centered narrower).
@@ -333,20 +337,21 @@ test.describe('Notion demo layout invariants', () => {
     expect(rightMargin).toBeGreaterThan(0);
   });
 
-  test('block handle, when shown, sits in the LEFT margin (negative left vs editor)', async ({ page }) => {
+  test('block handle, when shown, hugs the reading column from the left gutter', async ({ page }) => {
     await setContent(page, '<p>Centered</p>');
     const para = page.locator(`${editorSelector} p`);
     const pBox = await boxOf(para);
     await para.hover();
     await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
 
-    const editorBox = await boxOf(page.locator('app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('app-notion-demo .ProseMirror'));
     const handle = await boxOf(page.locator(blockHandleSelector));
-    // Handle's right edge should be ≤ editor's left edge (handle lives
-    // entirely in the left side gutter, not overlapping the content).
-    expect(handle.x + handle.width).toBeLessThanOrEqual(editorBox.x + 4);
+    // 4px before the column, the same gap BlockHandle uses for anchored
+    // blocks, so both paths agree.
+    expect(handle.x + handle.width).toBeGreaterThanOrEqual(columnBox.x - 6);
+    expect(handle.x + handle.width).toBeLessThanOrEqual(columnBox.x - 2);
     // And block content position is unchanged regardless.
-    expect(pBox.x).toBeGreaterThanOrEqual(editorBox.x);
+    expect(pBox.x).toBeGreaterThanOrEqual(columnBox.x);
   });
 });
 

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.scss
@@ -16,7 +16,7 @@
   position: relative;
   // Wide enough that the centered content column has clear left/right
   // whitespace AND the BlockHandle has room to live in that left margin.
-  max-width: 56rem;
+  max-width: 60rem;
   margin: 2rem auto 6rem;
   padding: 2rem 3rem;
   // Use the semantic base tokens (`--dm-bg`, `--dm-border-color`) so the

--- a/apps/demo-angular/src/styles.scss
+++ b/apps/demo-angular/src/styles.scss
@@ -19,6 +19,13 @@ body.dm-theme-dark {
   margin: 2rem auto;
   padding: 0 1rem;
 
+  // Notion mode is a page, not a sheet of A4: its 44rem column plus the 48px
+  // the block handle needs does not fit a 210mm shell.
+  &:has(.notion-page) {
+    width: auto;
+    max-width: 72rem;
+  }
+
   // Page-like editor padding (~640px text area with ~77px margins).
   // Excludes Notion-mode editors so they keep their own zero-padding
   // contract from `.dm-notion-mode` (defined in `@domternal/theme`).

--- a/apps/demo-react/e2e/notion-demo.spec.ts
+++ b/apps/demo-react/e2e/notion-demo.spec.ts
@@ -619,6 +619,11 @@ test.describe('Notion-mode library class', () => {
         editorPadding: cs.getPropertyValue('--dm-editor-padding').trim(),
         blockHandleGutter: cs.getPropertyValue('--dm-block-handle-gutter').trim(),
         blockHandleLeft: cs.getPropertyValue('--dm-block-handle-left').trim(),
+        notionColumnWidth: cs.getPropertyValue('--dm-notion-column-width').trim(),
+        columnMaxWidth: (() => {
+          const pm = el.querySelector('.ProseMirror');
+          return pm ? getComputedStyle(pm).maxWidth : null;
+        })(),
         editorLineHeight: cs.getPropertyValue('--dm-editor-line-height').trim(),
         editorFontSize: cs.getPropertyValue('--dm-editor-font-size').trim(),
       };
@@ -629,11 +634,24 @@ test.describe('Notion-mode library class', () => {
     expect(styles.borderLeft).toBe('none');
     expect(styles.borderRadius).toBe('0px');
     expect(styles.boxShadow).toBe('none');
-    expect(styles.maxWidth).toBe('608px'); // 38rem at 16px base
+    // Uncapped on purpose; the measure moved onto the column, asserted below.
+    expect(styles.maxWidth).toBe('none');
+    expect(styles.notionColumnWidth).toBe('44rem');
     expect(styles.editorPadding).toBe('0');
     expect(styles.blockHandleGutter).toBe('0');
-    expect(styles.blockHandleLeft).toBe('-2.75rem');
+    // Not pinned as a string: the token is an unregistered custom property, so
+    // getPropertyValue returns the calc unevaluated and the exact spelling is
+    // browser-dependent. What the contract actually promises is that it is
+    // derived from the column and follows a panel push, so assert the shape
+    // and let the resolved 4px gap be proven by the layout specs.
+    // Not pinned as a literal: getPropertyValue substitutes var() first and
+    // the spelling is browser-dependent. The contract is that it is derived,
+    // not constant; the resolved 4px gap belongs to the layout specs.
+    expect(styles.blockHandleLeft).toContain('calc(');
+    expect(styles.blockHandleLeft).toContain('2.75rem');
     expect(styles.editorLineHeight).toBe('1.7');
+    // The measure now lives on the column, one level down.
+    expect(styles.columnMaxWidth).toBe('704px'); // 44rem at 16px base
     // Notion mode inherits classic body size; toggle shifts layout, not scale.
     expect(styles.editorFontSize).toBe('1rem');
   });

--- a/apps/demo-react/e2e/notion-handle-edge-cases.spec.ts
+++ b/apps/demo-react/e2e/notion-handle-edge-cases.spec.ts
@@ -312,20 +312,24 @@ test.describe('Default scoring rules - exclusions', () => {
 test.describe('Notion demo layout invariants', () => {
   test.beforeEach(async ({ page }) => { await goNotion(page); });
 
-  test('.dm-editor max-width matches the configured 38rem (608px)', async ({ page }) => {
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
-    // 38rem at default 16px/rem = 608px. Allow a few px of slop for sub-
+  test('the reading column is capped at 44rem while the frame fills the page card', async ({ page }) => {
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
+    // 44rem at default 16px/rem = 704px. Allow a few px of slop for sub-
     // pixel rounding and scroll-bar inclusion in the bbox.
-    expect(editorBox.width).toBeLessThanOrEqual(608 + 4);
-    expect(editorBox.width).toBeGreaterThanOrEqual(608 - 4);
+    expect(columnBox.width).toBeLessThanOrEqual(704 + 4);
+    expect(columnBox.width).toBeGreaterThanOrEqual(704 - 4);
+
+    // The gap is the room a docked panel slides the column into.
+    const frameBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    expect(frameBox.width).toBeGreaterThan(columnBox.width);
   });
 
-  test('.dm-editor is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
+  test('the reading column is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
     const host = await boxOf(page.locator('.app-notion-demo'));
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
 
-    const leftMargin = editorBox.x - host.x;
-    const rightMargin = (host.x + host.width) - (editorBox.x + editorBox.width);
+    const leftMargin = columnBox.x - host.x;
+    const rightMargin = (host.x + host.width) - (columnBox.x + columnBox.width);
     // Margins should be symmetric within a few px (centered).
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(4);
     // And both should be > 0 (actually centered narrower).
@@ -333,20 +337,21 @@ test.describe('Notion demo layout invariants', () => {
     expect(rightMargin).toBeGreaterThan(0);
   });
 
-  test('block handle, when shown, sits in the LEFT margin (negative left vs editor)', async ({ page }) => {
+  test('block handle, when shown, hugs the reading column from the left gutter', async ({ page }) => {
     await setContent(page, '<p>Centered</p>');
     const para = page.locator(`${editorSelector} p`);
     const pBox = await boxOf(para);
     await para.hover();
     await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
 
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
     const handle = await boxOf(page.locator(blockHandleSelector));
-    // Handle's right edge should be ≤ editor's left edge (handle lives
-    // entirely in the left side gutter, not overlapping the content).
-    expect(handle.x + handle.width).toBeLessThanOrEqual(editorBox.x + 4);
+    // 4px before the column, the same gap BlockHandle uses for anchored
+    // blocks, so both paths agree.
+    expect(handle.x + handle.width).toBeGreaterThanOrEqual(columnBox.x - 6);
+    expect(handle.x + handle.width).toBeLessThanOrEqual(columnBox.x - 2);
     // And block content position is unchanged regardless.
-    expect(pBox.x).toBeGreaterThanOrEqual(editorBox.x);
+    expect(pBox.x).toBeGreaterThanOrEqual(columnBox.x);
   });
 });
 

--- a/apps/demo-react/src/_notion-demo.scss
+++ b/apps/demo-react/src/_notion-demo.scss
@@ -11,7 +11,7 @@
   position: relative;
   // Wide enough that the centered content column has clear left/right
   // whitespace AND the BlockHandle has room to live in that left margin.
-  max-width: 56rem;
+  max-width: 60rem;
   margin: 2rem auto 6rem;
   padding: 2rem 3rem;
   // Use the semantic base tokens (`--dm-bg`, `--dm-border-color`) so the

--- a/apps/demo-react/src/styles.scss
+++ b/apps/demo-react/src/styles.scss
@@ -20,6 +20,13 @@ body.dm-theme-dark {
   margin: 2rem auto;
   padding: 0 1rem;
 
+  // Notion mode is a page, not a sheet of A4: its 44rem column plus the 48px
+  // the block handle needs does not fit a 210mm shell.
+  &:has(.notion-page) {
+    width: auto;
+    max-width: 72rem;
+  }
+
   // Page-like editor padding (~640px text area with ~77px margins).
   // Excludes Notion-mode editors so they keep their own zero-padding
   // contract from `.dm-notion-mode` (defined in `@domternal/theme`).

--- a/apps/demo-vanilla/e2e/notion-demo.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-demo.spec.ts
@@ -619,6 +619,11 @@ test.describe('Notion-mode library class', () => {
         editorPadding: cs.getPropertyValue('--dm-editor-padding').trim(),
         blockHandleGutter: cs.getPropertyValue('--dm-block-handle-gutter').trim(),
         blockHandleLeft: cs.getPropertyValue('--dm-block-handle-left').trim(),
+        notionColumnWidth: cs.getPropertyValue('--dm-notion-column-width').trim(),
+        columnMaxWidth: (() => {
+          const pm = el.querySelector('.ProseMirror');
+          return pm ? getComputedStyle(pm).maxWidth : null;
+        })(),
         editorLineHeight: cs.getPropertyValue('--dm-editor-line-height').trim(),
         editorFontSize: cs.getPropertyValue('--dm-editor-font-size').trim(),
       };
@@ -629,11 +634,24 @@ test.describe('Notion-mode library class', () => {
     expect(styles.borderLeft).toBe('none');
     expect(styles.borderRadius).toBe('0px');
     expect(styles.boxShadow).toBe('none');
-    expect(styles.maxWidth).toBe('608px'); // 38rem at 16px base
+    // Uncapped on purpose; the measure moved onto the column, asserted below.
+    expect(styles.maxWidth).toBe('none');
+    expect(styles.notionColumnWidth).toBe('44rem');
     expect(styles.editorPadding).toBe('0');
     expect(styles.blockHandleGutter).toBe('0');
-    expect(styles.blockHandleLeft).toBe('-2.75rem');
+    // Not pinned as a string: the token is an unregistered custom property, so
+    // getPropertyValue returns the calc unevaluated and the exact spelling is
+    // browser-dependent. What the contract actually promises is that it is
+    // derived from the column and follows a panel push, so assert the shape
+    // and let the resolved 4px gap be proven by the layout specs.
+    // Not pinned as a literal: getPropertyValue substitutes var() first and
+    // the spelling is browser-dependent. The contract is that it is derived,
+    // not constant; the resolved 4px gap belongs to the layout specs.
+    expect(styles.blockHandleLeft).toContain('calc(');
+    expect(styles.blockHandleLeft).toContain('2.75rem');
     expect(styles.editorLineHeight).toBe('1.7');
+    // The measure now lives on the column, one level down.
+    expect(styles.columnMaxWidth).toBe('704px'); // 44rem at 16px base
     // Notion mode inherits classic body size; toggle shifts layout, not scale.
     expect(styles.editorFontSize).toBe('1rem');
   });

--- a/apps/demo-vanilla/e2e/notion-handle-edge-cases.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-handle-edge-cases.spec.ts
@@ -312,20 +312,24 @@ test.describe('Default scoring rules - exclusions', () => {
 test.describe('Notion demo layout invariants', () => {
   test.beforeEach(async ({ page }) => { await goNotion(page); });
 
-  test('.dm-editor max-width matches the configured 38rem (608px)', async ({ page }) => {
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
-    // 38rem at default 16px/rem = 608px. Allow a few px of slop for sub-
+  test('the reading column is capped at 44rem while the frame fills the page card', async ({ page }) => {
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
+    // 44rem at default 16px/rem = 704px. Allow a few px of slop for sub-
     // pixel rounding and scroll-bar inclusion in the bbox.
-    expect(editorBox.width).toBeLessThanOrEqual(608 + 4);
-    expect(editorBox.width).toBeGreaterThanOrEqual(608 - 4);
+    expect(columnBox.width).toBeLessThanOrEqual(704 + 4);
+    expect(columnBox.width).toBeGreaterThanOrEqual(704 - 4);
+
+    // The gap is the room a docked panel slides the column into.
+    const frameBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    expect(frameBox.width).toBeGreaterThan(columnBox.width);
   });
 
-  test('.dm-editor is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
+  test('the reading column is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
     const host = await boxOf(page.locator('.app-notion-demo'));
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
 
-    const leftMargin = editorBox.x - host.x;
-    const rightMargin = (host.x + host.width) - (editorBox.x + editorBox.width);
+    const leftMargin = columnBox.x - host.x;
+    const rightMargin = (host.x + host.width) - (columnBox.x + columnBox.width);
     // Margins should be symmetric within a few px (centered).
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(4);
     // And both should be > 0 (actually centered narrower).
@@ -333,20 +337,21 @@ test.describe('Notion demo layout invariants', () => {
     expect(rightMargin).toBeGreaterThan(0);
   });
 
-  test('block handle, when shown, sits in the LEFT margin (negative left vs editor)', async ({ page }) => {
+  test('block handle, when shown, hugs the reading column from the left gutter', async ({ page }) => {
     await setContent(page, '<p>Centered</p>');
     const para = page.locator(`${editorSelector} p`);
     const pBox = await boxOf(para);
     await para.hover();
     await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
 
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
     const handle = await boxOf(page.locator(blockHandleSelector));
-    // Handle's right edge should be ≤ editor's left edge (handle lives
-    // entirely in the left side gutter, not overlapping the content).
-    expect(handle.x + handle.width).toBeLessThanOrEqual(editorBox.x + 4);
+    // 4px before the column, the same gap BlockHandle uses for anchored
+    // blocks, so both paths agree.
+    expect(handle.x + handle.width).toBeGreaterThanOrEqual(columnBox.x - 6);
+    expect(handle.x + handle.width).toBeLessThanOrEqual(columnBox.x - 2);
     // And block content position is unchanged regardless.
-    expect(pBox.x).toBeGreaterThanOrEqual(editorBox.x);
+    expect(pBox.x).toBeGreaterThanOrEqual(columnBox.x);
   });
 });
 

--- a/apps/demo-vanilla/src/_notion-demo.scss
+++ b/apps/demo-vanilla/src/_notion-demo.scss
@@ -11,7 +11,7 @@
   position: relative;
   // Wide enough that the centered content column has clear left/right
   // whitespace AND the BlockHandle has room to live in that left margin.
-  max-width: 56rem;
+  max-width: 60rem;
   margin: 2rem auto 6rem;
   padding: 2rem 3rem;
   // Use the semantic base tokens (`--dm-bg`, `--dm-border-color`) so the

--- a/apps/demo-vanilla/src/styles.scss
+++ b/apps/demo-vanilla/src/styles.scss
@@ -20,6 +20,13 @@ body.dm-theme-dark {
   margin: 2rem auto;
   padding: 0 1rem;
 
+  // Notion mode is a page, not a sheet of A4: its 44rem column plus the 48px
+  // the block handle needs does not fit a 210mm shell.
+  &:has(.notion-page) {
+    width: auto;
+    max-width: 72rem;
+  }
+
   // Page-like editor padding (~640px text area with ~77px margins).
   // Excludes Notion-mode editors so they keep their own zero-padding
   // contract from `.dm-notion-mode` (defined in `@domternal/theme`).

--- a/apps/demo-vue/e2e/notion-demo.spec.ts
+++ b/apps/demo-vue/e2e/notion-demo.spec.ts
@@ -622,6 +622,11 @@ test.describe('Notion-mode library class', () => {
         editorPadding: cs.getPropertyValue('--dm-editor-padding').trim(),
         blockHandleGutter: cs.getPropertyValue('--dm-block-handle-gutter').trim(),
         blockHandleLeft: cs.getPropertyValue('--dm-block-handle-left').trim(),
+        notionColumnWidth: cs.getPropertyValue('--dm-notion-column-width').trim(),
+        columnMaxWidth: (() => {
+          const pm = el.querySelector('.ProseMirror');
+          return pm ? getComputedStyle(pm).maxWidth : null;
+        })(),
         editorLineHeight: cs.getPropertyValue('--dm-editor-line-height').trim(),
         editorFontSize: cs.getPropertyValue('--dm-editor-font-size').trim(),
       };
@@ -632,11 +637,24 @@ test.describe('Notion-mode library class', () => {
     expect(styles.borderLeft).toBe('none');
     expect(styles.borderRadius).toBe('0px');
     expect(styles.boxShadow).toBe('none');
-    expect(styles.maxWidth).toBe('608px'); // 38rem at 16px base
+    // Uncapped on purpose; the measure moved onto the column, asserted below.
+    expect(styles.maxWidth).toBe('none');
+    expect(styles.notionColumnWidth).toBe('44rem');
     expect(styles.editorPadding).toBe('0');
     expect(styles.blockHandleGutter).toBe('0');
-    expect(styles.blockHandleLeft).toBe('-2.75rem');
+    // Not pinned as a string: the token is an unregistered custom property, so
+    // getPropertyValue returns the calc unevaluated and the exact spelling is
+    // browser-dependent. What the contract actually promises is that it is
+    // derived from the column and follows a panel push, so assert the shape
+    // and let the resolved 4px gap be proven by the layout specs.
+    // Not pinned as a literal: getPropertyValue substitutes var() first and
+    // the spelling is browser-dependent. The contract is that it is derived,
+    // not constant; the resolved 4px gap belongs to the layout specs.
+    expect(styles.blockHandleLeft).toContain('calc(');
+    expect(styles.blockHandleLeft).toContain('2.75rem');
     expect(styles.editorLineHeight).toBe('1.7');
+    // The measure now lives on the column, one level down.
+    expect(styles.columnMaxWidth).toBe('704px'); // 44rem at 16px base
     // Notion mode inherits classic body size; toggle shifts layout, not scale.
     expect(styles.editorFontSize).toBe('1rem');
   });

--- a/apps/demo-vue/e2e/notion-handle-edge-cases.spec.ts
+++ b/apps/demo-vue/e2e/notion-handle-edge-cases.spec.ts
@@ -312,20 +312,24 @@ test.describe('Default scoring rules - exclusions', () => {
 test.describe('Notion demo layout invariants', () => {
   test.beforeEach(async ({ page }) => { await goNotion(page); });
 
-  test('.dm-editor max-width matches the configured 38rem (608px)', async ({ page }) => {
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
-    // 38rem at default 16px/rem = 608px. Allow a few px of slop for sub-
+  test('the reading column is capped at 44rem while the frame fills the page card', async ({ page }) => {
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
+    // 44rem at default 16px/rem = 704px. Allow a few px of slop for sub-
     // pixel rounding and scroll-bar inclusion in the bbox.
-    expect(editorBox.width).toBeLessThanOrEqual(608 + 4);
-    expect(editorBox.width).toBeGreaterThanOrEqual(608 - 4);
+    expect(columnBox.width).toBeLessThanOrEqual(704 + 4);
+    expect(columnBox.width).toBeGreaterThanOrEqual(704 - 4);
+
+    // The gap is the room a docked panel slides the column into.
+    const frameBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    expect(frameBox.width).toBeGreaterThan(columnBox.width);
   });
 
-  test('.dm-editor is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
+  test('the reading column is horizontally centered inside <.app-notion-demo>', async ({ page }) => {
     const host = await boxOf(page.locator('.app-notion-demo'));
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
 
-    const leftMargin = editorBox.x - host.x;
-    const rightMargin = (host.x + host.width) - (editorBox.x + editorBox.width);
+    const leftMargin = columnBox.x - host.x;
+    const rightMargin = (host.x + host.width) - (columnBox.x + columnBox.width);
     // Margins should be symmetric within a few px (centered).
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(4);
     // And both should be > 0 (actually centered narrower).
@@ -333,20 +337,21 @@ test.describe('Notion demo layout invariants', () => {
     expect(rightMargin).toBeGreaterThan(0);
   });
 
-  test('block handle, when shown, sits in the LEFT margin (negative left vs editor)', async ({ page }) => {
+  test('block handle, when shown, hugs the reading column from the left gutter', async ({ page }) => {
     await setContent(page, '<p>Centered</p>');
     const para = page.locator(`${editorSelector} p`);
     const pBox = await boxOf(para);
     await para.hover();
     await expect(page.locator(blockHandleSelector)).toHaveAttribute('data-show', '');
 
-    const editorBox = await boxOf(page.locator('.app-notion-demo .dm-editor'));
+    const columnBox = await boxOf(page.locator('.app-notion-demo .ProseMirror'));
     const handle = await boxOf(page.locator(blockHandleSelector));
-    // Handle's right edge should be ≤ editor's left edge (handle lives
-    // entirely in the left side gutter, not overlapping the content).
-    expect(handle.x + handle.width).toBeLessThanOrEqual(editorBox.x + 4);
+    // 4px before the column, the same gap BlockHandle uses for anchored
+    // blocks, so both paths agree.
+    expect(handle.x + handle.width).toBeGreaterThanOrEqual(columnBox.x - 6);
+    expect(handle.x + handle.width).toBeLessThanOrEqual(columnBox.x - 2);
     // And block content position is unchanged regardless.
-    expect(pBox.x).toBeGreaterThanOrEqual(editorBox.x);
+    expect(pBox.x).toBeGreaterThanOrEqual(columnBox.x);
   });
 });
 

--- a/apps/demo-vue/src/_notion-demo.scss
+++ b/apps/demo-vue/src/_notion-demo.scss
@@ -11,7 +11,7 @@
   position: relative;
   // Wide enough that the centered content column has clear left/right
   // whitespace AND the BlockHandle has room to live in that left margin.
-  max-width: 56rem;
+  max-width: 60rem;
   margin: 2rem auto 6rem;
   padding: 2rem 3rem;
   // Use the semantic base tokens (`--dm-bg`, `--dm-border-color`) so the

--- a/apps/demo-vue/src/styles.scss
+++ b/apps/demo-vue/src/styles.scss
@@ -20,6 +20,13 @@ body.dm-theme-dark {
   margin: 2rem auto;
   padding: 0 1rem;
 
+  // Notion mode is a page, not a sheet of A4: its 44rem column plus the 48px
+  // the block handle needs does not fit a 210mm shell.
+  &:has(.notion-page) {
+    width: auto;
+    max-width: 72rem;
+  }
+
   // Notion mode owns its own padding via `.dm-notion-mode` preset; only
   // apply the A4-page-style padding to non-Notion editors.
   .dm-editor:not(.dm-notion-mode) {

--- a/e2e/block-handle-layout.spec.ts
+++ b/e2e/block-handle-layout.spec.ts
@@ -9,12 +9,11 @@
  *
  * Geometry contract (theme/_block-handle.scss + _notion-mode.scss): each button
  * is `1.25rem` (20px) wide and the two sit flush (no `gap`), so the cluster is
- * ~40px. In Notion mode `--dm-block-handle-gutter: 0` and
- * `--dm-block-handle-left: -2.75rem` (-44px) pull the 40px cluster left of the
- * `.dm-editor` column so its right edge ends 4px before the content's left edge
- * (-44 + 40 = -4). These tests pin the ORDER and the flush ADJACENCY so a
- * refactor that swaps the buttons or strands the grip out in the margin is
- * caught as a regression.
+ * ~40px. In Notion mode `--dm-block-handle-left` is a calc derived from
+ * `--dm-notion-column-width`, so the cluster ends 4px before the text at any
+ * frame width (pinned by `notion-column-token.spec.ts`). These tests pin the
+ * ORDER and the flush ADJACENCY so a refactor that swaps the buttons or
+ * strands the grip out in the margin is caught as a regression.
  */
 import { test } from './fixtures.js';
 import { expect, type Page } from '@playwright/test';

--- a/e2e/menu-click-during-transaction.spec.ts
+++ b/e2e/menu-click-during-transaction.spec.ts
@@ -13,12 +13,21 @@
  * on any press outside the editor, which is exactly the timing that broke.
  * Only React ever failed either body, so the value is in running both against
  * all four demos.
+ *
+ * Vanilla broke the same way twice more, in shapes the press tests miss when
+ * the render lands outside the press: the bubble menu rebuilt its whole DOM,
+ * and the toolbar compared its trigger against `btn.innerHTML`, the browser's
+ * re-serialisation, which never matched. So the tests below assert identity
+ * instead. A click fires only when mousedown and mouseup share an element.
  */
 import { test } from './fixtures.js';
 import { expect, type Page } from '@playwright/test';
 import { demoTargets, type DemoTarget } from './targets.js';
 
 const EDITOR = '.dm-editor .ProseMirror';
+/** Any toolbar control that opens a panel; alignment exists in every demo. */
+const ALIGN_TRIGGER = '.dm-toolbar [aria-label="Text Alignment"]';
+const PANEL = '.dm-toolbar-dropdown-panel';
 
 async function openDemo(page: Page, target: DemoTarget): Promise<void> {
   await page.goto(target.baseURL + '/');
@@ -74,6 +83,48 @@ async function selectFirstWords(page: Page): Promise<void> {
   }, EDITOR);
 }
 
+/**
+ * Remembers the live node, so a later render can be asked whether it kept it.
+ * A rebuilt menu looks identical to a preserved one in every other query.
+ */
+async function rememberNode(page: Page, selector: string, key: string): Promise<void> {
+  await page.evaluate(
+    ({ sel, k }) => {
+      const element = document.querySelector(sel);
+      if (!element) throw new Error(`nothing matches ${sel}`);
+      (window as unknown as Record<string, unknown>)[k] = element;
+    },
+    { sel: selector, k: key },
+  );
+}
+
+/** Whether the selector still resolves to the very node remembered earlier. */
+function isSameNode(page: Page, selector: string, key: string): Promise<boolean> {
+  return page.evaluate(
+    ({ sel, k }) => {
+      const remembered = (window as unknown as Record<string, unknown>)[k] as Element | undefined;
+      const current = document.querySelector(sel);
+      return Boolean(remembered && current && remembered === current && remembered.isConnected);
+    },
+    { sel: selector, k: key },
+  );
+}
+
+/**
+ * Repaints active states without changing which items the menus hold: the
+ * state-only render the structure is supposed to survive.
+ */
+async function stateOnlyRender(page: Page): Promise<void> {
+  await page.keyboard.press('ControlOrMeta+b');
+  // Two frames: the toolbar defers its render by one.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => { resolve(); }));
+      }),
+  );
+}
+
 function boldIsActive(page: Page): Promise<boolean> {
   return page.evaluate(
     () =>
@@ -124,5 +175,74 @@ for (const target of demoTargets) {
     await page.mouse.up();
 
     await expect.poll(() => boldIsActive(page)).toBe(true);
+  });
+
+  test(`${target.name}: a bubble menu button and its icon survive a state-only render`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await selectFirstWords(page);
+    const menu = page.locator('.dm-bubble-menu');
+    await expect(menu).toHaveAttribute('data-show', '');
+
+    const button = '.dm-bubble-menu [aria-label="Italic"]';
+    const icon = `${button} svg`;
+    await expect(page.locator(icon)).toHaveCount(1);
+    await rememberNode(page, button, '__buttonBefore');
+    await rememberNode(page, icon, '__iconBefore');
+
+    await stateOnlyRender(page);
+
+    // Bold went on, so the menu re-rendered; Italic had no reason to change.
+    await expect.poll(() => boldIsActive(page)).toBe(true);
+    expect(await isSameNode(page, button, '__buttonBefore'), 'the button was replaced').toBe(true);
+    expect(await isSameNode(page, icon, '__iconBefore'), 'the icon was rewritten').toBe(true);
+  });
+
+  test(`${target.name}: a toolbar dropdown trigger keeps its glyph across a render`, async ({
+    page,
+  }) => {
+    // The alignment glyph is dynamic, so it may change when the alignment
+    // does. This render changes a mark, so rewriting it is pure destruction.
+    await openDemo(page, target);
+    await selectFirstWords(page);
+    await expect(page.locator(ALIGN_TRIGGER)).toBeVisible();
+    await rememberNode(page, ALIGN_TRIGGER, '__triggerBefore');
+    await rememberNode(page, `${ALIGN_TRIGGER} svg`, '__triggerIconBefore');
+
+    await stateOnlyRender(page);
+
+    await expect.poll(() => boldIsActive(page)).toBe(true);
+    expect(
+      await isSameNode(page, ALIGN_TRIGGER, '__triggerBefore'),
+      'the trigger was replaced',
+    ).toBe(true);
+    expect(
+      await isSameNode(page, `${ALIGN_TRIGGER} svg`, '__triggerIconBefore'),
+      'the glyph was rewritten though it depicts the same alignment',
+    ).toBe(true);
+  });
+
+  test(`${target.name}: a toolbar dropdown trigger fires when the press outlives a frame`, async ({
+    page,
+  }) => {
+    // Harder than the plain button above: this trigger's markup is recomputed
+    // every render, since the glyph follows the active sub-item. Rewriting it
+    // replaces the node under the pointer and the press yields no click.
+    await openDemo(page, target);
+    await installOverlayProbe(page);
+    await selectFirstWords(page);
+
+    const trigger = page.locator('.dm-toolbar .dm-toolbar-dropdown-trigger').first();
+    await expect(trigger).toBeVisible();
+    const box = await trigger.boundingBox();
+    if (!box) throw new Error('no box');
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(150);
+    await page.mouse.up();
+
+    await expect(page.locator(PANEL)).toBeVisible();
   });
 }

--- a/e2e/notion-column-token.spec.ts
+++ b/e2e/notion-column-token.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Notion mode's column measure and the handle offset derived from it.
+ *
+ * The frame stays wide and the measure sits on the column, because the
+ * centring whitespace is the room a docked sidebar slides the column into.
+ * Both numbers come from `--dm-notion-column-width`, so every test here
+ * checks the same invariant: the handle ends 4px before the text, at any
+ * width and at any override. See the Notion mode guide for the reasoning.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const handleSelector = '.dm-block-handle';
+
+/** The frame is the column's parent `.dm-editor`, derived from the target. */
+function frameSelector(target: DemoTarget): string {
+  return target.editorSelector.replace(/\s+\.ProseMirror$/, ' .dm-editor');
+}
+
+async function goNotion(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 3000 },
+  );
+}
+
+interface Rect {
+  left: number;
+  right: number;
+  width: number;
+}
+
+async function rectOf(page: Page, selector: string): Promise<Rect> {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no box for ${selector}`);
+  return { left: box.x, right: box.x + box.width, width: box.width };
+}
+
+/** Gap between the handle's right edge and the text; settles the hover tick. */
+async function handleGapToText(page: Page, target: DemoTarget): Promise<number> {
+  const paragraph = page.locator(`${target.editorSelector} > p`).first();
+  await paragraph.hover();
+  await expect(page.locator(handleSelector)).toHaveAttribute('data-show', '');
+  await page.waitForTimeout(20);
+  const handle = await rectOf(page, handleSelector);
+  const box = await paragraph.boundingBox();
+  if (!box) throw new Error('no paragraph box');
+  return box.x - handle.right;
+}
+
+for (const target of demoTargets) {
+  test.describe(`notion column measure [${target.name}]`, () => {
+    test.beforeEach(async ({ page }) => {
+      await goNotion(page, target);
+    });
+
+    test('the measure sits on the column and the frame keeps the whitespace beside it', async ({
+      page,
+    }) => {
+      const column = await rectOf(page, target.editorSelector);
+      const frame = await rectOf(page, frameSelector(target));
+
+      // 44rem at a 16px root. A few px of slop for sub-pixel rounding.
+      expect(column.width).toBeGreaterThanOrEqual(704 - 4);
+      expect(column.width).toBeLessThanOrEqual(704 + 4);
+
+      // The gap between the two is the room a docked panel pushes into.
+      expect(frame.width).toBeGreaterThan(column.width);
+      expect(column.left).toBeGreaterThan(frame.left);
+      expect(column.right).toBeLessThan(frame.right);
+
+      // Centred, within a px of rounding.
+      const leftRoom = column.left - frame.left;
+      const rightRoom = frame.right - column.right;
+      expect(Math.abs(leftRoom - rightRoom)).toBeLessThanOrEqual(2);
+    });
+
+    test('the handle ends 4px before the text', async ({ page }) => {
+      expect(await handleGapToText(page, target)).toBeGreaterThanOrEqual(2);
+      expect(await handleGapToText(page, target)).toBeLessThanOrEqual(6);
+    });
+
+    test('overriding the column token moves the handle with it', async ({ page }) => {
+      const before = await rectOf(page, target.editorSelector);
+
+      // The token's whole reason for existing: the offset carries half the
+      // measure, so a consumer must not have to restate it.
+      await page.evaluate((selector) => {
+        const frame = document.querySelector<HTMLElement>(selector);
+        frame?.style.setProperty('--dm-notion-column-width', '30rem');
+      }, frameSelector(target));
+      await page.waitForTimeout(50);
+
+      const after = await rectOf(page, target.editorSelector);
+      expect(after.width).toBeLessThan(before.width);
+      expect(after.width).toBeGreaterThanOrEqual(480 - 4); // 30rem
+      expect(after.width).toBeLessThanOrEqual(480 + 4);
+
+      // The handle followed the narrower column rather than staying put.
+      expect(await handleGapToText(page, target)).toBeGreaterThanOrEqual(2);
+      expect(await handleGapToText(page, target)).toBeLessThanOrEqual(6);
+    });
+
+    test('the handle keeps its 4px when the frame is narrower than the measure', async ({
+      page,
+    }) => {
+      // Past the measure the column fills the frame and the centring term
+      // clamps to zero. Driven by widening the token, not by shrinking the
+      // viewport: the demo card never narrows past its own content.
+      await page.evaluate((selector) => {
+        const frame = document.querySelector<HTMLElement>(selector);
+        frame?.style.setProperty('--dm-notion-column-width', '400rem');
+      }, frameSelector(target));
+      await page.waitForTimeout(50);
+
+      const column = await rectOf(page, target.editorSelector);
+      const frame = await rectOf(page, frameSelector(target));
+      expect(column.width).toBeLessThan(400 * 16);
+      expect(Math.abs(column.left - frame.left)).toBeLessThanOrEqual(2);
+
+      expect(await handleGapToText(page, target)).toBeGreaterThanOrEqual(2);
+      expect(await handleGapToText(page, target)).toBeLessThanOrEqual(6);
+    });
+  });
+}

--- a/e2e/paste-block-identity.spec.ts
+++ b/e2e/paste-block-identity.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Block ids across a real copy and paste.
+ *
+ * Everything that names a block from outside the document rides on the id: a
+ * table-of-contents entry, a `#hash` link, Copy link, and a Pro block comment.
+ *
+ * Ids are regenerated to avoid a duplicate, judged against the document as it
+ * stands at paste time. That is wrong for a paste REPLACING its own source:
+ * the incumbents it sees are the blocks about to be deleted. Ctrl+A then
+ * Ctrl+V renamed everything, and the next paste, finding those ids free, kept
+ * them, so ids flickered on alternate pastes.
+ *
+ * Driven through the real clipboard, since that is the mechanism under test.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const CONTENT = '<h1>Title</h1><p>First paragraph</p><p>Second paragraph</p>';
+
+async function openNotionDemo(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>)['__DEMO_EDITOR__']),
+    { timeout: 5000 },
+  );
+}
+
+/** Seeds the document and puts the caret in it, so the keyboard reaches it. */
+async function seed(page: Page, target: DemoTarget, html: string): Promise<void> {
+  await page.evaluate((markup) => {
+    const editor = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+      | { setContent: (h: string, emit: boolean) => void }
+      | undefined;
+    editor?.setContent(markup, false);
+  }, html);
+  await page.click(`${target.editorSelector} > *:first-child`);
+}
+
+/** The id attribute of every top-level block, in document order. */
+function blockIds(page: Page, target: DemoTarget): Promise<string[]> {
+  return page.evaluate(
+    (selector) =>
+      Array.from(document.querySelectorAll(`${selector} > *`)).map((element) => element.id),
+    target.editorSelector,
+  );
+}
+
+// `(string | null)[]`, because the two repos' DOM lib types disagree on
+// whether `textContent` is nullable, and this file is mirrored between them.
+function blockText(page: Page, target: DemoTarget): Promise<(string | null)[]> {
+  return page.evaluate(
+    (selector) =>
+      Array.from(document.querySelectorAll(`${selector} > *`)).map(
+        (element) => element.textContent,
+      ),
+    target.editorSelector,
+  );
+}
+
+async function selectAll(page: Page): Promise<void> {
+  await page.keyboard.press('ControlOrMeta+a');
+}
+
+/** A paste is several transactions; assert against a settled document. */
+async function pasteAndSettle(page: Page, target: DemoTarget): Promise<void> {
+  await page.keyboard.press('ControlOrMeta+v');
+  let previous: string[] = [];
+  await expect
+    .poll(
+      async () => {
+        const current = await blockIds(page, target);
+        const stable = current.length > 0 && current.join(',') === previous.join(',');
+        previous = current;
+        return stable;
+      },
+      { timeout: 5000, intervals: [100, 100, 100, 100, 100] },
+    )
+    .toBe(true);
+}
+
+for (const target of demoTargets) {
+  test.describe(`${target.name} block ids across a copy and paste`, () => {
+    test('a paste over the whole document keeps every id, and keeps it on the next paste too', async ({
+      page,
+    }) => {
+      await openNotionDemo(page, target);
+      await seed(page, target, CONTENT);
+
+      const before = await blockIds(page, target);
+      // The premise: without ids this file compares empty strings to empty
+      // strings and passes on anything.
+      expect(before, 'the demo seeded three blocks').toHaveLength(3);
+      expect(before.every((id) => id.length > 0), 'every block carries an id').toBe(true);
+      expect(new Set(before).size, 'the ids are distinct').toBe(3);
+
+      await selectAll(page);
+      await page.keyboard.press('ControlOrMeta+c');
+      await selectAll(page);
+      await pasteAndSettle(page, target);
+
+      expect(await blockIds(page, target), 'ids survive the paste that replaced them').toEqual(
+        before,
+      );
+      expect(await blockText(page, target)).toEqual([
+        'Title',
+        'First paragraph',
+        'Second paragraph',
+      ]);
+
+      // Twice: the defect alternated, so one paste cannot tell a fix from
+      // the bug's other half.
+      await selectAll(page);
+      await pasteAndSettle(page, target);
+      expect(await blockIds(page, target), 'and again on the paste after that').toEqual(before);
+    });
+
+    test('a copy pasted alongside its original gets fresh ids', async ({ page }) => {
+      await openNotionDemo(page, target);
+      await seed(page, target, '<p>Only paragraph</p>');
+
+      const before = await blockIds(page, target);
+      expect(before).toHaveLength(1);
+
+      await selectAll(page);
+      await page.keyboard.press('ControlOrMeta+c');
+      // Through the editor, not a navigation key: the caret is setup, and a
+      // selection left standing would turn this into the replacement case.
+      await page.evaluate(() => {
+        const editor = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
+          | { commands: { focus: (position: string) => void } }
+          | undefined;
+        editor?.commands.focus('end');
+      });
+      await pasteAndSettle(page, target);
+
+      const after = await blockIds(page, target);
+      // The original is still here, so the copy is a second, unrelated block
+      // and must not answer to the same id.
+      expect(after.length, 'the paste added a block').toBeGreaterThan(before.length);
+      expect(after[0], 'the original keeps its id').toBe(before[0]);
+      expect(new Set(after).size, 'no id is in the document twice').toBe(after.length);
+    });
+
+    test('a cut and pasted document keeps its ids', async ({ page }) => {
+      await openNotionDemo(page, target);
+      await seed(page, target, CONTENT);
+      const before = await blockIds(page, target);
+
+      // A cut empties the document first, so nothing holds these ids by paste
+      // time. The case a fix could break by over-correcting.
+      await selectAll(page);
+      await page.keyboard.press('ControlOrMeta+x');
+      await expect
+        .poll(async () => (await blockText(page, target)).join(''), { timeout: 5000 })
+        .toBe('');
+      await pasteAndSettle(page, target);
+
+      expect(await blockIds(page, target)).toEqual(before);
+    });
+  });
+}

--- a/e2e/print.spec.ts
+++ b/e2e/print.spec.ts
@@ -989,12 +989,9 @@ for (const target of demoTargets) {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // Dark theme
-  //
-  // The theme forces the document's text black, and the rule that clears
-  // ancestor backgrounds cannot reach `body`, which is not a descendant of
-  // itself. Black on near-black. Both halves are pinned together, because
-  // either assertion alone passes in the broken state.
+  // Dark theme. The print layer forces the text black, and the rule clearing
+  // ancestor backgrounds cannot reach `body`, which is not its own descendant:
+  // black on near-black. Pinned together, since either half alone passes.
   // ──────────────────────────────────────────────────────────────────────────
 
   /** The dark theme, applied the way every demo applies it. */
@@ -1029,7 +1026,7 @@ for (const target of demoTargets) {
     await goDark(page);
     await page.emulateMedia({ media: 'print' });
 
-    // Transparent, not merely "not dark": html has none, so this propagates.
+    // Transparent, not merely "not dark": html has none, so it propagates.
     expect(await styleOf(page, 'body', 'background-color')).toBe('rgba(0, 0, 0, 0)');
     await page.emulateMedia({ media: null });
   });
@@ -1044,7 +1041,7 @@ for (const target of demoTargets) {
     // The pairing that broke, asserted together.
     expect(await styleOf(page, '.dm-editor', 'color')).toBe('rgb(0, 0, 0)');
     expect(await styleOf(page, '.dm-editor', 'background-color')).toBe('rgba(0, 0, 0, 0)');
-    expect(await styleOf(page, `${EDITOR}`, 'color')).toBe('rgb(0, 0, 0)');
+    expect(await styleOf(page, EDITOR, 'color')).toBe('rgb(0, 0, 0)');
     expect(await styleOf(page, 'body', 'background-color')).toBe('rgba(0, 0, 0, 0)');
     await page.emulateMedia({ media: null });
   });
@@ -1076,8 +1073,8 @@ for (const target of demoTargets) {
     );
     await page.emulateMedia({ media: 'print' });
 
-    // Clearing the canvas must not become "clear every background": a code
-    // block's tint is content.
+    // Clearing the canvas must not clear every background: a code block's
+    // tint is content.
     const codeBg = await styleOf(page, `${EDITOR} pre`, 'background-color');
     expect(codeBg).not.toBe('rgba(0, 0, 0, 0)');
     await page.emulateMedia({ media: null });

--- a/e2e/print.spec.ts
+++ b/e2e/print.spec.ts
@@ -987,4 +987,99 @@ for (const target of demoTargets) {
     expect(await styleOf(page, '#host-chrome', 'display')).not.toBe('none');
     await page.emulateMedia({ media: null });
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Dark theme
+  //
+  // The theme forces the document's text black, and the rule that clears
+  // ancestor backgrounds cannot reach `body`, which is not a descendant of
+  // itself. Black on near-black. Both halves are pinned together, because
+  // either assertion alone passes in the broken state.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /** The dark theme, applied the way every demo applies it. */
+  async function goDark(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      document.body.classList.add('dm-theme-dark');
+      document.querySelectorAll('.dm-editor').forEach((el) => {
+        el.classList.add('dm-theme-dark');
+      });
+    });
+    // Past the theme-toggle transition, so this proves the rule not the timing.
+    await page.waitForTimeout(300);
+  }
+
+  /** What printDocument stamps, held so it can be measured. */
+  async function markAsPrinting(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      const root = document.querySelector('.dm-editor');
+      if (!root) throw new Error('no editor to mark');
+      root.classList.add('dm-print-root');
+      let el = root.parentElement;
+      while (el) {
+        el.classList.add('dm-print-ancestor');
+        el = el.parentElement;
+      }
+      document.body.classList.add('dm-printing');
+    });
+  }
+
+  test(`${target.name}: a dark theme does not print the page canvas dark`, async ({ page }) => {
+    await openDemo(page, target);
+    await goDark(page);
+    await page.emulateMedia({ media: 'print' });
+
+    // Transparent, not merely "not dark": html has none, so this propagates.
+    expect(await styleOf(page, 'body', 'background-color')).toBe('rgba(0, 0, 0, 0)');
+    await page.emulateMedia({ media: null });
+  });
+
+  test(`${target.name}: dark-theme text and canvas agree on the printed sheet`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await goDark(page);
+    await page.emulateMedia({ media: 'print' });
+
+    // The pairing that broke, asserted together.
+    expect(await styleOf(page, '.dm-editor', 'color')).toBe('rgb(0, 0, 0)');
+    expect(await styleOf(page, '.dm-editor', 'background-color')).toBe('rgba(0, 0, 0, 0)');
+    expect(await styleOf(page, `${EDITOR}`, 'color')).toBe('rgb(0, 0, 0)');
+    expect(await styleOf(page, 'body', 'background-color')).toBe('rgba(0, 0, 0, 0)');
+    await page.emulateMedia({ media: null });
+  });
+
+  test(`${target.name}: the marked print path clears the canvas body included`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await goDark(page);
+    await markAsPrinting(page);
+    await page.emulateMedia({ media: 'print' });
+
+    // body carries the ancestor class but the ancestor rule cannot reach it.
+    expect(await styleOf(page, 'body', 'background-color')).toBe('rgba(0, 0, 0, 0)');
+    expect(await styleOf(page, 'body', 'color')).toBe('rgb(0, 0, 0)');
+    // And the ancestors the rule does reach, caught separately.
+    expect(await styleOf(page, '.dm-print-ancestor', 'background-color')).toBe('rgba(0, 0, 0, 0)');
+    await page.emulateMedia({ media: null });
+  });
+
+  test(`${target.name}: dark-theme block backgrounds that carry meaning still print`, async ({
+    page,
+  }) => {
+    await openDemo(page, target);
+    await goDark(page);
+    await setContent(
+      page,
+      '<p>Before</p><pre><code>const answer = 42;</code></pre><p>After</p>',
+    );
+    await page.emulateMedia({ media: 'print' });
+
+    // Clearing the canvas must not become "clear every background": a code
+    // block's tint is content.
+    const codeBg = await styleOf(page, `${EDITOR} pre`, 'background-color');
+    expect(codeBg).not.toBe('rgba(0, 0, 0, 0)');
+    await page.emulateMedia({ media: null });
+  });
 }

--- a/e2e/slash-menu-leading-group.spec.ts
+++ b/e2e/slash-menu-leading-group.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * The slash menu's leading group, the one with no heading.
+ *
+ * An ungrouped item leads the menu. Every free extension declares a group, so
+ * a free build shows no such section and no separator rule, which ships with
+ * whichever package supplies the ungrouped item rather than with the theme.
+ * The Pro suite owns the other half.
+ */
+import { test } from './fixtures.js';
+import { expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const GROUP = '.dm-slash-command-group';
+const LABEL = '.dm-slash-command-group-label';
+const ITEM = '.dm-slash-command-item';
+
+async function openSlashMenu(page: Page, target: DemoTarget): Promise<void> {
+  await page.goto(target.baseURL + '/');
+  await page.waitForSelector(target.notionToggle);
+  await page.click(target.notionToggle);
+  await page.waitForSelector(target.editorSelector);
+  await page.click(`${target.editorSelector} > *:first-child`);
+  await page.keyboard.press('End');
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('/');
+  await expect(page.locator(ITEM).first()).toBeVisible();
+}
+
+/** Every child of the popup in document order, tagged by what it is. */
+function popupOutline(page: Page): Promise<{ kind: string }[]> {
+  return page.evaluate(
+    ({ groupSelector, labelSelector }) => {
+      const first = document.querySelector(groupSelector);
+      const root = first?.parentElement;
+      if (!root) return [];
+      return Array.from(root.children).map((child) => ({
+        kind: child.matches(labelSelector)
+          ? 'label'
+          : child.matches(groupSelector)
+            ? 'group'
+            : 'other',
+      }));
+    },
+    { groupSelector: GROUP, labelSelector: LABEL },
+  );
+}
+
+function itemLabels(page: Page): Promise<string[]> {
+  return page.evaluate(
+    (selector) =>
+      Array.from(document.querySelectorAll(selector)).map((element) =>
+        (element.querySelector('.dm-slash-command-item-label')?.textContent ?? '').trim(),
+      ),
+    ITEM,
+  );
+}
+
+for (const target of demoTargets) {
+  test.describe(`${target.name} slash menu without a leading group`, () => {
+    test('every group has a heading, so the menu opens on a category', async ({ page }) => {
+      await openSlashMenu(page, target);
+
+      const outline = await popupOutline(page);
+      expect(outline.length, 'the popup rendered something').toBeGreaterThan(1);
+      expect(outline[0]?.kind, 'the first child is a heading, not a group').toBe('label');
+      const headless = outline.filter(
+        (child, index) => child.kind === 'group' && outline[index - 1]?.kind !== 'label',
+      );
+      expect(headless, 'no group is missing its heading').toEqual([]);
+    });
+
+    test('no rule is drawn above the first heading', async ({ page }) => {
+      // Nothing here supplies a leading ungrouped item, so no line over nothing.
+      await openSlashMenu(page, target);
+
+      const border = await page
+        .locator(LABEL)
+        .first()
+        .evaluate((element) => getComputedStyle(element).borderTopWidth);
+      expect(border).toBe('0px');
+    });
+
+    test('the headings stay in one uninterrupted run', async ({ page }) => {
+      await openSlashMenu(page, target);
+      const labels = await itemLabels(page);
+
+      const first = labels.indexOf('Heading 1');
+      expect(first, 'Heading 1 is in the menu').toBeGreaterThanOrEqual(0);
+      expect(labels.slice(first, first + 3), 'nothing is wedged between them').toEqual([
+        'Heading 1',
+        'Heading 2',
+        'Heading 3',
+      ]);
+    });
+
+    test('every item keeps its description', async ({ page }) => {
+      // A leading item with no description must not become descriptions
+      // dropped menu-wide.
+      await openSlashMenu(page, target);
+
+      const missing = await page.evaluate(
+        (selector) =>
+          Array.from(document.querySelectorAll(selector))
+            .filter(
+              (element) => element.querySelector('.dm-slash-command-item-description') === null,
+            )
+            .map((element) =>
+              (element.querySelector('.dm-slash-command-item-label')?.textContent ?? '').trim(),
+            ),
+        ITEM,
+      );
+      expect(missing, 'these rows lost their description').toEqual([]);
+    });
+  });
+}

--- a/packages/core/src/FloatingMenuController.test.ts
+++ b/packages/core/src/FloatingMenuController.test.ts
@@ -151,7 +151,7 @@ describe('FloatingMenuController', () => {
       expect(controller.itemCount).toBe(0);
     });
 
-    it('groups items by group name, preserving first-seen order', () => {
+    it('groups items by group name, preserving first-seen order, ungrouped first', () => {
       const items = [
         item('a', { group: 'Basic' }),
         item('b', { group: 'Media' }),
@@ -161,7 +161,9 @@ describe('FloatingMenuController', () => {
       const { editor } = createMockEditor({ items });
       controller = new FloatingMenuController(editor, () => undefined);
       const groupNames = controller.groups.map((g) => g.name);
-      expect(groupNames).toEqual(['Basic', 'Media', '']);
+      // Ungrouped leads however late it arrives; ordering itself is tested in
+      // groupFloatingMenuItems.test.ts.
+      expect(groupNames).toEqual(['', 'Basic', 'Media']);
       const basic = controller.groups.find((g) => g.name === 'Basic')!;
       expect(basic.items.map((i) => i.name)).toEqual(['a', 'c']);
     });

--- a/packages/core/src/extensions/UniqueID.test.ts
+++ b/packages/core/src/extensions/UniqueID.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Fragment, Slice } from '@domternal/pm/model';
-import { Plugin } from '@domternal/pm/state';
+import { AllSelection, Plugin, TextSelection } from '@domternal/pm/state';
 import { Extension } from '../Extension.js';
 import { UniqueID } from './UniqueID.js';
 import { Document } from '../nodes/Document.js';
@@ -574,6 +574,112 @@ describe('UniqueID', () => {
       const copied = transformPasted.call(plugin!, slice, editor.view, false);
       expect(copied.content.firstChild?.attrs['id']).toBe('regenerated');
       view.dragging = null;
+    });
+
+    /**
+     * A block inside the replaced selection is about to be deleted, so its id
+     * is about to be free. Counting it renames the content replacing it.
+     */
+    describe('a paste that replaces its own source', () => {
+      const pasteOnce = (): Slice => {
+        const plugin = editor!.state.plugins.find((p) => p.props.transformPasted !== undefined);
+        const slice = editor!.state.doc.slice(0, editor!.state.doc.content.size);
+        editor!.view.dispatch(editor!.state.tr.setSelection(new AllSelection(editor!.state.doc)));
+        const transformed = plugin!.props.transformPasted!.call(
+          plugin!,
+          slice,
+          editor!.view,
+          false
+        );
+        editor!.view.dispatch(editor!.state.tr.replaceSelection(transformed));
+        return transformed;
+      };
+
+      const idsOf = (): string[] => {
+        const ids: string[] = [];
+        editor!.state.doc.descendants((node) => {
+          const id = node.attrs['id'] as string | undefined;
+          if (id) ids.push(id);
+          return true;
+        });
+        return ids;
+      };
+
+      it('keeps every id, and keeps them on the paste after that', () => {
+        // Counted, not constant: unfixed, this regenerates three ids at once,
+        // and one repeated string sends the renaming sweep round forever.
+        let fresh = 0;
+        const CustomUniqueID = UniqueID.configure({
+          types: ['paragraph', 'heading'],
+          generateID: () => `regenerated-${String(++fresh)}`,
+        });
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, Heading, CustomUniqueID],
+          content: '<h1 id="b1">Title</h1><p id="b2">First</p><p id="b3">Second</p>',
+        });
+
+        // Twice: the failure alternated, the first paste freeing the ids the
+        // second then kept.
+        pasteOnce();
+        expect(idsOf()).toEqual(['b1', 'b2', 'b3']);
+        pasteOnce();
+        expect(idsOf()).toEqual(['b1', 'b2', 'b3']);
+      });
+
+      it('still regenerates when the source survives the paste', () => {
+        const CustomUniqueID = UniqueID.configure({
+          types: ['paragraph'],
+          generateID: () => 'regenerated',
+        });
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, CustomUniqueID],
+          content: '<p id="source">Source</p><p id="target">Target</p>',
+        });
+        const plugin = editor.state.plugins.find((p) => p.props.transformPasted !== undefined);
+        const copied = editor.state.schema.nodes['paragraph']!.create(
+          { id: 'source' },
+          editor.state.schema.text('Source')
+        );
+        const slice = new Slice(Fragment.from(copied), 0, 0);
+
+        // The second paragraph selected; the first, which owns the pasted id,
+        // survives.
+        const target = editor.state.doc.child(0).nodeSize;
+        editor.view.dispatch(
+          editor.state.tr.setSelection(
+            TextSelection.create(editor.state.doc, target + 1, target + 7)
+          )
+        );
+        const result = plugin!.props.transformPasted!.call(plugin!, slice, editor.view, false);
+        expect(result.content.firstChild?.attrs['id']).toBe('regenerated');
+      });
+
+      it('regenerates when the selection only clips the block holding the id', () => {
+        const CustomUniqueID = UniqueID.configure({
+          types: ['paragraph'],
+          generateID: () => 'regenerated',
+        });
+        editor = new Editor({
+          extensions: [Document, Text, Paragraph, CustomUniqueID],
+          content: '<p id="first">First block</p><p id="second">Second block</p>',
+        });
+        const plugin = editor.state.plugins.find((p) => p.props.transformPasted !== undefined);
+        const copied = editor.state.schema.nodes['paragraph']!.create(
+          { id: 'first' },
+          editor.state.schema.text('First block')
+        );
+        const slice = new Slice(Fragment.from(copied), 0, 0);
+
+        // Trims both blocks and deletes neither, so both keep their ids.
+        const secondStart = editor.state.doc.child(0).nodeSize + 1;
+        editor.view.dispatch(
+          editor.state.tr.setSelection(
+            TextSelection.create(editor.state.doc, 4, secondStart + 4)
+          )
+        );
+        const result = plugin!.props.transformPasted!.call(plugin!, slice, editor.view, false);
+        expect(result.content.firstChild?.attrs['id']).toBe('regenerated');
+      });
     });
 
     it('a duplicate landing ABOVE the original renames the copy, not the original', async () => {

--- a/packages/core/src/extensions/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID.ts
@@ -26,6 +26,25 @@ function generateUUID(): string {
 
 export const uniqueIDPluginKey = new PluginKey('uniqueID');
 
+/** What a paste transform reads off the view; structural so a stub works. */
+interface PasteView {
+  dragging?: { move?: boolean } | null;
+  state?: {
+    selection?: {
+      ranges?: readonly { $from: { pos: number }; $to: { pos: number } }[];
+    };
+  };
+}
+
+/** Whether `[from, to)` lies entirely inside one of the given ranges. */
+function isWithin(
+  from: number,
+  to: number,
+  ranges: readonly { from: number; to: number }[]
+): boolean {
+  return ranges.some((range) => from >= range.from && to <= range.to);
+}
+
 export interface UniqueIDOptions {
   /**
    * Node types that should receive unique IDs.
@@ -106,6 +125,22 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
     const { types, attributeName, generateID, filterDuplicates } = this.options;
     const editor = this.editor as Editor | null;
 
+    /** The ranges a paste is about to delete. */
+    const replacedRanges = (view?: PasteView): { from: number; to: number }[] => {
+      // A drop inserts at the drop point and leaves the selection alone, so
+      // there the selection names content that SURVIVES.
+      if (view?.dragging) return [];
+      const ranges = view?.state?.selection?.ranges;
+      if (ranges === undefined) return [];
+      const replaced: { from: number; to: number }[] = [];
+      for (const range of ranges) {
+        if (range.$to.pos > range.$from.pos) {
+          replaced.push({ from: range.$from.pos, to: range.$to.pos });
+        }
+      }
+      return replaced;
+    };
+
     /**
      * ProseMirror runs this on the DRAGGED slice too, before the source is
      * deleted, so a plain block move looks like a duplicate and the moved block
@@ -114,15 +149,23 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
      * `move` is false for a copy drag, which should still regenerate. If a move
      * never completes, `assignMissingIDs` catches the duplicate.
      */
-    const transformPastedSlice = (slice: Slice, view?: { dragging?: { move?: boolean } | null }): Slice => {
+    const transformPastedSlice = (slice: Slice, view?: PasteView): Slice => {
       if (view?.dragging?.move === true) return slice;
 
       const existingIDs = new Set<string>();
+      const replaced = replacedRanges(view);
 
-      // Collect existing IDs in document
-      editor?.state.doc.descendants((node: PMNode) => {
+      // Existing ids, minus the ones the paste is about to delete: a block
+      // being replaced is not an incumbent, and counting it renamed the very
+      // content replacing it (Ctrl+A then paste), orphaning every reference.
+      // A `handlePaste` that inserts elsewhere can defeat this; the cost is a
+      // duplicate `assignMissingIDs` renames on the next transaction.
+      editor?.state.doc.descendants((node: PMNode, pos: number) => {
+        // Whole subtree: everything inside a replaced node is replaced too.
+        if (isWithin(pos, pos + node.nodeSize, replaced)) return false;
         const id = node.attrs[attributeName] as string | undefined;
         if (id) existingIDs.add(id);
+        return true;
       });
 
       // Transform pasted content

--- a/packages/core/src/utils/groupFloatingMenuItems.test.ts
+++ b/packages/core/src/utils/groupFloatingMenuItems.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { groupFloatingMenuItems } from './groupFloatingMenuItems.js';
+import type { FloatingMenuItem } from '../types/FloatingMenu.js';
+
+function item(partial: Partial<FloatingMenuItem> & { name: string }): FloatingMenuItem {
+  return { label: partial.name, command: 'noop', ...partial };
+}
+
+const names = (groups: { name: string }[]): string[] => groups.map((group) => group.name);
+
+describe('groupFloatingMenuItems', () => {
+  it('keeps groups in the order their first item arrived', () => {
+    const groups = groupFloatingMenuItems([
+      item({ name: 'a', group: 'Basic' }),
+      item({ name: 'b', group: 'Media' }),
+      item({ name: 'c', group: 'Basic' }),
+    ]);
+
+    expect(names(groups)).toEqual(['Basic', 'Media']);
+    expect(groups[0]?.items.map((entry) => entry.name)).toEqual(['a', 'c']);
+  });
+
+  it('sorts by priority within a group, highest first, default 100', () => {
+    const groups = groupFloatingMenuItems([
+      item({ name: 'low', group: 'Basic', priority: 10 }),
+      item({ name: 'high', group: 'Basic', priority: 300 }),
+      item({ name: 'default', group: 'Basic' }),
+    ]);
+
+    expect(groups[0]?.items.map((entry) => entry.name)).toEqual(['high', 'default', 'low']);
+  });
+
+  describe('an item with no group', () => {
+    it('leads, however late it arrives', () => {
+      // Insertion order would file it last, which is the whole problem.
+      const groups = groupFloatingMenuItems([
+        item({ name: 'heading', group: 'Basic' }),
+        item({ name: 'image', group: 'Media' }),
+        item({ name: 'ask-ai' }),
+      ]);
+
+      expect(names(groups)).toEqual(['', 'Basic', 'Media']);
+      expect(groups[0]?.items.map((entry) => entry.name)).toEqual(['ask-ai']);
+    });
+
+    it('leads when it arrives first too', () => {
+      const groups = groupFloatingMenuItems([
+        item({ name: 'ask-ai' }),
+        item({ name: 'heading', group: 'Basic' }),
+      ]);
+
+      expect(names(groups)).toEqual(['', 'Basic']);
+    });
+
+    it('leaves the order of the named groups behind it alone', () => {
+      const groups = groupFloatingMenuItems([
+        item({ name: 'heading', group: 'Basic' }),
+        item({ name: 'ask-ai' }),
+        item({ name: 'image', group: 'Media' }),
+        item({ name: 'table', group: 'Blocks' }),
+      ]);
+
+      expect(names(groups)).toEqual(['', 'Basic', 'Media', 'Blocks']);
+    });
+
+    it('shares one leading group with every other ungrouped item, by priority', () => {
+      const groups = groupFloatingMenuItems([
+        item({ name: 'second', priority: 10 }),
+        item({ name: 'heading', group: 'Basic' }),
+        item({ name: 'first', priority: 20 }),
+      ]);
+
+      expect(names(groups)).toEqual(['', 'Basic']);
+      expect(groups[0]?.items.map((entry) => entry.name)).toEqual(['first', 'second']);
+    });
+
+    it('is absent entirely when every item declares a group', () => {
+      // What the separator rule hangs on: no ungrouped item, no line.
+      const groups = groupFloatingMenuItems([
+        item({ name: 'heading', group: 'Basic' }),
+        item({ name: 'image', group: 'Media' }),
+      ]);
+
+      expect(groups.some((group) => group.name === '')).toBe(false);
+    });
+
+    it('treats an empty-string group as the same thing', () => {
+      const groups = groupFloatingMenuItems([
+        item({ name: 'heading', group: 'Basic' }),
+        item({ name: 'blank', group: '' }),
+      ]);
+
+      expect(names(groups)).toEqual(['', 'Basic']);
+    });
+  });
+});

--- a/packages/core/src/utils/groupFloatingMenuItems.ts
+++ b/packages/core/src/utils/groupFloatingMenuItems.ts
@@ -13,6 +13,10 @@ export interface FloatingMenuGroup {
  * order of groups. Within each group, items are sorted by `priority`
  * descending (higher first, default 100).
  *
+ * An item with NO group leads: declining a category marks a primary action,
+ * and insertion order would file it last, since whatever adds one loads after
+ * the extensions defining the categories. Renderers give it no heading.
+ *
  * Shared between `FloatingMenuController` (which renders grouped item lists
  * for FloatingMenu + framework wrappers) and `createSlashSuggestionRenderer`
  * (the popup shown by SlashCommand). Having one implementation keeps visual
@@ -28,7 +32,8 @@ export function groupFloatingMenuItems(items: FloatingMenuItem[]): FloatingMenuG
     if (!list) {
       list = [];
       map.set(name, list);
-      order.push(name);
+      if (name === '') order.unshift(name);
+      else order.push(name);
     }
     list.push(item);
   }

--- a/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
+++ b/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
@@ -147,9 +147,12 @@ describe('createSlashSuggestionRenderer - rendered DOM', () => {
     const renderer = createSlashSuggestionRenderer();
     renderer.onStart(makeProps([itemA, itemC])); // C has no icon
 
+    // By label, not index: C declines a group, and an ungrouped item leads.
     const buttons = Array.from(host?.querySelectorAll<HTMLButtonElement>('.dm-slash-command-item') ?? []);
-    expect(buttons[0]?.querySelector('.dm-slash-command-item-icon')).not.toBeNull();
-    expect(buttons[1]?.querySelector('.dm-slash-command-item-icon')).toBeNull();
+    const byLabel = (label: string): HTMLButtonElement | undefined =>
+      buttons.find((button) => button.textContent?.includes(label));
+    expect(byLabel('Heading 1')?.querySelector('.dm-slash-command-item-icon')).not.toBeNull();
+    expect(byLabel('Code block')?.querySelector('.dm-slash-command-item-icon')).toBeNull();
     renderer.onExit();
   });
 

--- a/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
+++ b/packages/extension-block-controls/src/createSlashSuggestionRenderer.test.ts
@@ -150,7 +150,7 @@ describe('createSlashSuggestionRenderer - rendered DOM', () => {
     // By label, not index: C declines a group, and an ungrouped item leads.
     const buttons = Array.from(host?.querySelectorAll<HTMLButtonElement>('.dm-slash-command-item') ?? []);
     const byLabel = (label: string): HTMLButtonElement | undefined =>
-      buttons.find((button) => button.textContent?.includes(label));
+      buttons.find((button) => button.textContent.includes(label));
     expect(byLabel('Heading 1')?.querySelector('.dm-slash-command-item-icon')).not.toBeNull();
     expect(byLabel('Code block')?.querySelector('.dm-slash-command-item-icon')).toBeNull();
     renderer.onExit();

--- a/packages/theme/src/_block-handle.scss
+++ b/packages/theme/src/_block-handle.scss
@@ -66,12 +66,11 @@
   // Pin static position to parent top so the hidden box doesn't
   // inflate parent scrollHeight. JS sets `top` inline on show.
   top: 0;
-  // Tokenised so demos with a centered narrower content column can move
-  // the handle further out (e.g., `--dm-block-handle-left: -2.75rem`) to
-  // place it fully in the surrounding whitespace (that needs the
-  // `overflow: visible` set above on `.dm-editor--has-block-handle`).
-  // Default `0.25rem` keeps the 40px cluster inside the standard
-  // `--dm-block-handle-gutter` reservation, 4px before the text.
+  // Resolved against `.dm-editor`, so a layout whose column is narrower than
+  // the editor must derive this from the column (see `_notion-mode.scss`) or
+  // the handle stays pinned to the editor's edge. A negative value needs the
+  // `overflow: visible` set above. Default `0.25rem` keeps the 40px cluster
+  // inside the `--dm-block-handle-gutter` reservation, 4px before the text.
   left: var(--dm-block-handle-left, 0.25rem);
   display: flex;
   align-items: center;

--- a/packages/theme/src/_notion-mode.scss
+++ b/packages/theme/src/_notion-mode.scss
@@ -12,30 +12,37 @@
   box-shadow: none;
   background: transparent;
 
-  // Centered, comfortably narrow reading column. The surrounding margin
-  // is where the BlockHandle sits (see token overrides below). Consumers
-  // are expected to control the surrounding container width; on viewports
-  // narrower than 38rem the column overflows by design (Notion mode is
-  // opt-in).
-  max-width: 38rem;
+  // The measure. Read twice: as the column's width, and halved in the handle
+  // offset below, so overriding it moves both.
+  --dm-notion-column-width: 44rem;
+
+  // Do NOT cap the frame here. A docked sidebar makes room by sliding the
+  // column, and only within the frame; capped to the column's own width there
+  // is no whitespace to slide into and the sidebar lands on the prose.
+  max-width: none;
   margin: 0 auto;
 
-  // Generous reading line-height; padding zeroed because the page wrapper
-  // supplies the white space around the column. Body font-size inherits
-  // classic 1rem so toggling between modes doesn't shift text size.
+  // Zero padding is a precondition of the handle offset, not tidiness: it
+  // assumes the text starts at the column's left edge.
   --dm-editor-line-height: 1.7;
   --dm-editor-padding: 0;
 
-  // Handle lives fully OUTSIDE the centered content column. Zeroing the
-  // ProseMirror gutter token reclaims the reserved column (the handle no
-  // longer overlaps content - there is nothing to reserve). The negative
-  // `left` token pulls the 40px handle cluster left of the column so its
-  // right edge ends 4px before the content's left edge (Notion hugs its
-  // controls to the text the same way): -44px + 40px = -4px.
+  // Walk in to the centred column's edge, then back off the 40px cluster plus
+  // the 4px gap `BlockHandle` uses for container-anchored blocks, so both
+  // paths agree. The shift term follows a panel that slides the column.
   --dm-block-handle-gutter: 0;
-  --dm-block-handle-left: -2.75rem;
+  --dm-block-handle-left: calc(
+    max(50% - var(--dm-notion-column-width) * 0.5, 0px) - 2.75rem +
+      var(--dm-panel-column-shift, 0px)
+  );
 
   .ProseMirror {
+    // `border-box` because `.ProseMirror` has no box-sizing of its own, so
+    // padding would otherwise widen the box past the measure.
+    box-sizing: border-box;
+    max-width: var(--dm-notion-column-width);
+    margin-inline: auto;
+
     min-height: 60vh;
     outline: none;
 

--- a/packages/theme/src/_print.scss
+++ b/packages/theme/src/_print.scss
@@ -191,6 +191,15 @@
   // A border, a shadow and a tinted panel are screen furniture: the paper is
   // already the page. The gutter is the expensive one, it is reserved for the
   // drag handle and costs ~48px on every printed page.
+  // The canvas, to match the black text forced below. Named here because the
+  // ancestor rule further down cannot reach `body`, which is not a descendant
+  // of itself. Transition first: a running one outranks `!important`, and a
+  // theme toggle animates this.
+  body {
+    transition: none !important;
+    background: none !important;
+  }
+
   .dm-editor {
     border: none !important;
     border-radius: 0 !important;
@@ -314,6 +323,12 @@
   // The ancestors themselves survive but stop imposing layout: a sidebar
   // grid, a centred max-width column or a scroll container would otherwise
   // keep shaping a page that no longer has anything beside the document.
+  // Only under the command path, where everything but the document is hidden,
+  // so this can reach nothing the host owns.
+  body.dm-printing {
+    color: #000 !important;
+  }
+
   body.dm-printing .dm-print-ancestor {
     display: block !important;
     position: static !important;

--- a/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
+++ b/packages/vanilla/src/bubble-menu/DomternalBubbleMenu.ts
@@ -72,14 +72,13 @@ export type { BubbleMenuItem, BubbleMenuTrailingState };
  * "..." for block context menu) are rendered automatically when the
  * corresponding extensions are loaded.
  *
- * Re-renders are batched via `requestAnimationFrame`. DOM is rebuilt on every
- * transaction because the item list changes with context (selection moves
- * between text and code-block, for example).
+ * Re-renders are batched via `requestAnimationFrame`. The structure is rebuilt
+ * only when the item list changes; a state-only render updates the nodes on
+ * screen, so a press that outlives a transaction still produces a click.
  *
- * **Stable identity convention.** Trigger buttons (including the "A" and "..."
- * trailing triggers and dropdown triggers) are DESTROYED and RECREATED on
- * every transaction. Consumers that store a reference to a trigger element
- * (e.g. as a popover anchor) should:
+ * **Stable identity convention.** A trigger survives a state-only render but
+ * NOT an item-list change, so consumers holding a reference to one (e.g. as a
+ * popover anchor) should still:
  * - Either listen for `selectionUpdate` / `transaction` and re-resolve the
  *   anchor via `host.querySelector('.dm-ncp-trigger')` on demand
  * - Or match the trigger by class + container (`closest('.dm-bubble-menu')`)
@@ -154,6 +153,16 @@ export class DomternalBubbleMenu extends EventTarget {
   #activeMap = new Map<string, boolean>();
   #disabledMap = new Map<string, boolean>();
   #trailing: BubbleMenuTrailingState = { ...INITIAL_TRAILING_STATE };
+
+  // Structure rebuilt only on an item-list change, so a pressed button lives.
+  #structureKey: string | null = null;
+  #buttonEls = new Map<string, HTMLButtonElement>();
+  // Icon markup last WRITTEN. `btn.innerHTML` returns the browser's
+  // re-serialisation, so comparing against it rewrites every render and
+  // replaces the glyph under the pointer. Keyed by element: names repeat.
+  #iconHtml = new WeakMap<Element, string>();
+  #colorTriggerEl: HTMLButtonElement | null = null;
+  #blockMenuTriggerEl: HTMLButtonElement | null = null;
 
   // Dropdown state (text-align dropdown inside bubble menu)
   #openDropdown: string | null = null;
@@ -283,6 +292,10 @@ export class DomternalBubbleMenu extends EventTarget {
   setIcons(icons: IconSet | undefined): void {
     if (this.#destroyed) return;
     this.#icons = icons;
+    // Icons live in innerHTML where the state-only render never looks: the
+    // "..." trigger and an open panel. Rebuild, as the toolbar does; a
+    // consumer call catches no press.
+    this.#structureKey = null;
     this.#scheduleRender();
   }
 
@@ -506,32 +519,61 @@ export class DomternalBubbleMenu extends EventTarget {
     });
   }
 
+  /** Signature of what decides which nodes exist; equal keys reuse the DOM. */
+  #computeStructureKey(): string {
+    const items = this.#resolvedItems
+      .map((item) =>
+        item.type === 'dropdown'
+          ? `${item.type}:${item.name}:${item.items.map((sub) => sub.name).join(',')}`
+          : `${item.type}:${item.name}`,
+      )
+      .join('|');
+    const t = this.#trailing;
+    return [
+      items,
+      t.showColorPickerButton && !t.isNodeSelection ? 'color' : '',
+      t.showBlockMenuButton && !t.isNodeSelection ? 'block' : '',
+      this.#customContent ? 'custom' : '',
+    ].join('#');
+  }
+
+  /**
+   * Runs on every transaction, and pointer motion alone dispatches those. A
+   * render lands a frame late, so rebuilding wholesale can replace a button
+   * between mousedown and mouseup: the two events share no element and the
+   * browser fires no click at all. Structure only on an item-list change,
+   * state in place otherwise, as the toolbar does.
+   */
   #render(): void {
-    // Bubble menu items change with selection context, so we rebuild DOM
-    // every render. The cost is small (typically <10 buttons) and keeps
-    // the logic straightforward vs incremental diff.
-    this.host.replaceChildren();
-
-    // The dropdown panel was a child of host - replaceChildren() removed it.
-    // Detach our floating + AbortController state but KEEP `#openDropdown`
-    // name so `#createDropdownTrigger` re-creates the panel when it encounters
-    // the matching item below. Without this preservation, clicking a dropdown
-    // trigger (which sets openDropdown then calls #render) would immediately
-    // see the panel orphaned and close.
-    this.#cleanupDropdownFloating?.();
-    this.#cleanupDropdownFloating = null;
-    this.#dropdownAbortCtl?.abort();
-    this.#dropdownAbortCtl = null;
-    this.#dropdownPanelEl = null;
-
-    // If the open dropdown is no longer in resolvedItems (e.g. selection
-    // moved to a context that doesn't show it), clear the flag.
+    // A dropdown whose trigger left the item list cannot stay open.
     if (this.#openDropdown !== null) {
       const stillExists = this.#resolvedItems.some(
         (item) => item.type === 'dropdown' && item.name === this.#openDropdown,
       );
-      if (!stillExists) this.#openDropdown = null;
+      if (!stillExists) {
+        this.#openDropdown = null;
+        this.#detachDropdown();
+      }
     }
+
+    const key = this.#computeStructureKey();
+    if (key === this.#structureKey) {
+      this.#updateButtons();
+    } else {
+      this.#renderStructure();
+      this.#structureKey = key;
+    }
+    this.#syncDropdownPanel();
+  }
+
+  #renderStructure(): void {
+    this.host.replaceChildren();
+    this.#buttonEls.clear();
+    this.#colorTriggerEl = null;
+    this.#blockMenuTriggerEl = null;
+    // replaceChildren() took the panel; `#openDropdown` survives and
+    // `#syncDropdownPanel` rebuilds it under the new trigger.
+    this.#detachDropdown();
 
     for (const item of this.#resolvedItems) {
       if (item.type === 'separator') {
@@ -583,10 +625,11 @@ export class DomternalBubbleMenu extends EventTarget {
     btn.setAttribute('aria-label', item.label);
     btn.setAttribute('aria-pressed', String(isActive));
     btn.title = item.label;
-    btn.innerHTML = resolveIcon(item.icon, this.#icons);
+    this.#setIconHtml(btn, resolveIcon(item.icon, this.#icons));
 
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', (e) => { this.#onButtonClick(item, e); });
+    this.#buttonEls.set(item.name, btn);
     return btn;
   }
 
@@ -611,21 +654,13 @@ export class DomternalBubbleMenu extends EventTarget {
     trigger.setAttribute('aria-label', dd.label);
     trigger.title = dd.label;
     trigger.dataset['dropdown'] = dd.name;
-    trigger.innerHTML = triggerHtml;
+    this.#setIconHtml(trigger, triggerHtml);
     trigger.addEventListener('mousedown', (e) => { e.preventDefault(); });
     trigger.addEventListener('click', () => { this.#onDropdownToggle(dd); });
 
     wrapper.appendChild(trigger);
-
-    // If this dropdown was already open (e.g. re-render preserving open state)
-    // append its panel too. In practice #render closes open dropdowns first,
-    // so this branch is reached only from explicit re-opens.
-    if (this.#openDropdown === dd.name) {
-      const panel = this.#createDropdownPanel(dd);
-      wrapper.appendChild(panel);
-      this.#dropdownPanelEl = panel;
-      this.#attachDropdownListeners(trigger, panel);
-    }
+    this.#buttonEls.set(dd.name, trigger);
+    // `#syncDropdownPanel` owns the panel, so opening one rebuilds nothing.
     return wrapper;
   }
 
@@ -645,6 +680,7 @@ export class DomternalBubbleMenu extends EventTarget {
       if (subActive) subBtn.classList.add('dm-toolbar-dropdown-item--active');
       subBtn.setAttribute('role', 'menuitem');
       subBtn.setAttribute('aria-label', sub.label);
+      subBtn.dataset['dropdownItem'] = sub.name;
       subBtn.innerHTML = subHtml;
       subBtn.addEventListener('mousedown', (e) => { e.preventDefault(); });
       subBtn.addEventListener('click', () => { this.#onDropdownItemClick(sub); });
@@ -676,6 +712,7 @@ export class DomternalBubbleMenu extends EventTarget {
 
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', () => { this.openColorPicker(btn); });
+    this.#colorTriggerEl = btn;
     return btn;
   }
 
@@ -693,7 +730,96 @@ export class DomternalBubbleMenu extends EventTarget {
     btn.innerHTML = resolveIcon('dotsThree', this.#icons);
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', () => { this.openBlockContextMenu(btn); });
+    this.#blockMenuTriggerEl = btn;
     return btn;
+  }
+
+  // === In-place updates (the common render) ===
+
+  #updateButtons(): void {
+    for (const item of this.#resolvedItems) {
+      if (item.type === 'separator') continue;
+      const el = this.#buttonEls.get(item.name);
+      if (!el) continue;
+      if (item.type === 'dropdown') this.#updateDropdownTrigger(item, el);
+      else this.#updateButton(item, el);
+    }
+
+    const t = this.#trailing;
+    if (this.#colorTriggerEl) {
+      this.#colorTriggerEl.classList.toggle('dm-toolbar-button--active', t.hasAnyColor);
+      const glyph = this.#colorTriggerEl.querySelector<HTMLElement>('.dm-ncp-trigger-glyph');
+      if (glyph) glyph.style.color = t.currentTextColorVar ?? '';
+      const underline = this.#colorTriggerEl.querySelector<HTMLElement>('.dm-ncp-trigger-underline');
+      if (underline) underline.style.backgroundColor = t.currentBgColorVar ?? '';
+    }
+    if (this.#blockMenuTriggerEl) {
+      this.#blockMenuTriggerEl.disabled = t.blockMenuButtonDisabled;
+      this.#blockMenuTriggerEl.title = t.blockMenuButtonDisabled
+        ? 'Block actions (select within a single block)'
+        : 'More options';
+    }
+  }
+
+  #updateButton(item: ToolbarButton, btn: HTMLButtonElement): void {
+    const isActive = this.#activeMap.get(item.name) ?? false;
+    const isDisabled = this.#disabledMap.get(item.name) ?? false;
+    btn.classList.toggle('dm-toolbar-button--active', isActive);
+    btn.disabled = isDisabled;
+    btn.setAttribute('aria-pressed', String(isActive));
+    this.#setIconHtml(btn, resolveIcon(item.icon, this.#icons));
+  }
+
+  /** Writes icon markup only when it differs from what was written last. */
+  #setIconHtml(el: HTMLElement, html: string): void {
+    if (this.#iconHtml.get(el) === html) return;
+    this.#iconHtml.set(el, html);
+    el.innerHTML = html;
+  }
+
+  #updateDropdownTrigger(dd: ToolbarDropdown, trigger: HTMLButtonElement): void {
+    const dropdownActive = dd.items.some((sub) => this.#activeMap.get(sub.name) ?? false);
+    const activeChild = dd.dynamicIcon
+      ? dd.items.find((sub) => this.#activeMap.get(sub.name) ?? false)
+      : undefined;
+    const html = resolveIcon(activeChild?.icon ?? dd.icon, this.#icons) + DROPDOWN_CARET;
+    trigger.classList.toggle('dm-toolbar-button--active', dropdownActive);
+    trigger.setAttribute('aria-expanded', String(this.#openDropdown === dd.name));
+    this.#setIconHtml(trigger, html);
+  }
+
+  /** Builds the open dropdown's panel, or refreshes the marks on an open one. */
+  #syncDropdownPanel(): void {
+    const open = this.#openDropdown;
+    if (open === null) {
+      if (this.#dropdownPanelEl) this.#detachDropdown();
+      return;
+    }
+
+    const dd = this.#resolvedItems.find(
+      (item): item is ToolbarDropdown => item.type === 'dropdown' && item.name === open,
+    );
+    if (!dd) return;
+
+    const panel = this.#dropdownPanelEl;
+    if (panel?.isConnected === true) {
+      for (const sub of dd.items) {
+        const subBtn = panel.querySelector<HTMLElement>(`[data-dropdown-item="${sub.name}"]`);
+        subBtn?.classList.toggle(
+          'dm-toolbar-dropdown-item--active',
+          this.#activeMap.get(sub.name) ?? false,
+        );
+      }
+      return;
+    }
+
+    const trigger = this.#buttonEls.get(open);
+    const wrapper = trigger?.parentElement;
+    if (!trigger || !wrapper) return;
+    const fresh = this.#createDropdownPanel(dd);
+    wrapper.appendChild(fresh);
+    this.#dropdownPanelEl = fresh;
+    this.#attachDropdownListeners(trigger, fresh);
   }
 
   // === Event handlers ===

--- a/packages/vanilla/src/toolbar/DomternalToolbar.ts
+++ b/packages/vanilla/src/toolbar/DomternalToolbar.ts
@@ -103,6 +103,8 @@ export class DomternalToolbar extends EventTarget {
 
   /** Maps top-level button/dropdown name -> rendered trigger element. */
   #buttonEls = new Map<string, HTMLButtonElement>();
+  /** Trigger markup last written, so a re-render does not rewrite it blindly. */
+  #triggerHtml = new WeakMap<Element, string>();
 
   /** Rendered dropdown panel elements (created lazily when opened). */
   #dropdownPanelEl: HTMLElement | null = null;
@@ -350,7 +352,9 @@ export class DomternalToolbar extends EventTarget {
     btn.setAttribute('aria-label', dd.label);
     btn.title = dd.label;
     btn.setAttribute('data-dropdown', dd.name);
-    btn.innerHTML = this.#resolveDropdownTriggerHtml(dd);
+    const triggerHtml = this.#resolveDropdownTriggerHtml(dd);
+    this.#triggerHtml.set(btn, triggerHtml);
+    btn.innerHTML = triggerHtml;
 
     btn.addEventListener('mousedown', (e) => { e.preventDefault(); });
     btn.addEventListener('click', () => { this.#onDropdownToggle(dd); });
@@ -439,10 +443,13 @@ export class DomternalToolbar extends EventTarget {
     btn.setAttribute('aria-expanded', String(isOpen));
     btn.tabIndex = flat === focusedIndex ? 0 : -1;
 
-    // Trigger HTML may change with cursor (dynamicLabel/dynamicIcon).
-    // Recompute and only swap if different (avoids needless DOM writes).
+    // Trigger HTML follows the cursor (dynamicLabel/dynamicIcon). Compared
+    // against what was last WRITTEN: `btn.innerHTML` returns the browser's
+    // re-serialisation, so the old guard never held and every render replaced
+    // the glyph under the pointer, killing the press.
     const newHtml = this.#resolveDropdownTriggerHtml(dd);
-    if (btn.innerHTML !== newHtml) {
+    if (this.#triggerHtml.get(btn) !== newHtml) {
+      this.#triggerHtml.set(btn, newHtml);
       btn.innerHTML = newHtml;
     }
   }


### PR DESCRIPTION
## Summary

One behaviour change and four user-visible fixes, each with the e2e that would have caught it, plus two repo chores. Three of the five were invisible to the existing suites: the menu press one passed every press test we had, the print one only reproduces on a dark theme, and the block id one alternated, so a single reproduction step looked like a pass.

## Features

An item registered through `addFloatingMenuItems` with no `group` now leads the menu, above every category, in both surfaces that read the hook. Declining a category marks a primary action rather than one more of a kind, and insertion order could not express that: whatever adds one is loaded after the extensions that define the categories, so it filed last. Nothing in this repo ships an ungrouped item, so no menu here moves.

## Fix

**Vanilla menus lost a press that outlived a render.** Two separate causes with the same symptom. The bubble menu called `host.replaceChildren()` on every render, so a button did not merely lose its glyph, it stopped existing; the toolbar guarded its dropdown trigger with `btn.innerHTML !== newHtml`, a comparison against the browser's re-serialisation of what was written, which never matches, so every render replaced the glyph under the pointer. Either one kills the click, because a browser fires one only when mousedown and mouseup share an element. Worth recording because of how it hid: the matrix already ran two press tests against all four demos and vanilla passed both, since a no-op transaction does not always land inside the press. It shipped without a regression test, and the one added here asserts the mechanism instead of the symptom, that the button and its icon are the same DOM nodes after a render as before it. Reverting the two source files makes all three new tests fail with "the button was replaced" and "the glyph was rewritten though it depicts the same alignment".

**A paste that replaced its own source renamed every block it replaced.** Block ids are regenerated to avoid landing a duplicate, judged against the document as it stands when the paste is parsed, and that view is wrong for a paste that deletes the blocks it is reading: the incumbents it sees are about to go. Ctrl+A then Ctrl+V renamed everything, so anything naming a block from outside the document, a table-of-contents deep link, a `#hash` anchor, the block menu's Copy link, pointed at nothing. The next paste then found those ids unclaimed and kept them, so ids flickered on alternate pastes and one paste could not tell a fix from the other half of the bug, which is why both new e2e cases paste twice. Existing ids are now collected minus the ones the paste is about to delete; a `handlePaste` that inserts elsewhere can still defeat that, and the cost is one duplicate that the existing rename sweep resolves on the next transaction, in the incumbent's favour.

**Notion mode capped the frame instead of the column.** `max-width: 38rem` sat on `.dm-editor.dm-notion-mode`, so the frame was exactly as wide as the text. A docked sidebar makes room by sliding the content column within the frame, and with the frame capped there is no whitespace to slide into, so the sidebar lands on the prose. The measure now sits on the column behind `--dm-notion-column-width` (44rem), the frame is uncapped, and the block handle offset is derived from the same token so overriding it moves both. The demo containers grew with it: a 44rem column plus the 48px the handle needs does not fit the 210mm sheet they were shaped as.

**A dark theme printed its page canvas behind the black text the print layer forces.** Black on near-black, so the sheet came out unreadable rather than merely wrong. Two layers had to be fixed together: `body` was never cleared, because the rule that clears ancestor backgrounds cannot reach it (no element is a descendant of itself), and a running theme-toggle transition outranks `!important`, so the transition has to be killed in the same declaration. Either half alone still passes, which is why the tests assert them together.

## Changes

- The block handle's `--dm-block-handle-left` is documented as resolving against `.dm-editor`, so a layout with a narrower column must derive it from the column rather than restating a magic offset.
- A Pro bug report issue template and a support contact link, so Pro reports arrive labelled and anything involving customer data or a vulnerability goes to email rather than a public issue.
- `.pnpm-store/` ignored, for a store that lands inside the repo.

## Verified

- Root e2e matrix, all four demos: `menu-click-during-transaction` 20/20, `notion-column-token` and `print` 148/148, `paste-block-identity` 12/12 and 36/36 across three consecutive repeats, `slash-menu-leading-group` 16/16.
- Unit suites green across all 12 projects, plus the API surface snapshot, the CSS variable references, and lint.
- The full CI workflow was run locally at 11 of 11 steps for the first seven commits; the two added since were checked against build, typecheck, lint, unit, API surface and CSS variables rather than the whole workflow again.
- Three of the four fixes proven by reverting the source and watching the new tests fail: the vanilla one on all three new press tests, the paste one on the first of its three cases while the other two keep passing, since those guard against over-correcting in the opposite direction.