### PR TITLE
docs: the development floor is Node 22, matching the packages' engines fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pnpm lint       # Run linter
 pnpm typecheck  # Type check
 ```
 
-Requires Node.js >= 20 and pnpm >= 10.
+Requires Node.js >= 22 and pnpm >= 10.
 
 ## License
 


### PR DESCRIPTION
**Summary**
The development section of the root README still said Node.js >= 20, while every package's `engines` field requires >= 22. One line brings the README in line with what the tooling already enforces.

**Changes**
- `README.md`: the development requirement now reads Node.js >= 22.

**Verified**
Docs-only change; confirmed all 18 packages declare `engines: { "node": ">=22" }`. The root README does not ship in any npm tarball, so no changelog entry.