### PR TITLE
feat(core): lead the Notion selection menu with Ask AI and Comment, and pin the resolved order per framework

### DIFF
--- a/apps/demo-angular/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-angular/e2e/notion-drop-placement-sibling.spec.ts
@@ -170,14 +170,23 @@ async function dragBlock(
  * Drag-over WITHOUT dropping. Used to assert indicator state mid-drag.
  * Caller is responsible for ending the drag with `dragend` to clean up.
  */
-async function startDragOver(page: Page, sourceBlock: Locator, targetBlock: Locator): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
+async function startDragOver(
+  page: Page,
+  sourceBlock: Locator,
+  targetBlock: Locator,
+  position: { xReference?: Locator; xOffset?: number } = {},
+): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
   await sourceBlock.hover();
   const dt = await page.evaluateHandle(() => new DataTransfer());
   const handle = page.locator(dragBtnSelector);
   await handle.dispatchEvent('dragstart', { dataTransfer: dt });
   const targetBox = await targetBlock.boundingBox();
   if (!targetBox) throw new Error('target has no bounding box');
-  const clientX = targetBox.x + 4;
+  const xReferenceBox = position.xReference
+    ? await position.xReference.boundingBox()
+    : targetBox;
+  if (!xReferenceBox) throw new Error('X reference has no bounding box');
+  const clientX = xReferenceBox.x + (position.xOffset ?? 4);
   const clientY = targetBox.y + targetBox.height * 0.8;
   await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
   await flushIndicatorRaf(page);
@@ -428,13 +437,18 @@ test.describe('drop placement - indicator contract across target types', () => {
     // List item with [label paragraph, nested h2]. The slot model does not
     // make the nested heading an independent row, so its region belongs to the
     // parent list item: a drop there nests into the item (dashed) at the child
-    // slot next to the heading. startDragOver lands X at the heading's own
-    // indent, which is already past the nest threshold relative to the item.
+    // slot next to the heading. Keep Y inside the heading, but measure X from
+    // the parent item and land clearly past the 28px nesting threshold.
     await setContent(page, '<p>Top</p><ul><li><p>Label</p><h2>Nested</h2></li></ul>');
+    const nestedHeading = page.locator(`${editorSelector} h2:has-text("Nested")`);
     const { handle, dt } = await startDragOver(
       page,
       page.locator(`${editorSelector} p:has-text("Top")`),
-      page.locator(`${editorSelector} h2:has-text("Nested")`),
+      nestedHeading,
+      {
+        xReference: page.locator(`${editorSelector} li:has-text("Nested")`),
+        xOffset: 40,
+      },
     );
     const info = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');

--- a/apps/demo-angular/src/app/bubble-icons-fixtures.ts
+++ b/apps/demo-angular/src/app/bubble-icons-fixtures.ts
@@ -9,7 +9,7 @@
  * readable.
  */
 
-import type { IconSet } from '@domternal/core';
+import { Extension, type AnyExtension, type IconSet, type ToolbarItem } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
@@ -79,4 +79,35 @@ export function parseBubbleItemsParam(): string[] | undefined {
   const value = params.get('bubble-items');
   if (!value) return undefined;
   return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function bubbleOrderItem(name: 'ai' | 'comment', label: string, icon: string): AnyExtension {
+  return Extension.create({
+    name: `bubbleOrderFixture${name}`,
+    addToolbarItems(): ToolbarItem[] {
+      return [{
+        type: 'button',
+        name,
+        command: 'focus',
+        icon,
+        label,
+        toolbar: false,
+        bubbleMenu: 'text',
+      }];
+    },
+  });
+}
+
+/** Test-only toolbar contributions used to resolve the Pro slots in the FREE default context. */
+export function bubbleOrderFixtureExtensions(): AnyExtension[] {
+  if (typeof window === 'undefined') return [];
+  const fixture = new URLSearchParams(window.location.search).get('bubble-order');
+  if (fixture === 'both') {
+    return [
+      bubbleOrderItem('ai', 'Ask AI', 'textB'),
+      bubbleOrderItem('comment', 'Comment', 'link'),
+    ];
+  }
+  if (fixture === 'comment') return [bubbleOrderItem('comment', 'Comment', 'link')];
+  return [];
 }

--- a/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
+++ b/apps/demo-angular/src/app/notion-demo/notion-demo.component.ts
@@ -76,6 +76,7 @@ import type { IconSet } from '@domternal/core';
 import { createLowlight, common } from 'lowlight';
 import katex from 'katex';
 import {
+  bubbleOrderFixtureExtensions,
   parseBubbleIconsParam,
   resolveBubbleIcons,
   type BubbleIconsParam,
@@ -138,6 +139,7 @@ export class NotionDemoComponent implements OnDestroy {
 
   private static buildExtensions(scrollParent: Element | null): AnyExtension[] {
     return [
+      ...bubbleOrderFixtureExtensions(),
       Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
       Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
       BulletList, OrderedList, TaskList,

--- a/apps/demo-react/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-react/e2e/notion-drop-placement-sibling.spec.ts
@@ -170,14 +170,23 @@ async function dragBlock(
  * Drag-over WITHOUT dropping. Used to assert indicator state mid-drag.
  * Caller is responsible for ending the drag with `dragend` to clean up.
  */
-async function startDragOver(page: Page, sourceBlock: Locator, targetBlock: Locator): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
+async function startDragOver(
+  page: Page,
+  sourceBlock: Locator,
+  targetBlock: Locator,
+  position: { xReference?: Locator; xOffset?: number } = {},
+): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
   await sourceBlock.hover();
   const dt = await page.evaluateHandle(() => new DataTransfer());
   const handle = page.locator(dragBtnSelector);
   await handle.dispatchEvent('dragstart', { dataTransfer: dt });
   const targetBox = await targetBlock.boundingBox();
   if (!targetBox) throw new Error('target has no bounding box');
-  const clientX = targetBox.x + 4;
+  const xReferenceBox = position.xReference
+    ? await position.xReference.boundingBox()
+    : targetBox;
+  if (!xReferenceBox) throw new Error('X reference has no bounding box');
+  const clientX = xReferenceBox.x + (position.xOffset ?? 4);
   const clientY = targetBox.y + targetBox.height * 0.8;
   await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
   await flushIndicatorRaf(page);
@@ -428,13 +437,18 @@ test.describe('drop placement - indicator contract across target types', () => {
     // List item with [label paragraph, nested h2]. The slot model does not
     // make the nested heading an independent row, so its region belongs to the
     // parent list item: a drop there nests into the item (dashed) at the child
-    // slot next to the heading. startDragOver lands X at the heading's own
-    // indent, which is already past the nest threshold relative to the item.
+    // slot next to the heading. Keep Y inside the heading, but measure X from
+    // the parent item and land clearly past the 28px nesting threshold.
     await setContent(page, '<p>Top</p><ul><li><p>Label</p><h2>Nested</h2></li></ul>');
+    const nestedHeading = page.locator(`${editorSelector} h2:has-text("Nested")`);
     const { handle, dt } = await startDragOver(
       page,
       page.locator(`${editorSelector} p:has-text("Top")`),
-      page.locator(`${editorSelector} h2:has-text("Nested")`),
+      nestedHeading,
+      {
+        xReference: page.locator(`${editorSelector} li:has-text("Nested")`),
+        xOffset: 40,
+      },
     );
     const info = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');

--- a/apps/demo-react/src/NotionDemo.tsx
+++ b/apps/demo-react/src/NotionDemo.tsx
@@ -67,6 +67,7 @@ import katex from 'katex';
 import 'katex/dist/katex.min.css';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
 import {
+  bubbleOrderFixtureExtensions,
   parseBubbleIconsParam,
   resolveBubbleIcons,
   type BubbleIconsParam,
@@ -101,6 +102,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
 const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
+  ...bubbleOrderFixtureExtensions(),
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,

--- a/apps/demo-react/src/bubble-icons-fixtures.ts
+++ b/apps/demo-react/src/bubble-icons-fixtures.ts
@@ -9,7 +9,7 @@
  * readable.
  */
 
-import type { IconSet } from '@domternal/core';
+import { Extension, type AnyExtension, type IconSet, type ToolbarItem } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
@@ -79,4 +79,35 @@ export function parseBubbleItemsParam(): string[] | undefined {
   const value = params.get('bubble-items');
   if (!value) return undefined;
   return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function bubbleOrderItem(name: 'ai' | 'comment', label: string, icon: string): AnyExtension {
+  return Extension.create({
+    name: `bubbleOrderFixture${name}`,
+    addToolbarItems(): ToolbarItem[] {
+      return [{
+        type: 'button',
+        name,
+        command: 'focus',
+        icon,
+        label,
+        toolbar: false,
+        bubbleMenu: 'text',
+      }];
+    },
+  });
+}
+
+/** Test-only toolbar contributions used to resolve the Pro slots in the FREE default context. */
+export function bubbleOrderFixtureExtensions(): AnyExtension[] {
+  if (typeof window === 'undefined') return [];
+  const fixture = new URLSearchParams(window.location.search).get('bubble-order');
+  if (fixture === 'both') {
+    return [
+      bubbleOrderItem('ai', 'Ask AI', 'textB'),
+      bubbleOrderItem('comment', 'Comment', 'link'),
+    ];
+  }
+  if (fixture === 'comment') return [bubbleOrderItem('comment', 'Comment', 'link')];
+  return [];
 }

--- a/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-vanilla/e2e/notion-drop-placement-sibling.spec.ts
@@ -170,14 +170,23 @@ async function dragBlock(
  * Drag-over WITHOUT dropping. Used to assert indicator state mid-drag.
  * Caller is responsible for ending the drag with `dragend` to clean up.
  */
-async function startDragOver(page: Page, sourceBlock: Locator, targetBlock: Locator): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
+async function startDragOver(
+  page: Page,
+  sourceBlock: Locator,
+  targetBlock: Locator,
+  position: { xReference?: Locator; xOffset?: number } = {},
+): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
   await sourceBlock.hover();
   const dt = await page.evaluateHandle(() => new DataTransfer());
   const handle = page.locator(dragBtnSelector);
   await handle.dispatchEvent('dragstart', { dataTransfer: dt });
   const targetBox = await targetBlock.boundingBox();
   if (!targetBox) throw new Error('target has no bounding box');
-  const clientX = targetBox.x + 4;
+  const xReferenceBox = position.xReference
+    ? await position.xReference.boundingBox()
+    : targetBox;
+  if (!xReferenceBox) throw new Error('X reference has no bounding box');
+  const clientX = xReferenceBox.x + (position.xOffset ?? 4);
   const clientY = targetBox.y + targetBox.height * 0.8;
   await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
   await flushIndicatorRaf(page);
@@ -428,13 +437,18 @@ test.describe('drop placement - indicator contract across target types', () => {
     // List item with [label paragraph, nested h2]. The slot model does not
     // make the nested heading an independent row, so its region belongs to the
     // parent list item: a drop there nests into the item (dashed) at the child
-    // slot next to the heading. startDragOver lands X at the heading's own
-    // indent, which is already past the nest threshold relative to the item.
+    // slot next to the heading. Keep Y inside the heading, but measure X from
+    // the parent item and land clearly past the 28px nesting threshold.
     await setContent(page, '<p>Top</p><ul><li><p>Label</p><h2>Nested</h2></li></ul>');
+    const nestedHeading = page.locator(`${editorSelector} h2:has-text("Nested")`);
     const { handle, dt } = await startDragOver(
       page,
       page.locator(`${editorSelector} p:has-text("Top")`),
-      page.locator(`${editorSelector} h2:has-text("Nested")`),
+      nestedHeading,
+      {
+        xReference: page.locator(`${editorSelector} li:has-text("Nested")`),
+        xOffset: 40,
+      },
     );
     const info = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');

--- a/apps/demo-vanilla/src/NotionDemo.ts
+++ b/apps/demo-vanilla/src/NotionDemo.ts
@@ -63,6 +63,7 @@ import katex from 'katex';
 import 'katex/dist/katex.min.css';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
 import {
+  bubbleOrderFixtureExtensions,
   parseBubbleIconsParam,
   resolveBubbleIcons,
   type BubbleIconsParam,
@@ -96,6 +97,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
 const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
+  ...bubbleOrderFixtureExtensions(),
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,

--- a/apps/demo-vanilla/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vanilla/src/bubble-icons-fixtures.ts
@@ -9,7 +9,7 @@
  * readable.
  */
 
-import type { IconSet } from '@domternal/core';
+import { Extension, type AnyExtension, type IconSet, type ToolbarItem } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
@@ -79,4 +79,35 @@ export function parseBubbleItemsParam(): string[] | undefined {
   const value = params.get('bubble-items');
   if (!value) return undefined;
   return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function bubbleOrderItem(name: 'ai' | 'comment', label: string, icon: string): AnyExtension {
+  return Extension.create({
+    name: `bubbleOrderFixture${name}`,
+    addToolbarItems(): ToolbarItem[] {
+      return [{
+        type: 'button',
+        name,
+        command: 'focus',
+        icon,
+        label,
+        toolbar: false,
+        bubbleMenu: 'text',
+      }];
+    },
+  });
+}
+
+/** Test-only toolbar contributions used to resolve the Pro slots in the FREE default context. */
+export function bubbleOrderFixtureExtensions(): AnyExtension[] {
+  if (typeof window === 'undefined') return [];
+  const fixture = new URLSearchParams(window.location.search).get('bubble-order');
+  if (fixture === 'both') {
+    return [
+      bubbleOrderItem('ai', 'Ask AI', 'textB'),
+      bubbleOrderItem('comment', 'Comment', 'link'),
+    ];
+  }
+  if (fixture === 'comment') return [bubbleOrderItem('comment', 'Comment', 'link')];
+  return [];
 }

--- a/apps/demo-vue/e2e/notion-drop-placement-sibling.spec.ts
+++ b/apps/demo-vue/e2e/notion-drop-placement-sibling.spec.ts
@@ -170,14 +170,23 @@ async function dragBlock(
  * Drag-over WITHOUT dropping. Used to assert indicator state mid-drag.
  * Caller is responsible for ending the drag with `dragend` to clean up.
  */
-async function startDragOver(page: Page, sourceBlock: Locator, targetBlock: Locator): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
+async function startDragOver(
+  page: Page,
+  sourceBlock: Locator,
+  targetBlock: Locator,
+  position: { xReference?: Locator; xOffset?: number } = {},
+): Promise<{ handle: Locator; dt: JSHandle<DataTransfer> }> {
   await sourceBlock.hover();
   const dt = await page.evaluateHandle(() => new DataTransfer());
   const handle = page.locator(dragBtnSelector);
   await handle.dispatchEvent('dragstart', { dataTransfer: dt });
   const targetBox = await targetBlock.boundingBox();
   if (!targetBox) throw new Error('target has no bounding box');
-  const clientX = targetBox.x + 4;
+  const xReferenceBox = position.xReference
+    ? await position.xReference.boundingBox()
+    : targetBox;
+  if (!xReferenceBox) throw new Error('X reference has no bounding box');
+  const clientX = xReferenceBox.x + (position.xOffset ?? 4);
   const clientY = targetBox.y + targetBox.height * 0.8;
   await page.locator(editorSelector).dispatchEvent('dragover', { dataTransfer: dt, clientX, clientY });
   await flushIndicatorRaf(page);
@@ -428,13 +437,18 @@ test.describe('drop placement - indicator contract across target types', () => {
     // List item with [label paragraph, nested h2]. The slot model does not
     // make the nested heading an independent row, so its region belongs to the
     // parent list item: a drop there nests into the item (dashed) at the child
-    // slot next to the heading. startDragOver lands X at the heading's own
-    // indent, which is already past the nest threshold relative to the item.
+    // slot next to the heading. Keep Y inside the heading, but measure X from
+    // the parent item and land clearly past the 28px nesting threshold.
     await setContent(page, '<p>Top</p><ul><li><p>Label</p><h2>Nested</h2></li></ul>');
+    const nestedHeading = page.locator(`${editorSelector} h2:has-text("Nested")`);
     const { handle, dt } = await startDragOver(
       page,
       page.locator(`${editorSelector} p:has-text("Top")`),
-      page.locator(`${editorSelector} h2:has-text("Nested")`),
+      nestedHeading,
+      {
+        xReference: page.locator(`${editorSelector} li:has-text("Nested")`),
+        xOffset: 40,
+      },
     );
     const info = await page.evaluate(() => {
       const el = document.querySelector('.dm-block-drop-indicator');

--- a/apps/demo-vue/src/NotionDemo.vue
+++ b/apps/demo-vue/src/NotionDemo.vue
@@ -67,6 +67,7 @@ import katex from 'katex';
 import 'katex/dist/katex.min.css';
 import { NOTION_DEMO_CONTENT } from './notion-demo-content.js';
 import {
+  bubbleOrderFixtureExtensions,
   parseBubbleIconsParam,
   resolveBubbleIcons,
   type BubbleIconsParam,
@@ -101,6 +102,7 @@ const PARAGRAPH_EXCLUSION_PARENTS = new Set([
 const TOAST_MS = { success: 1800, error: 2600 } as const;
 
 const buildExtensions = (scrollParent: Element | null): AnyExtension[] => [
+  ...bubbleOrderFixtureExtensions(),
   Italic, Bold, Underline, Strike, Code, Highlight, Subscript, Superscript, Link,
   Heading, Blockquote, CodeBlockLowlight.configure({ lowlight }), HardBreak, HorizontalRule,
   BulletList, OrderedList, TaskList,

--- a/apps/demo-vue/src/bubble-icons-fixtures.ts
+++ b/apps/demo-vue/src/bubble-icons-fixtures.ts
@@ -9,7 +9,7 @@
  * readable.
  */
 
-import type { IconSet } from '@domternal/core';
+import { Extension, type AnyExtension, type IconSet, type ToolbarItem } from '@domternal/core';
 
 export type BubbleIconsParam = 'default' | 'full' | 'partial' | 'empty' | 'malformed' | 'html';
 
@@ -79,4 +79,35 @@ export function parseBubbleItemsParam(): string[] | undefined {
   const value = params.get('bubble-items');
   if (!value) return undefined;
   return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function bubbleOrderItem(name: 'ai' | 'comment', label: string, icon: string): AnyExtension {
+  return Extension.create({
+    name: `bubbleOrderFixture${name}`,
+    addToolbarItems(): ToolbarItem[] {
+      return [{
+        type: 'button',
+        name,
+        command: 'focus',
+        icon,
+        label,
+        toolbar: false,
+        bubbleMenu: 'text',
+      }];
+    },
+  });
+}
+
+/** Test-only toolbar contributions used to resolve the Pro slots in the FREE default context. */
+export function bubbleOrderFixtureExtensions(): AnyExtension[] {
+  if (typeof window === 'undefined') return [];
+  const fixture = new URLSearchParams(window.location.search).get('bubble-order');
+  if (fixture === 'both') {
+    return [
+      bubbleOrderItem('ai', 'Ask AI', 'textB'),
+      bubbleOrderItem('comment', 'Comment', 'link'),
+    ];
+  }
+  if (fixture === 'comment') return [bubbleOrderItem('comment', 'Comment', 'link')];
+  return [];
 }

--- a/e2e/bubble-menu-items.spec.ts
+++ b/e2e/bubble-menu-items.spec.ts
@@ -3,11 +3,11 @@
  * frameworks.
  *
  * Two things are pinned here that nothing else can pin. The Notion selection
- * menu's order is a product decision (Notion's own: act on the selection,
- * change what the block is, attach something, then style it) and it is worth
- * one loud failure if it drifts. And the separator cleanup only shows itself
- * in rendered DOM: the resolver's unit tests prove the list, but the bar with
- * nothing on one side of it is a thing you see, and it was the visible defect.
+ * menu's order is a product decision: act on the selection, change what the
+ * block is, attach something, then style it. It is worth one loud failure if
+ * it drifts. The separator cleanup only shows itself in rendered DOM: the
+ * resolver's unit tests prove the list, but the bar with nothing on one side
+ * of it is a thing you see, and it was the visible defect.
  *
  * The four wrappers share one resolver in `@domternal/core` now. That is
  * exactly why these run per framework: the shared implementation is worth
@@ -80,13 +80,14 @@ async function selectInParagraph(page: Page, target: DemoTarget, text = 'selecti
 // ---------------------------------------------------------------------------
 
 for (const target of demoTargets) {
-  test(`${target.name}: the Notion selection menu is in Notion's order`, async ({ page }) => {
+  test(`${target.name}: the Notion selection menu keeps the product group order`, async ({ page }) => {
     await goNotion(page, target);
     await selectInParagraph(page, target);
 
     /* The whole menu, once, so a reordering fails here and nowhere else.
-       `ai` and `comment` are Pro items and resolve to nothing in a free demo;
-       the alignment dropdown at the end is the demo's own addition on top of
+       `ai` and `comment` form the leading action group, and both resolve to
+       nothing in a free demo. Their separator collapses, so Turn into leads.
+       The alignment dropdown at the end is the demo's own addition on top of
        the default, and the two trailing triggers are the menu's. */
     expect(await menuTokens(page)).toEqual([
       '▾heading',

--- a/e2e/bubble-menu-order.spec.ts
+++ b/e2e/bubble-menu-order.spec.ts
@@ -54,7 +54,7 @@ async function visibleMenuTokens(page: Page): Promise<string[]> {
       .filter((element) => element.getClientRects().length > 0)
       .map((element) => {
         if (element.getAttribute('role') === 'separator') return '|';
-        return element.getAttribute('aria-label') ?? element.textContent?.trim() ?? '';
+        return element.getAttribute('aria-label') ?? element.textContent.trim();
       })
       .filter(Boolean),
   );

--- a/e2e/bubble-menu-order.spec.ts
+++ b/e2e/bubble-menu-order.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test';
+import { demoTargets, type DemoTarget } from './targets.js';
+
+const NOTION_WITH_AI = [
+  'Ask AI',
+  'Comment',
+  '|',
+  'Heading',
+  '|',
+  'Link',
+  '|',
+  'Bold',
+  'Italic',
+  'Underline',
+  'Strikethrough',
+  'Code',
+  'Inline equation',
+  '|',
+  'Text Alignment',
+  '|',
+  'Text and background color',
+  '|',
+  'More options',
+];
+
+const NOTION_WITHOUT_AI = NOTION_WITH_AI.slice(1);
+
+async function selectText(page: Page, editorSelector: string): Promise<void> {
+  await page.locator(editorSelector).click();
+  const selected = await page.evaluate((selector) => {
+    const editor = document.querySelector<HTMLElement>(selector);
+    if (!editor) return false;
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+    let text = walker.nextNode();
+    while (text && (text.textContent?.trim().length ?? 0) < 4) text = walker.nextNode();
+    if (!text?.textContent) return false;
+    const range = document.createRange();
+    range.setStart(text, 1);
+    range.setEnd(text, Math.min(text.textContent.length, 7));
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.dispatchEvent(new Event('selectionchange'));
+    return true;
+  }, editorSelector);
+  expect(selected).toBe(true);
+}
+
+async function visibleMenuTokens(page: Page): Promise<string[]> {
+  const menu = page.locator('.dm-bubble-menu:visible').first();
+  await expect(menu).toBeVisible();
+  return menu.locator('button, [role="separator"]').evaluateAll((elements) =>
+    elements
+      .filter((element) => element.getClientRects().length > 0)
+      .map((element) => {
+        if (element.getAttribute('role') === 'separator') return '|';
+        return element.getAttribute('aria-label') ?? element.textContent?.trim() ?? '';
+      })
+      .filter(Boolean),
+  );
+}
+
+async function openNotionFixture(page: Page, target: DemoTarget, fixture: 'both' | 'comment'): Promise<void> {
+  await page.goto(`${target.baseURL}/?bubble-order=${fixture}`);
+  await page.locator(target.notionToggle).click();
+  await expect(page.locator(target.editorSelector)).toBeVisible();
+  await selectText(page, target.editorSelector);
+}
+
+for (const target of demoTargets) {
+  test(`${target.name}: Notion resolves AI before Comment with exact grouped order`, async ({ page }) => {
+    await openNotionFixture(page, target, 'both');
+    expect(await visibleMenuTokens(page)).toEqual(NOTION_WITH_AI);
+  });
+
+  test(`${target.name}: Notion starts with Comment and removes the orphaned AI separator`, async ({ page }) => {
+    await openNotionFixture(page, target, 'comment');
+    expect(await visibleMenuTokens(page)).toEqual(NOTION_WITHOUT_AI);
+  });
+
+  test(`${target.name}: the Notion-only fixture cannot change the Classic bubble`, async ({ page }) => {
+    await page.goto(`${target.baseURL}/`);
+    await expect(page.locator('.ProseMirror')).toBeVisible();
+    await selectText(page, '.ProseMirror');
+    const baseline = await visibleMenuTokens(page);
+
+    await page.goto(`${target.baseURL}/?bubble-order=both`);
+    await expect(page.locator('.ProseMirror')).toBeVisible();
+    await selectText(page, '.ProseMirror');
+    const withFixtureQuery = await visibleMenuTokens(page);
+
+    expect(withFixtureQuery).toEqual(baseline);
+    expect(withFixtureQuery).not.toContain('Ask AI');
+    expect(withFixtureQuery).not.toContain('Comment');
+  });
+}

--- a/e2e/playwright.cross-browser.config.ts
+++ b/e2e/playwright.cross-browser.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config.js';
+
+const browserNames = ['chromium', 'firefox', 'webkit'] as const;
+
+export default defineConfig(baseConfig, {
+  projects: browserNames.map((browserName) => ({
+    name: browserName,
+    use: { browserName },
+  })),
+});

--- a/packages/core/src/utils/defaultBubbleContexts.test.ts
+++ b/packages/core/src/utils/defaultBubbleContexts.test.ts
@@ -31,16 +31,16 @@ describe('defaultBubbleContexts', () => {
     ]);
   });
 
-  it('orders the Notion-mode selection menu the way Notion does', () => {
+  it('orders Notion-mode selection actions before structure, attachment and styling', () => {
     editor = makeEditor();
     editor.view.dom.classList.add('dm-notion-mode');
     expect(defaultBubbleContexts(editor)['text']).toEqual([
       'ai',
+      'comment',
       '|',
       'heading',
       '|',
       'link',
-      'comment',
       '|',
       'bold',
       'italic',

--- a/packages/core/src/utils/defaultBubbleContexts.ts
+++ b/packages/core/src/utils/defaultBubbleContexts.ts
@@ -1,13 +1,12 @@
 import type { Editor } from '../Editor.js';
 
 /**
- * The Notion selection menu, in Notion's own order.
- *
- * Notion reads left to right as: do something with this selection, change what
- * this block is, attach something to it, then style it. The formatting marks
- * come LAST of the four, which is the part that looks wrong until you notice
- * that Ask AI, Turn into, Link and Comment each change what the text is, while
- * bold and italic only change how it looks.
+ * The Notion preset selection menu follows four intent groups: act on this
+ * selection (Ask AI about it, comment on it), change what it is (Turn into),
+ * attach something (Link), then style it. Comment is frequent enough in
+ * collaborative editing to earn the leading group beside Ask AI. This is a
+ * deliberate deviation from Notion's own menu, which keeps Link and Comment
+ * together after Turn into.
  *
  * Four names here are not in this package and are meant to be absent most of
  * the time. `ai` and `comment` come from the Pro extensions, `mathInline` from
@@ -27,9 +26,9 @@ import type { Editor } from '../Editor.js';
  * items; each menu appends them itself, gated on the extension that owns them.
  */
 const NOTION_TEXT_CONTEXT: readonly string[] = Object.freeze([
-  'ai',
+  'ai', 'comment',
   '|', 'heading',
-  '|', 'link', 'comment',
+  '|', 'link',
   '|', 'bold', 'italic', 'underline', 'strike', 'code', 'mathInline',
 ]);
 
@@ -43,8 +42,8 @@ const STANDARD_TEXT_CONTEXT: readonly string[] = Object.freeze([
  * supplied one. Returns a richer item set when the editor resolves to the
  * Notion preset (the `preset` option, or the `.dm-notion-mode` class the
  * getter also honors), so the bubble menu mirrors the Notion UX by leading
- * with `ai`, offering the block-type dropdown, and grouping `link` and
- * `comment` ahead of the formatting marks.
+ * with the `ai` and `comment` selection actions, then offering the block-type
+ * dropdown and `link` ahead of the formatting marks.
  *
  * Consumers can always override by passing their own `contexts` prop.
  */


### PR DESCRIPTION
# Summary

The Notion preset's selection menu now leads with both act-on-selection items, Ask AI and Comment, instead of leaving Comment beside Link. The demos gain a query-param fixture that stands in for those two Pro slots so the resolved order can be asserted end to end, and one nested drop-placement spec stops sitting on the nesting threshold.

# Features

- `defaultBubbleContexts` places `comment` next to `ai` in the Notion text context, so the menu reads as four intent groups: act on this selection, change what it is (Turn into), attach something (Link), then style it. This is a deliberate deviation from Notion's own menu, which keeps Link and Comment together after Turn into. Comment is frequent enough in collaborative editing to earn the leading group. Consumers who pass their own `contexts` are unaffected.
- `bubbleOrderFixtureExtensions()` in each demo's `bubble-icons-fixtures.ts` registers test-only `ai` and `comment` toolbar buttons behind `?bubble-order=both` or `?bubble-order=comment`. Both items belong to Pro extensions and resolve to nothing in a free build, so without a stand-in nothing in this repo can prove the order the resolver actually produces once they exist.

# Fix

- The nested drop-placement spec landed X at the nested heading's own indent, which sits right on the 28px nesting threshold relative to the parent list item, leaving the assertion dependent on sub-pixel layout. It now measures X from the parent `li` at a 40px offset while keeping Y inside the heading. Applied to all four per-app copies.

# Changes

- `e2e/bubble-menu-order.spec.ts` runs on all four demos and pins the exact visible token order three ways: with both fixture items present, with only Comment (proving the orphaned AI separator collapses rather than leaving a bar with nothing on one side), and against the Classic bubble menu, which the Notion-only fixture must not touch.
- `e2e/bubble-menu-items.spec.ts` and the `defaultBubbleContexts` unit test drop the "Notion's own order" framing. The order is this project's product decision now, and a test name claiming otherwise would mislead the next person to change it.
- `e2e/playwright.cross-browser.config.ts` extends the matrix config with chromium, firefox and webkit projects. Nothing wires it into a script: run it with `pnpm exec playwright test --config e2e/playwright.cross-browser.config.ts`.

# Verified

- `pnpm test:e2e:matrix`: 908 passed, 0 failed (chromium, all four demos), including the new order spec and the reworded item spec.
- `pnpm test:api-surface`: 28 entries match the committed snapshots. Only the contents of the Notion text context moved, so no public export changed.
- [pending] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and the four per-app suites that carry the drop-placement change.