### PR TITLE
fix(core): let a dismissed bubble menu return on re-selection, and count a pending show as shown

### DIFF
--- a/packages/core/src/extensions/BubbleMenu.test.ts
+++ b/packages/core/src/extensions/BubbleMenu.test.ts
@@ -976,6 +976,56 @@ describe('BubbleMenu', () => {
       expect(editor).toBeDefined();
     });
 
+    it('a dismissal survives an edit that leaves the selection alone', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+      editor = new Editor({
+        element: host,
+        extensions: [Document, Text, Paragraph, BubbleMenu.configure({ element, shouldShow: () => true })],
+        content: '<p>Hello world</p>',
+      });
+
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),
+      );
+      expect(element.hasAttribute('data-show')).toBe(true);
+
+      const editorEl = editor.view.dom.closest('.dm-editor');
+      editorEl?.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: true }));
+      expect(element.hasAttribute('data-show')).toBe(false);
+
+      // An edit past the selection (a remote collaboration change, say) shifts
+      // nothing the menu belonged to, so it must not pop back over text the
+      // user has left alone.
+      const end = editor.state.doc.content.size - 1;
+      editor.view.dispatch(editor.state.tr.insertText('!', end, end));
+      expect(element.hasAttribute('data-show')).toBe(false);
+    });
+
+    it('re-selecting the same range after a dismissal asks the menu back', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+      editor = new Editor({
+        element: host,
+        extensions: [Document, Text, Paragraph, BubbleMenu.configure({ element, shouldShow: () => true })],
+        content: '<p>Hello world</p>',
+      });
+
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),
+      );
+      const editorEl = editor.view.dom.closest('.dm-editor');
+      editorEl?.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: true }));
+      expect(element.hasAttribute('data-show')).toBe(false);
+
+      // The SAME range, selected again: without this the menu stayed locked
+      // for that text until some other text was selected.
+      editor.view.dispatch(
+        editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),
+      );
+      expect(element.hasAttribute('data-show')).toBe(true);
+    });
+
     it('updateDelay > 0 schedules setTimeout then cleared on destroy', () => {
       const element = document.createElement('div');
       editor = new Editor({

--- a/packages/core/src/extensions/BubbleMenu.test.ts
+++ b/packages/core/src/extensions/BubbleMenu.test.ts
@@ -994,9 +994,7 @@ describe('BubbleMenu', () => {
       editorEl?.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: true }));
       expect(element.hasAttribute('data-show')).toBe(false);
 
-      // An edit past the selection (a remote collaboration change, say) shifts
-      // nothing the menu belonged to, so it must not pop back over text the
-      // user has left alone.
+      // An edit past the selection must not pop the menu back.
       const end = editor.state.doc.content.size - 1;
       editor.view.dispatch(editor.state.tr.insertText('!', end, end));
       expect(element.hasAttribute('data-show')).toBe(false);
@@ -1018,8 +1016,7 @@ describe('BubbleMenu', () => {
       editorEl?.dispatchEvent(new Event('dm:dismiss-overlays', { bubbles: true }));
       expect(element.hasAttribute('data-show')).toBe(false);
 
-      // The SAME range, selected again: without this the menu stayed locked
-      // for that text until some other text was selected.
+      // The same range again: this stayed locked until other text was selected.
       editor.view.dispatch(
         editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),
       );

--- a/packages/core/src/extensions/BubbleMenu.test.ts
+++ b/packages/core/src/extensions/BubbleMenu.test.ts
@@ -985,6 +985,9 @@ describe('BubbleMenu', () => {
         content: '<p>Hello world</p>',
       });
 
+      // Mock coordsAtPos for jsdom (no real layout)
+      editor.view.coordsAtPos = () => ({ left: 10, right: 50, top: 10, bottom: 30 });
+
       editor.view.dispatch(
         editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),
       );
@@ -1008,6 +1011,9 @@ describe('BubbleMenu', () => {
         extensions: [Document, Text, Paragraph, BubbleMenu.configure({ element, shouldShow: () => true })],
         content: '<p>Hello world</p>',
       });
+
+      // Mock coordsAtPos for jsdom (no real layout)
+      editor.view.coordsAtPos = () => ({ left: 10, right: 50, top: 10, bottom: 30 });
 
       editor.view.dispatch(
         editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 6)),

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -163,7 +163,7 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
   };
 
   // When the user clicks outside the bubble menu and outside the editor
-  // (e.g. on the toolbar), suppress the menu until the selection changes.
+  // (e.g. on the toolbar), suppress the menu until the selection is set again.
   let suppressed = false;
 
   // Suppress bubble menu during active mouse drag inside the editor.
@@ -211,12 +211,24 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
         from: 0,
         to: 0,
       }),
