### PR TITLE
chore: bound package compatibility ranges and align public release documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Domternal version
       description: The version of the @domternal packages you are using.
-      placeholder: '0.11.2'
+      placeholder: 'For example: 1.x.y'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/pro_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/pro_bug_report.yml
@@ -53,7 +53,7 @@ body:
     attributes:
       label: Versions
       description: The versions of the @domternal-pro and @domternal packages you are using.
-      placeholder: '@domternal-pro/extension-comments 0.1.0, @domternal/core 0.14.0'
+      placeholder: '@domternal-pro/extension-comments 1.x.y, @domternal/core 1.x.y'
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Package manifest policy
         # Releases are hand-edited across eighteen manifests. A version bumped
-        # without its `>=MAJOR.MINOR.0` floors publishes a package a consumer
+        # without its `>=MAJOR.MINOR.0 <NEXT_MAJOR.0.0` ranges publishes a package a consumer
         # may legally install beside the previous minor, which is the mixed-copy
         # install the single-copy gates exist to prevent.
         run: pnpm test:package-policy

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ The example above wires the minimum schema by hand to show the headless model; i
 
 See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of what each package includes and how tree-shaking works.
 
+## Domternal Pro
+
+[Domternal Pro](https://domternal.dev/pro) adds the collaborative layer on top of these MIT packages, published as `@domternal-pro/*` on the public npm registry under a commercial license: real-time [collaboration](https://domternal.dev/v1/pro/collaboration) with live carets and presence, [comments](https://domternal.dev/v1/pro/comments), [version history](https://domternal.dev/v1/pro/version-history), an [AI assistant](https://domternal.dev/v1/pro/ai), [columns](https://domternal.dev/v1/pro/columns), [Word and PDF export](https://domternal.dev/v1/pro/export), and a [self-hosted collaboration server](https://domternal.dev/v1/pro/self-hosting).
+
+- [Installation and licensing](https://domternal.dev/v1/pro/licensing) - install from npm, evaluate without a key, activate with a Commercial Key
+- [Pricing](https://domternal.dev/pricing) - plans and what each one includes
+- [Support and reporting issues](https://domternal.dev/v1/pro/support) - Pro defects are tracked in this repository through the [Pro bug report](https://github.com/domternal/domternal/issues/new?template=pro_bug_report.yml) template
+
 ## Documentation
 
 Full documentation, live playgrounds, and API reference at **[domternal.dev](https://domternal.dev)**.

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Requires Node.js >= 22 and pnpm >= 10.
 
 ## License
 
-[MIT](LICENSE)
+The source code is available under the [MIT License](LICENSE). Use of the Domternal name and logo is governed by the [Trademark Usage Policy](TRADEMARKS.md).

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ A rich text editor toolkit built on [ProseMirror](https://prosemirror.net/), wit
 - **130+ chainable commands** - `editor.chain().focus().toggleBold().run()`
 - **Full table support** - cell merging, column resize, row/column controls, cell toolbar
 - **Tree-shakeable** - import only what you use, your bundler strips the rest
-- **~48 KB gzipped** (own code), [~129 KB total](https://domternal.dev/v1/packages) with ProseMirror - see Packages for full bundle breakdown
+- **~51 KiB minified and gzipped** (own code), [**~132 KiB minified and gzipped total**](https://domternal.dev/v1/packages) with runtime dependencies - see Packages for the full bundle breakdown
 - **TypeScript first** - every package builds under `strict`, with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
-- **17,800+ tests** - 4,700+ unit and 13,100+ E2E across 309 Playwright spec files and 4 demo apps
+- **17,800+ tests** - 4,700+ unit and 13,100+ E2E across the Playwright matrix and 4 demo apps
 - **Light and dark theme** - 160 CSS custom properties for full visual control
 - **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
 - **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
@@ -77,7 +77,7 @@ The example above wires the minimum schema by hand to show the headless model; i
 | [`@domternal/extension-details`](https://www.npmjs.com/package/@domternal/extension-details) | Collapsible details/accordion blocks |
 | [`@domternal/extension-code-block-lowlight`](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
 
-`@domternal/extension-block-menu`, the deprecated shim left from the v0.10.0 rename, shipped through the 0.x line only and is not published for 1.x. Import `@domternal/extension-block-controls` directly.
+`@domternal/extension-block-menu`, the deprecated shim left from the v0.10.0 rename, ended with the 0.x line. Briefly published 1.0.x builds were withdrawn from the registry; import `@domternal/extension-block-controls` directly.
 
 See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of what each package includes and how tree-shaking works.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,10 @@
 Only the latest released version of the `@domternal/*` packages receives
 security fixes.
 
+The commercial `@domternal-pro/*` packages have their own security support
+period and response targets, published under
+[Security on the Pro support page](https://domternal.dev/v1/pro/support#security).
+
 ## Reporting a Vulnerability
 
 Please do not report security vulnerabilities through public GitHub issues.
@@ -16,6 +20,11 @@ directly, or go to the repository's Security tab and click
 the maintainer can see.
 
 Alternatively, email [security@domternal.dev](mailto:security@domternal.dev).
+
+Vulnerabilities in the `@domternal-pro/*` packages go to that same email
+address; their source repository is private, so the advisory form above does
+not cover them. The self-hosted collaboration server has its own
+[security policy](https://github.com/domternal/self-hosting/blob/main/SECURITY.md).
 
 Please include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ Please include:
 - Steps to reproduce, ideally with a minimal example
 - The affected package(s) and version(s)
 
-You will get an initial response within a few days. Please allow time for a fix
+We aim to acknowledge security reports within a few business days. Please allow time for a fix
 to be released before any public disclosure.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,17 @@
+# Domternal Trademark Usage Policy
+
+The MIT License covers the Domternal source code. It does not grant rights to the Domternal name, logo, or other trademarks.
+
+Anyone lawfully using Domternal may make truthful, non-misleading references to it to describe compatibility, integration, or use. For those same descriptive purposes, they may also display the [current official Domternal logo](https://domternal.dev/domternal_logo.png) without modification and use the phrases "Built with Domternal", "Powered by Domternal", or "Uses Domternal". The logo must not be used as the primary brand for another offering, decoratively, or on merchandise.
+
+These permissions are subject to the following conditions:
+
+- Do not state or imply that Domternal endorses, sponsors, certifies, or is affiliated with you, your organization, or your offering.
+- Do not use Domternal or a confusingly similar term as part of a company, organization, product, service, domain, package, application-store, or social-media account name.
+- Do not alter the Domternal logo, except to resize it proportionally. Do not change its colors, proportions, elements, or orientation.
+- Forks, modified distributions, and derivative projects must use a clearly distinct name and presentation and must not appear to be an official Domternal release.
+- This policy does not grant permission to use the legal business name of the Domternal mark owner, an owner or other person's name, identity, likeness, or personal marks, or any other Domternal-related mark not expressly permitted above for branding, promotion, endorsement claims, or merchandise. Truthful factual references remain subject to applicable law.
+
+Permission under this policy may be withdrawn for misuse, likely confusion, or a violation of these conditions. If permission is withdrawn, you must stop the affected use within a reasonable period specified in the notice.
+
+This policy does not limit any nominative, descriptive, or other use that applicable law permits without authorization. No other trademark rights are granted by implication, estoppel, or otherwise.

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@playwright/test": "^1.58.2",
     "@types/node": "^22.20.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "esbuild": "0.28.1",
     "eslint": "^10.8.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.0.0",

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -19,7 +19,7 @@ emoji picker, and Notion color picker auto-render from the extensions you load.
 pnpm add @domternal/angular @domternal/core @domternal/theme
 ```
 
-`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=1.0.0)
+`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=1.0.0 <2.0.0)
 are peer dependencies. Add the theme ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme))
 to your global stylesheet (e.g. `styles.scss`):
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -20,7 +20,7 @@
     "@angular/core": ">=17.1.0",
     "@angular/forms": ">=17.1.0",
     "@angular/platform-browser": ">=17.1.0",
-    "@domternal/core": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0"
   },
   "files": [
     "dist"

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -41,8 +41,8 @@
     "hast-util-to-html": "^9.0.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0",
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0",
     "lowlight": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -41,8 +41,8 @@
     "markdown-it": "^14.3.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0",
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0",
     "katex": "^0.16.0 || ^0.17.0"
   },
   "devDependencies": {

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -39,8 +39,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
-    "@domternal/pm": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/pm": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -18,7 +18,8 @@ extension. You rarely install it yourself: it ships transitively with `@domterna
 
 Install it explicitly when you import ProseMirror primitives in your own code, or when a
 strict peer resolver asks for it: every `@domternal/extension-*` package declares
-`@domternal/pm` as a peer dependency at the same minor floor as `@domternal/core`.
+`@domternal/pm` as a peer dependency with the same minor floor and next-major ceiling as
+`@domternal/core`.
 
 ```bash
 pnpm add @domternal/pm

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ and React 19.
 pnpm add @domternal/react @domternal/core @domternal/theme react react-dom
 ```
 
-`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=1.0.0) are peer dependencies. Import the theme
+`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=1.0.0 <2.0.0) are peer dependencies. Import the theme
 ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)) in your entry CSS for default styling:
 
 ```css

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "@domternal/core": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -22,7 +22,7 @@ Lit, Web Components, or plain HTML - anywhere without a framework runtime.
 pnpm add @domternal/core @domternal/theme @domternal/vanilla
 ```
 
-`@domternal/core` (>=1.0.0) is a peer dependency. `@domternal/theme` supplies the editor
+`@domternal/core` (>=1.0.0 <2.0.0) is a peer dependency. `@domternal/theme` supplies the editor
 styles (import it once in your app).
 
 ## Usage

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0"
+    "@domternal/core": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -19,7 +19,7 @@ editor is created in `onMounted`. Requires Vue 3.3+ and the Composition API.
 pnpm add @domternal/vue @domternal/core @domternal/theme vue
 ```
 
-`vue` (>=3.3) and `@domternal/core` (>=1.0.0) are peer dependencies. `@domternal/theme`
+`vue` (>=3.3) and `@domternal/core` (>=1.0.0 <2.0.0) are peer dependencies. `@domternal/theme`
 supplies the editor styles.
 
 ## Usage

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0",
+    "@domternal/core": ">=1.0.0 <2.0.0",
     "vue": ">=3.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^10.8.1
         version: 10.8.1(jiti@2.7.0)

--- a/scripts/prepare-publish-manifest.mjs
+++ b/scripts/prepare-publish-manifest.mjs
@@ -11,25 +11,28 @@ import { fileURLToPath } from 'node:url';
 const SOURCE_CONDITION = '@domternal/source';
 
 /**
- * The compatibility floor a published package declares: `>=MAJOR.MINOR.0`.
+ * The compatibility range a published package declares:
+ * `>=MAJOR.MINOR.0 <NEXT_MAJOR.0.0`.
  *
  * A prerelease is refused rather than reduced to its release part, because the
  * reduction would be silently wrong: semver ranges exclude prereleases, so a
  * coordinated `1.0.0-rc.1` of this workspace would publish a core declaring
- * `@domternal/pm >=1.0.0`, which `1.0.0-rc.1` does not satisfy, and installing
- * the rc would fail with ETARGET until a stable 1.0.0 existed. Nothing here has
+ * `@domternal/pm >=1.0.0 <2.0.0`, which `1.0.0-rc.1` does not satisfy, and
+ * installing the rc would fail with ETARGET until a stable 1.0.0 existed. Nothing here has
  * ever shipped a prerelease; the day one is wanted, this is the decision to
  * make deliberately rather than to inherit from a regex.
  */
-export function versionFloor(version) {
+export function versionRange(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
   if (match === null) {
     throw new Error(
       `version "${version}" is not a plain MAJOR.MINOR.PATCH. ` +
-        'A prerelease needs a floor decided by hand: no prerelease satisfies a >=X.Y.0 range.'
+        'A prerelease needs a compatibility range decided by hand: no prerelease satisfies ' +
+        'a >=X.Y.0 <NEXT_MAJOR.0.0 range.'
     );
   }
-  return `>=${match[1]}.${match[2]}.0`;
+  const nextMajor = String(Number(match[1]) + 1);
+  return `>=${match[1]}.${match[2]}.0 <${nextMajor}.0.0`;
 }
 
 /** Strips the dev-source condition wherever it appears in an exports map. */
@@ -79,12 +82,12 @@ export function preparePublishManifest(manifest) {
   }
 
   if (prepared.dependencies !== undefined) {
-    const floor = versionFloor(prepared.version);
+    const range = versionRange(prepared.version);
     const rewritten = {};
     const named = [];
     for (const [name, specifier] of Object.entries(prepared.dependencies)) {
       if (specifier === 'workspace:*') {
-        rewritten[name] = floor;
+        rewritten[name] = range;
         named.push(name);
       } else {
         rewritten[name] = specifier;
@@ -92,7 +95,7 @@ export function preparePublishManifest(manifest) {
     }
     if (named.length > 0) {
       prepared.dependencies = rewritten;
-      changes.push(`pinned ${named.join(', ')} to ${floor}`);
+      changes.push(`pinned ${named.join(', ')} to ${range}`);
     }
   }
 

--- a/tests/bundle-size/check.mjs
+++ b/tests/bundle-size/check.mjs
@@ -69,13 +69,25 @@
  * arrive under the twelve's combined headroom without anyone being told. A
  * ceiling per subpath needs no special case, and it says the one thing that
  * matters about these files, which is that each stays a re-export.
+ *
+ * ## The public marketing metric
+ *
+ * README size claims use one reproducible pipeline over the built core ESM
+ * entry. "Own code" minifies that entry without bundling, so dependency imports
+ * remain external. "Total" bundles the same entry and its runtime dependencies
+ * for a browser. Both use the repository's pinned esbuild, target ES2022, drop
+ * legal comments, and gzip at level 9 with a zero timestamp. Exact byte counts
+ * are printed; README uses `~` and rounds each to the nearest whole KiB. The
+ * gate checks those rounded claims instead of leaving a second
+ * manually maintained size calculation to drift.
  */
 import { createReadStream, existsSync, readFileSync, readdirSync } from 'node:fs';
-import { createGzip } from 'node:zlib';
+import { createGzip, gzipSync } from 'node:zlib';
 import { pipeline } from 'node:stream/promises';
 import { Writable } from 'node:stream';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { build, version as esbuildVersion } from 'esbuild';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..');
@@ -271,6 +283,75 @@ export function suggestBudget(size) {
   return Math.ceil(withHeadroom / step) * step;
 }
 
+/** Nearest whole KiB for a public `~N KiB` claim. */
+export function marketingKiB(bytes) {
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    throw new Error(`marketing size must be a non-negative safe integer, got ${String(bytes)}`);
+  }
+  return Math.round(bytes / 1024);
+}
+
+/** Whether README's two marketing claims match the deterministic measurements. */
+export function marketingClaimFailures(readme, { ownBytes, totalBytes }) {
+  const match =
+    /\*\*~(\d+) KiB minified and gzipped\*\* \(own code\), \[\*\*~(\d+) KiB minified and gzipped total\*\*\]/.exec(
+      readme
+    );
+  if (match === null) {
+    return [
+      'README has no standard core bundle claim. Expected "~N KiB minified and gzipped" for own code and total.',
+    ];
+  }
+
+  const expectedOwn = marketingKiB(ownBytes);
+  const expectedTotal = marketingKiB(totalBytes);
+  const claimedOwn = Number(match[1]);
+  const claimedTotal = Number(match[2]);
+  const failures = [];
+  if (claimedOwn !== expectedOwn) {
+    failures.push(
+      `README claims ~${claimedOwn} KiB own code, measured value rounds to ~${expectedOwn} KiB`
+    );
+  }
+  if (claimedTotal !== expectedTotal) {
+    failures.push(
+      `README claims ~${claimedTotal} KiB total, measured value rounds to ~${expectedTotal} KiB`
+    );
+  }
+  return failures;
+}
+
+/** Minified and gzipped core sizes with dependencies external and bundled. */
+export async function marketingBundleSizes(
+  entry = join(repoRoot, 'packages', 'core', 'dist', 'index.js')
+) {
+  const common = {
+    absWorkingDir: repoRoot,
+    entryPoints: [entry],
+    format: 'esm',
+    legalComments: 'none',
+    logLevel: 'silent',
+    minify: true,
+    target: 'es2022',
+    treeShaking: true,
+    write: false,
+  };
+  const [own, total] = await Promise.all([
+    build({ ...common, bundle: false }),
+    build({ ...common, bundle: true, platform: 'browser' }),
+  ]);
+  if (own.outputFiles.length !== 1 || total.outputFiles.length !== 1) {
+    throw new Error(
+      'the marketing bundle pipeline must produce exactly one own and one total file'
+    );
+  }
+  const gzipOptions = { level: 9, mtime: 0 };
+  return {
+    ownBytes: gzipSync(own.outputFiles[0].contents, gzipOptions).byteLength,
+    totalBytes: gzipSync(total.outputFiles[0].contents, gzipOptions).byteLength,
+  };
+}
+
 async function gzippedSize(path) {
   let bytes = 0;
   const sink = new Writable({ write(chunk, _enc, cb) { bytes += chunk.length; cb(); } });
@@ -361,6 +442,30 @@ async function main() {
     console.error('[bundle-size] in which case fix the exports map in the package. Note that');
     console.error('[bundle-size] two keys resolving to one file share one budget, held by the');
     console.error('[bundle-size] root entry, so the second key belongs in neither place.');
+    process.exit(1);
+  }
+
+  const marketing = await marketingBundleSizes();
+  const claimFailures = marketingClaimFailures(
+    readFileSync(join(repoRoot, 'README.md'), 'utf8'),
+    marketing
+  );
+  console.log('');
+  console.log(
+    `[bundle-size] public core metric: esbuild ${esbuildVersion}, minified ESM, ES2022, gzip level 9`
+  );
+  console.log(
+    `  own code  ${String(marketing.ownBytes).padStart(7)} bytes  ` +
+      `(${(marketing.ownBytes / 1024).toFixed(2)} KiB, README ~${String(marketingKiB(marketing.ownBytes))} KiB)`
+  );
+  console.log(
+    `  total     ${String(marketing.totalBytes).padStart(7)} bytes  ` +
+      `(${(marketing.totalBytes / 1024).toFixed(2)} KiB, README ~${String(marketingKiB(marketing.totalBytes))} KiB)`
+  );
+  if (claimFailures.length > 0) {
+    console.error('');
+    console.error('[bundle-size] FAILED: public README bundle claim is stale:');
+    for (const failure of claimFailures) console.error(`  ${failure}`);
     process.exit(1);
   }
 

--- a/tests/bundle-size/check.test.mjs
+++ b/tests/bundle-size/check.test.mjs
@@ -20,6 +20,8 @@ import {
   completeness,
   discoverEntries,
   manifestEntries,
+  marketingClaimFailures,
+  marketingKiB,
   runtimeTarget,
   subpathMap,
   suggestBudget,
@@ -227,6 +229,26 @@ test('a suggested budget keeps about a tenth of headroom and lands on a round nu
   for (const size of [54, 61, 2367, 13992, 78409]) {
     assert.ok(suggestBudget(size) >= size * 1.1, `${size} needs headroom`);
   }
+});
+
+test('marketing KiB rounds to the nearest whole unit used by the approximate claim', () => {
+  assert.equal(marketingKiB(0), 0);
+  assert.equal(marketingKiB(1024), 1);
+  assert.equal(marketingKiB(1535), 1);
+  assert.equal(marketingKiB(1536), 2);
+  assert.throws(() => marketingKiB(-1), /non-negative safe integer/);
+});
+
+test('the public README claim must match both deterministic bundle measurements', () => {
+  const readme =
+    '**~51 KiB minified and gzipped** (own code), ' +
+    '[**~132 KiB minified and gzipped total**](https://domternal.dev/v1/packages)';
+  const sizes = { ownBytes: 52233, totalBytes: 135189 };
+  assert.deepEqual(marketingClaimFailures(readme, sizes), []);
+  assert.deepEqual(marketingClaimFailures(readme.replace('~51', '~48'), sizes), [
+    'README claims ~48 KiB own code, measured value rounds to ~51 KiB',
+  ]);
+  assert.match(marketingClaimFailures('no claim', sizes)[0], /no standard core bundle claim/);
 });
 
 test('discovery finds the three packages that had no ceiling before', () => {

--- a/tests/package-artifacts/check.test.mjs
+++ b/tests/package-artifacts/check.test.mjs
@@ -155,8 +155,8 @@ test('a workspace specifier the publish transform cannot resolve is caught', () 
   const source = { name: '@domternal/core', version: '0.15.0' };
   const base = { ...source, license: 'MIT' };
 
-  /* workspace:* is understood: the transform turns it into the floor, which is
-     what the published manifest carries, so it is not a failure here. */
+  /* workspace:* is understood: the transform turns it into the compatibility
+     range, which is what the published manifest carries, so it is not a failure here. */
   assert.deepEqual(
     manifestFailures(source, { ...base, dependencies: { '@domternal/pm': 'workspace:*' } }, [
       'package.json',

--- a/tests/package-policy/check.mjs
+++ b/tests/package-policy/check.mjs
@@ -9,7 +9,7 @@ import semver from 'semver';
 import {
   preparePublishManifest,
   publishBlockers,
-  versionFloor,
+  versionRange,
 } from '../../scripts/prepare-publish-manifest.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -178,16 +178,16 @@ export function peerRangeFailures({ directory, manifest }) {
 export function packageFailures({ directory, name, manifest }, names, rootLicense, nodeFloor) {
   const failures = [];
   const label = manifest.name;
-  const floor = versionFloor(manifest.version);
+  const compatibilityRange = versionRange(manifest.version);
 
-  // The floors a consumer resolves against. `>=MAJOR.MINOR.0` rather than
-  // `>=VERSION`, because a patch release deliberately keeps the floor where the
-  // minor put it: 0.12.1 shipped with `>=0.12.0`, and that was correct.
+  // The ranges a consumer resolves against. The lower bound stays at the minor
+  // floor across patch releases, while the upper bound keeps a future breaking
+  // major out: 1.4.17 declares `>=1.4.0 <2.0.0`.
   for (const [dependency, range] of Object.entries(manifest.peerDependencies ?? {})) {
     if (!dependency.startsWith(SCOPE)) continue;
-    if (range !== floor) {
+    if (range !== compatibilityRange) {
       failures.push(
-        `${label}: peerDependencies.${dependency} is "${range}", expected "${floor}" for version ${manifest.version}`
+        `${label}: peerDependencies.${dependency} is "${range}", expected "${compatibilityRange}" for version ${manifest.version}`
       );
     }
     if (!names.has(dependency)) {
@@ -196,8 +196,8 @@ export function packageFailures({ directory, name, manifest }, names, rootLicens
   }
 
   // A runtime dependency on a sibling is always workspace:*, and the publish
-  // transform turns it into the floor. Anything else here is either a mistake
-  // or the residue of a publish that died before postpublish restored the file.
+  // transform turns it into the compatibility range. Anything else here is
+  // either a mistake or the residue of a publish that died before postpublish restored the file.
   for (const [dependency, range] of Object.entries(manifest.dependencies ?? {})) {
     if (!dependency.startsWith(SCOPE)) continue;
     if (range !== 'workspace:*') {
@@ -330,7 +330,7 @@ function main() {
 
   const version = manifests[0]?.version ?? 'unknown';
   console.log(
-    `[package-policy] OK - ${String(packages.length)} packages at ${version}, floors at ${versionFloor(version)}, ` +
+    `[package-policy] OK - ${String(packages.length)} packages at ${version}, ranges at ${versionRange(version)}, ` +
       `node ${nodeFloor}, manifests publishable`
   );
 }

--- a/tests/package-policy/check.test.mjs
+++ b/tests/package-policy/check.test.mjs
@@ -2,7 +2,7 @@
  * Fixture tests for the manifest policy gate and the publish transform it runs.
  *
  * The transform is the only code between a working tree and npm, and npm is a
- * place nothing can be taken back from: a wrong floor or a dangling export
+ * place nothing can be taken back from: a wrong compatibility range or a dangling export
  * condition is public the moment it lands. So its behaviour is pinned here on
  * hand-written manifests rather than only on the eighteen real ones, which all
  * happen to be correct and would therefore prove nothing about the failures.
@@ -25,7 +25,7 @@ import {
   exportTargets,
   preparePublishManifest,
   publishBlockers,
-  versionFloor,
+  versionRange,
 } from '../../scripts/prepare-publish-manifest.mjs';
 
 /** A throwaway packages/ directory built from `{ dirName: manifest }`. */
@@ -78,24 +78,25 @@ test('lockstep reports the buckets, not just that they exist', () => {
   );
 });
 
-test('the floor is the minor, so a patch release does not move it', () => {
-  assert.equal(versionFloor('0.15.0'), '>=0.15.0');
-  /* 0.12.1 shipped with floors at >=0.12.0. Deriving >=VERSION instead would
-     have declared that release incompatible with its own minor. */
-  assert.equal(versionFloor('0.12.1'), '>=0.12.0');
-  assert.equal(versionFloor('1.4.17'), '>=1.4.0');
-  assert.throws(() => versionFloor('next'), /not a plain MAJOR\.MINOR\.PATCH/);
+test('the compatibility range keeps the minor floor and excludes the next major', () => {
+  assert.equal(versionRange('0.15.0'), '>=0.15.0 <1.0.0');
+  /* A patch keeps the floor where its minor put it, while the upper bound
+     prevents a future breaking major from satisfying an old package. */
+  assert.equal(versionRange('0.12.1'), '>=0.12.0 <1.0.0');
+  assert.equal(versionRange('1.4.17'), '>=1.4.0 <2.0.0');
+  assert.equal(versionRange('2.3.4'), '>=2.3.0 <3.0.0');
+  assert.throws(() => versionRange('next'), /not a plain MAJOR\.MINOR\.PATCH/);
 });
 
 test('a prerelease is refused rather than reduced to its release part', () => {
-  /* `1.0.0-rc.1` would otherwise derive `>=1.0.0`, and semver ranges exclude
+  /* `1.0.0-rc.1` would otherwise derive `>=1.0.0 <2.0.0`, and semver ranges exclude
      prereleases: the whole workspace would publish at 1.0.0-rc.1 declaring a
-     floor that 1.0.0-rc.1 does not satisfy, so installing the rc would fail
+     range that 1.0.0-rc.1 does not satisfy, so installing the rc would fail
      with ETARGET until a stable 1.0.0 existed. Both gates would stay green
      while that happened, which is why it is refused here. */
-  assert.throws(() => versionFloor('1.0.0-rc.1'), /decided by hand/);
-  assert.throws(() => versionFloor('2.0.0-0'), /decided by hand/);
-  assert.throws(() => versionFloor('0.16.0+build.5'), /decided by hand/);
+  assert.throws(() => versionRange('1.0.0-rc.1'), /decided by hand/);
+  assert.throws(() => versionRange('2.0.0-0'), /decided by hand/);
+  assert.throws(() => versionRange('0.16.0+build.5'), /decided by hand/);
 });
 
 test('the transform drops devDependencies and pins only the workspace protocol', () => {
@@ -106,8 +107,11 @@ test('the transform drops devDependencies and pins only the workspace protocol',
     devDependencies: { typescript: '~5.9.3' },
   });
   assert.equal(prepared.devDependencies, undefined);
-  assert.deepEqual(prepared.dependencies, { '@domternal/pm': '>=0.15.0', linkifyjs: '^4.3.2' });
-  assert.deepEqual(changes, ['dropped devDependencies', 'pinned @domternal/pm to >=0.15.0']);
+  assert.deepEqual(prepared.dependencies, {
+    '@domternal/pm': '>=0.15.0 <1.0.0',
+    linkifyjs: '^4.3.2',
+  });
+  assert.deepEqual(changes, ['dropped devDependencies', 'pinned @domternal/pm to >=0.15.0 <1.0.0']);
 });
 
 test('the transform strips the dev-source condition wherever it sits', () => {
@@ -131,7 +135,7 @@ test('the transform strips the dev-source condition wherever it sits', () => {
 test('the transform leaves a manifest it has already prepared alone', () => {
   /* postpublish restores the file with git, but a publish that dies between the
      two leaves a prepared manifest on disk. Running it again must not turn
-     ">=0.15.0" into something else or report changes it did not make. */
+     ">=0.15.0 <1.0.0" into something else or report changes it did not make. */
   const source = {
     name: '@domternal/core',
     version: '0.15.0',
@@ -204,7 +208,7 @@ test('an exports target that is missing, or that files does not ship, blocks the
   rmSync(root, { recursive: true, force: true });
 });
 
-test('a package whose floors did not move with its version is reported', () => {
+test('a package whose compatibility range did not move with its version is reported', () => {
   const root = mkdtempSync(join(tmpdir(), 'domternal-failures-'));
   writeFileSync(join(root, 'LICENSE'), 'MIT');
   const failures = packageFailures(
@@ -223,7 +227,7 @@ test('a package whose floors did not move with its version is reported', () => {
         sideEffects: false,
         files: ['LICENSE'],
         repository: { directory: 'packages/extension-toc' },
-        peerDependencies: { '@domternal/core': '>=0.15.0' },
+        peerDependencies: { '@domternal/core': '>=0.15.0 <1.0.0' },
         scripts: { prepublishOnly: 'x', postpublish: 'y' },
       },
     },
@@ -231,7 +235,9 @@ test('a package whose floors did not move with its version is reported', () => {
     'MIT'
   );
   assert.ok(
-    failures.some((failure) => /peerDependencies\.@domternal\/core is ">=0\.15\.0"/.test(failure)),
+    failures.some((failure) =>
+      /peerDependencies\.@domternal\/core is ">=0\.15\.0 <1\.0\.0"/.test(failure)
+    ),
     failures.join('\n')
   );
   rmSync(root, { recursive: true, force: true });
@@ -298,7 +304,7 @@ test('a peer range that excludes the version this repository tests is reported',
     directory: root,
     manifest: {
       name: '@domternal/extension-math',
-      peerDependencies: { '@domternal/core': '>=0.15.0', katex: peer },
+      peerDependencies: { '@domternal/core': '>=0.15.0 <1.0.0', katex: peer },
       devDependencies: dev === null ? {} : { katex: dev },
     },
   });
@@ -309,7 +315,7 @@ test('a peer range that excludes the version this repository tests is reported',
     /is "\^0\.16\.0", which excludes the 0\.17\.0 this repository builds and tests against/
   );
   assert.match(peerRangeFailures(entry('^0.17.0', null))[0], /not in devDependencies/);
-  /* An in-scope peer is judged by the floor rule instead, not here, so it must
+  /* An in-scope peer is judged by the compatibility-range rule instead, not here, so it must
      not be double-reported. */
   assert.equal(
     peerRangeFailures(entry('^0.17.0', '^0.17.0')).filter((f) => f.includes('@domternal/core'))


### PR DESCRIPTION
## Summary

The 1.0 line now declares bounded compatibility everywhere instead of open-ended floors, the README claims that CI can measure are actually verified, and the repository gains an explicit trademark policy. No runtime source changes: only package manifests, docs, and the gates that hold them honest.

## Changes

- Peer ranges on `@domternal/core` across the wrappers and extensions move from `>=1.0.0` to `>=1.0.0 <2.0.0`, so a future core 2.0 cannot silently satisfy 1.x consumers; `prepare-publish-manifest.mjs` applies the same bounded range at publish time and the package-policy gate enforces it.
- The bundle-size gate now also verifies README size claims against the measured bundles, so published numbers cannot drift from what ships.
- READMEs, issue templates, SECURITY.md and the CI workflow aligned with the current release line.
- New `TRADEMARKS.md` with the usage policy, and the README licensing wording now separates the MIT code license from trademark use.

## Verified

No runtime source changed. The enforcement for the new ranges and the README size claims ships in this same PR as updated package-policy and bundle-size checks with their tests, and the standard CI gate suite validates the branch.