-      apply: (_tr, prevValue, _oldState, newState): BubbleMenuPluginState => {
+      apply: (tr, prevValue, _oldState, newState): BubbleMenuPluginState => {
         const { selection } = newState;
         const { from, to } = selection;
 
-        // Reset suppression when the selection range changes
-        if (from !== prevValue.from || to !== prevValue.to) {
+        // Reset suppression when the selection range changes, and also when a
+        // transaction sets the selection to the SAME range: re-selecting the
+        // words a dismissed menu belonged to is the user asking for it back.
+        // Without that second case a suppressing dismissal (an outside click,
+        // or the `dm:dismiss-overlays` a docked panel or a comment composer
+        // broadcasts) outlives the thing that caused it, and the menu stays
+        // locked for that text until some OTHER text is selected.
+        //
+        // `selectionSet` is the narrow signal on purpose: typing, a remote
+        // collaboration edit and a plain `focus()` all leave it false, so none
+        // of them can pop the menu back over a selection the user has left
+        // alone. Only an explicit setSelection, which is what the DOM observer
+        // dispatches for a click or a drag, counts as that gesture.
+        if (tr.selectionSet || from !== prevValue.from || to !== prevValue.to) {
           suppressed = false;
         }
 
@@ -354,12 +366,16 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
             state?.visible === prevPluginState?.visible &&
             state?.from === prevPluginState?.from &&
             state?.to === prevPluginState?.to &&
-            !(state?.visible && view.state.doc !== prevState.doc)
+            !(state?.visible && view.state.doc !== prevState.doc) &&
+            // The DOM must already agree with the state. Every dismissal here
+            // hides the element without a transaction, so the two can fall out
+            // of step in BOTH directions, and an unchanged plugin state is then
+            // no reason to leave the DOM as it is. The hide direction always
+            // had its safety net; the show direction had none, so a menu
+            // dismissed over a selection could not come back while that exact
+            // selection stood, however the user asked for it.
+            element.hasAttribute('data-show') === Boolean(state?.visible)
           ) {
-            // Safety: ensure DOM matches state (onFocus setTimeout can race)
-            if (!state?.visible && element.hasAttribute('data-show')) {
-              hideMenu();
-            }
             return;
           }
 

--- a/packages/core/src/extensions/BubbleMenu.ts
+++ b/packages/core/src/extensions/BubbleMenu.ts
@@ -215,19 +215,9 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
         const { selection } = newState;
         const { from, to } = selection;
 
-        // Reset suppression when the selection range changes, and also when a
-        // transaction sets the selection to the SAME range: re-selecting the
-        // words a dismissed menu belonged to is the user asking for it back.
-        // Without that second case a suppressing dismissal (an outside click,
-        // or the `dm:dismiss-overlays` a docked panel or a comment composer
-        // broadcasts) outlives the thing that caused it, and the menu stays
-        // locked for that text until some OTHER text is selected.
-        //
-        // `selectionSet` is the narrow signal on purpose: typing, a remote
-        // collaboration edit and a plain `focus()` all leave it false, so none
-        // of them can pop the menu back over a selection the user has left
-        // alone. Only an explicit setSelection, which is what the DOM observer
-        // dispatches for a click or a drag, counts as that gesture.
+        // Re-selecting the same range asks a dismissed menu back. Typing, a
+        // remote edit and a plain focus() leave `selectionSet` false, so none
+        // of them can pop it back over a selection the user has left alone.
         if (tr.selectionSet || from !== prevValue.from || to !== prevValue.to) {
           suppressed = false;
         }
@@ -362,19 +352,16 @@ export function createBubbleMenuPlugin(options: CreateBubbleMenuPluginOptions): 
           // Skip if nothing changed - but reposition when the doc changed
           // while the menu is visible (e.g. image float attribute changed,
           // the DOM element moved but the selection stayed at the same pos)
+          // A dismissal hides the element without a transaction, so an unchanged
+          // state is no reason to leave the DOM as it is. A pending show counts
+          // as shown, or no-op transactions would keep re-arming its timer.
+          const domShown = element.hasAttribute('data-show') || updateTimeout !== null;
           if (
             state?.visible === prevPluginState?.visible &&
             state?.from === prevPluginState?.from &&
             state?.to === prevPluginState?.to &&
             !(state?.visible && view.state.doc !== prevState.doc) &&
-            // The DOM must already agree with the state. Every dismissal here
-            // hides the element without a transaction, so the two can fall out
-            // of step in BOTH directions, and an unchanged plugin state is then
-            // no reason to leave the DOM as it is. The hide direction always
-            // had its safety net; the show direction had none, so a menu
-            // dismissed over a selection could not come back while that exact
-            // selection stood, however the user asked for it.
-            element.hasAttribute('data-show') === Boolean(state?.visible)
+            domShown === Boolean(state?.visible)
           ) {
             return;
           }

--- a/packages/core/src/utils/inlineStyles.ts
+++ b/packages/core/src/utils/inlineStyles.ts
@@ -4,8 +4,8 @@
  * Applies inline CSS styles to serialized HTML so it renders correctly
  * when pasted outside the editor (email clients, CMS, Google Docs, etc.).
  *
- * Uses hardcoded light-theme defaults (same approach as Google Docs, Notion,
- * TinyMCE). Optionally accepts overrides for custom styling.
+ * Uses hardcoded light-theme defaults (same approach as Google Docs or
+ * Notion). Optionally accepts overrides for custom styling.
  *
  * Only structural styles are inlined (borders, padding, margins, fonts).
  * Colors are NOT inlined - explicit colors (TextColor, Highlight, cell bg)

--- a/tests/pm-ranges/check.mjs
+++ b/tests/pm-ranges/check.mjs
@@ -4,11 +4,11 @@
  * no longer agree on one copy.
  *
  * This is the root cause, checked at its source. `@domternal/pm` declares the
- * `prosemirror-*` packages as ordinary dependencies, the way `@tiptap/pm` does
- * and for the same reason: a consumer installs one package instead of twelve,
- * and neither version of Yarn installs peer dependencies automatically, so
- * declaring them that way would turn a rare duplicate into a broken install for
- * every Yarn user. The guide records that decision in full.
+ * `prosemirror-*` packages as ordinary dependencies rather than peers, and
+ * deliberately so: a consumer installs one package instead of twelve, and
+ * neither version of Yarn installs peer dependencies automatically, so
+ * declaring them as peers would turn a rare duplicate into a broken install
+ * for every Yarn user. The guide records that decision in full.
  *
  * The price of that choice is this: the copy `@domternal/pm` brings and the
  * copy another library asks for are unified by the package manager only while


### PR DESCRIPTION
**Summary**
Two bubble menu suppression fixes: a menu dismissed by a click outside the editor now comes back when the user explicitly selects the same range again, and the update guard keeps the DOM in step with a dismissal.
**Fix**
- Suppression now releases on `tr.selectionSet` as well as on a range change: re-selecting the same text asks the menu back, which used to stay locked until some other text was selected. Typing, a remote edit and a plain `focus()` leave `selectionSet` false, so none of them can pop the menu back over a selection the user has left alone.
- The skip guard now also compares the DOM's shown state (the `data-show` attribute, or a pending show timer) against the plugin state, replacing the old one-way hide safety: a dismissal hides the element without a transaction, so an unchanged state was no reason to leave the DOM as it was, and a pending show counts as shown so no-op transactions cannot keep re-arming its timer.

**Verified**
`BubbleMenu.test.ts` passes clean (53 tests, two new suppression-release cases) with `coordsAtPos` mocked in the new tests the way the suite already does elsewhere, so the run carries no jsdom unhandled rejections.