### PR TITLE
fix: align public product facts across npm metadata, README ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Domternal Editor](https://domternal.dev/readme/readme-banner.png?v=4)](https://domternal.dev)
 
-A rich text editor toolkit built on [ProseMirror](https://prosemirror.net/), with a headless core and first-class **Angular**, **React**, **Vue**, and **Vanilla** components. Take the core alone and drive the DOM yourself, add the toolbar and theme for a finished editor, or mount the components for your framework. Notion-style block editing, drag handle, slash menu and floating outline included, and every package is tree-shakeable.
+A rich text editor toolkit built on [ProseMirror](https://prosemirror.net/), with a headless core and first-class **Angular**, **React**, **Vue**, and **Vanilla** components. Take the core alone and drive the DOM yourself, add the toolbar and theme for a finished editor, or mount the components for your framework. Notion-style block editing, drag handle, slash menu and floating outline are included. JavaScript exports are tree-shakeable; the optional theme ships as one complete CSS stylesheet.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/domternal/domternal/actions/workflows/ci.yml/badge.svg)](https://github.com/domternal/domternal/actions/workflows/ci.yml)
@@ -22,14 +22,14 @@ A rich text editor toolkit built on [ProseMirror](https://prosemirror.net/), wit
 - **Vanilla wrapper** - framework-free class-based API for Astro, Svelte, Solid, plain HTML, and Web Components - editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker
 - **Notion-style block UX** - drag-to-reorder, block context menu, slash command, smart paste, keyboard reorder, floating Table of Contents, from `@domternal/extension-block-controls` and `@domternal/extension-toc`, with `preset: 'notion'` for the layout and preset-aware behavior
 - **Print to paper or PDF** - `printDocument()` leaves your app's chrome off the page, and the theme's paper layer applies to the reader's own Ctrl/Cmd+P with no code involved
-- **74 extensions across core and 10 extension packages** - nodes, marks, and behavior extensions
+- **70+ extensions across core and 10 extension packages** - nodes, marks, and behavior extensions
 - **130+ chainable commands** - `editor.chain().focus().toggleBold().run()`
 - **Full table support** - cell merging, column resize, row/column controls, cell toolbar
-- **Tree-shakeable** - import only what you use, your bundler strips the rest
+- **Tree-shakeable JavaScript** - import only the JavaScript exports you use; the optional `@domternal/theme` deliberately ships one complete stylesheet
 - **~51 KiB minified and gzipped** (own code), [**~132 KiB minified and gzipped total**](https://domternal.dev/v1/packages) with runtime dependencies - see Packages for the full bundle breakdown
 - **TypeScript first** - every package builds under `strict`, with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
-- **17,800+ tests** - 4,700+ unit and 13,100+ E2E across the Playwright matrix and 4 demo apps
-- **Light and dark theme** - 160 CSS custom properties for full visual control
+- **17,000+ automated test executions** - unit coverage and a Playwright matrix across four demo apps
+- **Light and dark theme** - 150+ CSS custom properties for full visual control
 - **Inline styles export** - `getHTML({ styled: true })` produces inline CSS ready for email clients, CMS, and Google Docs
 - **SSR helpers** - `generateHTML`, `generateJSON`, `generateText` for server-side rendering
 
@@ -57,27 +57,27 @@ The example above wires the minimum schema by hand to show the headless model; i
 
 ## Packages
 
-| Package | Description |
-|---|---|
-| [`@domternal/core`](https://www.npmjs.com/package/@domternal/core) | Editor engine with 13 nodes, 9 marks, 28 extensions, toolbar controller, and 52 built-in icons |
-| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme) | Light and dark themes with 160 CSS custom properties |
-| [`@domternal/angular`](https://www.npmjs.com/package/@domternal/angular) | Angular 17.1+ wrapper: 6 components (editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker) |
-| [`@domternal/react`](https://www.npmjs.com/package/@domternal/react) | React 18+ wrapper: composable component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views |
-| [`@domternal/vue`](https://www.npmjs.com/package/@domternal/vue) | Vue 3.3+ wrapper: composable component, composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views |
-| [`@domternal/vanilla`](https://www.npmjs.com/package/@domternal/vanilla) | Framework-free class-based wrapper for Astro, Svelte, Solid, plain HTML, and Web Components |
-| [`@domternal/pm`](https://www.npmjs.com/package/@domternal/pm) | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more) |
-| [`@domternal/extension-block-controls`](https://www.npmjs.com/package/@domternal/extension-block-controls) | Notion-style block UX: block handle, context menu, drag-to-reorder, keyboard reorder, slash command, floating menu, smart paste (formerly `@domternal/extension-block-menu`) |
-| [`@domternal/extension-toc`](https://www.npmjs.com/package/@domternal/extension-toc) | Notion-style Table of Contents: floating outline, inline `/toc` block, `scrollToHeading` command |
-| [`@domternal/extension-table`](https://www.npmjs.com/package/@domternal/extension-table) | Tables with 18 commands: merge, split, resize, cell styling, row/column controls |
-| [`@domternal/extension-math`](https://www.npmjs.com/package/@domternal/extension-math) | LaTeX math: inline and block equations with a pluggable renderer (KaTeX) |
-| [`@domternal/extension-markdown`](https://www.npmjs.com/package/@domternal/extension-markdown) | GitHub-flavored Markdown import and export: markdown paste, `insertMarkdown`/`setMarkdownContent`, headless parser and serializer with fidelity warnings |
-| [`@domternal/extension-image`](https://www.npmjs.com/package/@domternal/extension-image) | Image with paste/drop upload, URL input, XSS protection, bubble menu |
-| [`@domternal/extension-emoji`](https://www.npmjs.com/package/@domternal/extension-emoji) | Emoji picker panel and `:shortcode:` autocomplete |
-| [`@domternal/extension-mention`](https://www.npmjs.com/package/@domternal/extension-mention) | `@mention` autocomplete with multi-trigger and async support |
-| [`@domternal/extension-details`](https://www.npmjs.com/package/@domternal/extension-details) | Collapsible details/accordion blocks |
-| [`@domternal/extension-code-block-lowlight`](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight |
+| Package                                                                                                              | Description                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@domternal/core`](https://www.npmjs.com/package/@domternal/core)                                                   | Editor engine with 13 nodes, 9 marks, 28 extensions, toolbar controller, and 52 built-in icons                                                                               |
+| [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)                                                 | Light and dark themes with 150+ CSS custom properties                                                                                                                        |
+| [`@domternal/angular`](https://www.npmjs.com/package/@domternal/angular)                                             | Angular 17.1+ wrapper: 6 components (editor, toolbar, bubble menu, floating menu, emoji picker, notion color picker)                                                         |
+| [`@domternal/react`](https://www.npmjs.com/package/@domternal/react)                                                 | React 18+ wrapper: composable component, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views                                                  |
+| [`@domternal/vue`](https://www.npmjs.com/package/@domternal/vue)                                                     | Vue 3.3+ wrapper: composable component, composables, toolbar, bubble menu, floating menu, emoji picker, notion color picker, node views                                      |
+| [`@domternal/vanilla`](https://www.npmjs.com/package/@domternal/vanilla)                                             | Framework-free class-based wrapper for Astro, Svelte, Solid, plain HTML, and Web Components                                                                                  |
+| [`@domternal/pm`](https://www.npmjs.com/package/@domternal/pm)                                                       | ProseMirror re-exports (state, view, model, transform, commands, keymap, history, tables, and more)                                                                          |
+| [`@domternal/extension-block-controls`](https://www.npmjs.com/package/@domternal/extension-block-controls)           | Notion-style block UX: block handle, context menu, drag-to-reorder, keyboard reorder, slash command, floating menu, smart paste (formerly `@domternal/extension-block-menu`) |
+| [`@domternal/extension-toc`](https://www.npmjs.com/package/@domternal/extension-toc)                                 | Notion-style Table of Contents: floating outline, inline `/toc` block, `scrollToHeading` command                                                                             |
+| [`@domternal/extension-table`](https://www.npmjs.com/package/@domternal/extension-table)                             | Tables with 18 commands: merge, split, resize, cell styling, row/column controls                                                                                             |
+| [`@domternal/extension-math`](https://www.npmjs.com/package/@domternal/extension-math)                               | LaTeX math: inline and block equations with a pluggable renderer (KaTeX)                                                                                                     |
+| [`@domternal/extension-markdown`](https://www.npmjs.com/package/@domternal/extension-markdown)                       | GitHub-flavored Markdown import and export: markdown paste, `insertMarkdown`/`setMarkdownContent`, headless parser and serializer with fidelity warnings                     |
+| [`@domternal/extension-image`](https://www.npmjs.com/package/@domternal/extension-image)                             | Image with paste/drop upload, URL input, XSS protection, bubble menu                                                                                                         |
+| [`@domternal/extension-emoji`](https://www.npmjs.com/package/@domternal/extension-emoji)                             | Emoji picker panel and `:shortcode:` autocomplete                                                                                                                            |
+| [`@domternal/extension-mention`](https://www.npmjs.com/package/@domternal/extension-mention)                         | `@mention` autocomplete with multi-trigger and async support                                                                                                                 |
+| [`@domternal/extension-details`](https://www.npmjs.com/package/@domternal/extension-details)                         | Collapsible details/accordion blocks                                                                                                                                         |
+| [`@domternal/extension-code-block-lowlight`](https://www.npmjs.com/package/@domternal/extension-code-block-lowlight) | Syntax-highlighted code blocks powered by lowlight                                                                                                                           |
 
-`@domternal/extension-block-menu`, the deprecated shim left from the v0.10.0 rename, ended with the 0.x line. Briefly published 1.0.x builds were withdrawn from the registry; import `@domternal/extension-block-controls` directly.
+The table above lists all 17 current MIT packages. npm search may still show `@domternal/extension-block-menu` as a historical, deprecated 0.x entry. It is not an eighteenth current package. Briefly published 1.0.x builds were withdrawn from the registry; import `@domternal/extension-block-controls` directly.
 
 See [Packages & Bundle Size](https://domternal.dev/v1/packages) for a full breakdown of what each package includes and how tree-shaking works.
 

--- a/context7.json
+++ b/context7.json
@@ -1,20 +1,8 @@
 {
   "projectTitle": "Domternal",
   "description": "Framework-agnostic headless rich text editor toolkit built on ProseMirror, with native Angular, React, Vue, and Vanilla components, Notion-style block UX, and a tree-shakeable extension model. MIT licensed. Full guides and API reference at https://domternal.dev/v1.",
-  "excludeFolders": [
-    "apps",
-    "tests",
-    "e2e",
-    "scripts",
-    ".github",
-    ".vscode"
-  ],
-  "excludeFiles": [
-    "CHANGELOG.md",
-    "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md",
-    "SECURITY.md"
-  ],
+  "excludeFolders": ["apps", "tests", "e2e", "scripts", ".github", ".vscode"],
+  "excludeFiles": ["CHANGELOG.md", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md", "SECURITY.md"],
   "rules": [
     "The @domternal/core package is framework-agnostic and headless. Framework wrappers are @domternal/angular, @domternal/react, @domternal/vue, and @domternal/vanilla.",
     "Import editor primitives and built-in extensions from @domternal/core. Optional features are separate @domternal/extension-* packages: table, image, math, emoji, mention, markdown, block-controls, toc, details, code-block-lowlight.",
@@ -22,7 +10,9 @@
     "Commands are chainable: editor.chain().focus().toggleBold().run().",
     "Notion-style block UX (slash menu, drag-to-reorder, block context menu, smart paste) comes from @domternal/extension-block-controls.",
     "Styling is opt-in via @domternal/theme (CSS custom properties) and is separate from the headless core.",
-    "Extensions are tree-shakeable: register only what you use; the bundler strips the rest.",
+    "JavaScript extension exports are tree-shakeable: import and register only what you use. The optional @domternal/theme package ships one complete CSS stylesheet.",
+    "Domternal Free is the current set of 17 MIT-licensed @domternal packages. Domternal Pro is a separate commercially licensed suite distributed through public npm with a private source repository.",
+    "Domternal Pro runs in customer-chosen infrastructure and requires no Domternal-operated editor cloud. Current product, pricing, and licensing facts live at https://domternal.dev/pro/, https://domternal.dev/free-vs-pro/, and https://domternal.dev/license-explained/.",
     "Full guides, per-extension API, and the changelog live at https://domternal.dev/v1."
   ],
   "url": "https://context7.com/domternal/domternal",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/angular",
   "version": "1.0.1",
-  "description": "Angular components for Domternal editor",
+  "description": "MIT-licensed Angular components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "module",
@@ -50,6 +50,9 @@
     "prosemirror",
     "editor",
     "rich-text",
+    "rich-text-editor",
+    "wysiwyg",
+    "typescript",
     "domternal"
   ],
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/core",
   "version": "1.0.1",
-  "description": "Framework-agnostic ProseMirror editor engine",
+  "description": "MIT-licensed, framework-agnostic headless rich text editor engine built on ProseMirror",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "module",
@@ -63,7 +63,12 @@
     "prosemirror",
     "editor",
     "rich-text",
+    "rich-text-editor",
     "wysiwyg",
+    "headless",
+    "typescript",
+    "open-source",
+    "self-hosted",
     "domternal"
   ],
   "repository": {

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "block-controls",
     "block-menu",
     "floating-menu",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -56,6 +56,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "code-block",
     "syntax-highlighting",
     "lowlight",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "details",
     "accordion",
     "domternal"

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "emoji",
     "domternal"
   ],

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "image",
     "domternal"
   ],

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -61,6 +61,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "markdown",
     "gfm",
     "import",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -53,6 +53,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "math",
     "latex",
     "katex",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "mention",
     "domternal"
   ],

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -52,6 +52,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "table",
     "domternal"
   ],

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -51,6 +51,8 @@
   "keywords": [
     "prosemirror",
     "editor",
+    "rich-text-editor",
+    "typescript",
     "table-of-contents",
     "toc",
     "outline",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/react",
   "version": "1.0.1",
-  "description": "React components for Domternal editor",
+  "description": "MIT-licensed React components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "module",
@@ -48,6 +48,9 @@
     "prosemirror",
     "editor",
     "rich-text",
+    "rich-text-editor",
+    "wysiwyg",
+    "typescript",
     "domternal"
   ],
   "repository": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/theme",
   "version": "1.0.1",
-  "description": "Default themes and styles for Domternal editor",
+  "description": "Light and dark CSS theme for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "commonjs",
@@ -39,6 +39,7 @@
   "keywords": [
     "domternal",
     "editor",
+    "rich-text-editor",
     "theme",
     "css",
     "prosemirror"

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/vanilla",
   "version": "1.0.1",
-  "description": "Polished DOM components for the Domternal rich-text editor. Use in Astro, Svelte, Solid, plain HTML.",
+  "description": "MIT-licensed framework-free DOM components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "module",
@@ -45,6 +45,10 @@
     "prosemirror",
     "editor",
     "rich-text",
+    "rich-text-editor",
+    "wysiwyg",
+    "typescript",
+    "web-components",
     "domternal"
   ],
   "repository": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domternal/vue",
   "version": "1.0.1",
-  "description": "Vue 3 components for Domternal editor",
+  "description": "MIT-licensed Vue 3 components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
   "type": "module",
@@ -45,6 +45,9 @@
     "prosemirror",
     "editor",
     "rich-text",
+    "rich-text-editor",
+    "wysiwyg",
+    "typescript",
     "domternal"
   ],
   "repository": {

--- a/tests/package-policy/check.mjs
+++ b/tests/package-policy/check.mjs
@@ -18,6 +18,14 @@ const SCOPE = '@domternal/';
 const PUBLISH_HOOK = 'node ../../scripts/prepare-publish-manifest.mjs';
 const RESTORE_HOOK = 'git checkout package.json';
 
+const WRAPPER_KEYWORDS = new Map([
+  ['@domternal/angular', 'angular'],
+  ['@domternal/react', 'react'],
+  ['@domternal/vue', 'vue'],
+  ['@domternal/vanilla', 'vanilla'],
+]);
+const FRAMEWORK_KEYWORDS = new Set(['angular', 'react', 'vue', 'vue3', 'vanilla']);
+
 // The one package that must declare side effects: it is a stylesheet, and a
 // bundler told it is side-effect free is entitled to drop it entirely.
 const STYLESHEET_PACKAGE = '@domternal/theme';
@@ -69,6 +77,145 @@ export function lockstepViolations(manifests) {
     .map(([version, names]) => `${version}: ${names.sort().join(', ')}`);
 }
 
+/** Public npm metadata that keeps search results precise without mislabeling a wrapper. */
+export function publicMetadataFailures(manifest) {
+  const failures = [];
+  const label = manifest.name;
+  const keywords = new Set(manifest.keywords ?? []);
+
+  for (const keyword of ['domternal', 'prosemirror']) {
+    if (!keywords.has(keyword)) failures.push(`${label}: keywords is missing "${keyword}"`);
+  }
+
+  if (label !== '@domternal/pm' && !keywords.has('rich-text-editor')) {
+    failures.push(`${label}: keywords is missing "rich-text-editor"`);
+  }
+
+  if (label !== '@domternal/pm' && label !== '@domternal/theme' && !keywords.has('typescript')) {
+    failures.push(`${label}: keywords is missing "typescript"`);
+  }
+
+  const ownFramework = WRAPPER_KEYWORDS.get(label);
+  if (ownFramework !== undefined) {
+    if (!keywords.has(ownFramework)) {
+      failures.push(`${label}: keywords is missing its own framework, "${ownFramework}"`);
+    }
+    for (const keyword of FRAMEWORK_KEYWORDS) {
+      if (keyword === ownFramework || (ownFramework === 'vue' && keyword === 'vue3')) continue;
+      if (keywords.has(keyword)) {
+        failures.push(`${label}: keywords includes another wrapper's framework, "${keyword}"`);
+      }
+    }
+  }
+
+  if (
+    (label === '@domternal/core' || ownFramework !== undefined || label === '@domternal/theme') &&
+    !String(manifest.description).toLowerCase().includes('rich text editor')
+  ) {
+    failures.push(`${label}: description does not identify it as part of a rich text editor`);
+  }
+
+  return failures;
+}
+
+/** README package inventory and durable product statements checked against the workspace. */
+export function publicReadmeFailures(readme, packages) {
+  const failures = [];
+  const names = packages.map(({ manifest }) => manifest.name).sort();
+  const section = /## Packages\s+([\s\S]*?)\s+## Domternal Pro/.exec(readme)?.[1];
+  if (section === undefined) {
+    return ['README: Packages section is missing or no longer ends before Domternal Pro'];
+  }
+
+  const listed = [...section.matchAll(/\[`(@domternal\/[a-z0-9-]+)`\]/g)].map((match) => match[1]);
+  const uniqueListed = [...new Set(listed)].sort();
+  const missing = names.filter((name) => !uniqueListed.includes(name));
+  const stale = uniqueListed.filter((name) => !names.includes(name));
+  const duplicates = uniqueListed.filter(
+    (name) => listed.filter((entry) => entry === name).length > 1
+  );
+  if (missing.length > 0)
+    failures.push(`README: current packages not listed: ${missing.join(', ')}`);
+  if (stale.length > 0)
+    failures.push(`README: listed packages not in the workspace: ${stale.join(', ')}`);
+  if (duplicates.length > 0)
+    failures.push(`README: packages listed more than once: ${duplicates.join(', ')}`);
+
+  const currentCount = /table above lists all (\d+) current MIT packages/i.exec(readme)?.[1];
+  if (currentCount === undefined || Number(currentCount) !== names.length) {
+    failures.push(
+      `README: current MIT package count is ${currentCount ?? 'missing'}, expected ${String(names.length)}`
+    );
+  }
+
+  const extensionCount = /extensions across core and (\d+) extension packages/i.exec(readme)?.[1];
+  const actualExtensionCount = names.filter((name) =>
+    name.startsWith('@domternal/extension-')
+  ).length;
+  if (extensionCount === undefined || Number(extensionCount) !== actualExtensionCount) {
+    failures.push(
+      `README: extension package count is ${extensionCount ?? 'missing'}, expected ${String(actualExtensionCount)}`
+    );
+  }
+
+  for (const [claim, label] of [
+    ['70+ extensions', 'extension threshold'],
+    ['17,000+ automated test executions', 'automated test threshold'],
+    ['150+ CSS custom properties', 'theme token threshold'],
+  ]) {
+    if (!readme.includes(claim)) failures.push(`README: ${label} no longer states "${claim}"`);
+  }
+
+  if (/every package is tree-shakeable/i.test(readme)) {
+    failures.push('README: tree-shaking claim includes the complete theme stylesheet');
+  }
+  if (!readme.includes('JavaScript exports are tree-shakeable')) {
+    failures.push('README: tree-shaking statement no longer names JavaScript exports');
+  }
+  if (!readme.includes('the optional theme ships as one complete CSS stylesheet')) {
+    failures.push(
+      'README: tree-shaking statement no longer explains the complete theme stylesheet'
+    );
+  }
+
+  return failures;
+}
+
+/** Public Context7 facts that must describe the same product as the README and npm. */
+export function publicContext7Failures(config, packages) {
+  const failures = [];
+  const description = String(config.description ?? '');
+  const rules = Array.isArray(config.rules) ? config.rules.map(String) : [];
+  const joinedRules = rules.join('\n');
+
+  for (const fact of ['Framework-agnostic', 'Angular', 'React', 'Vue', 'Vanilla', 'MIT licensed']) {
+    if (!description.includes(fact)) {
+      failures.push(`context7.json: description is missing "${fact}"`);
+    }
+  }
+
+  const packageClaim = `Domternal Free is the current set of ${String(packages.length)} MIT-licensed`;
+  if (!joinedRules.includes(packageClaim)) {
+    failures.push(`context7.json: package inventory no longer states "${packageClaim}"`);
+  }
+  for (const fact of [
+    'Domternal Pro is a separate commercially licensed suite',
+    'private source repository',
+    'requires no Domternal-operated editor cloud',
+    'https://domternal.dev/free-vs-pro/',
+    'https://domternal.dev/license-explained/',
+  ]) {
+    if (!joinedRules.includes(fact)) failures.push(`context7.json: rules are missing "${fact}"`);
+  }
+  if (joinedRules.includes('the bundler strips the rest')) {
+    failures.push(
+      'context7.json: tree-shaking claim is broader than the JavaScript export boundary'
+    );
+  }
+
+  return failures;
+}
+
 /** Every source file under `directory`, so a stylesheet import cannot hide in a subfolder. */
 export function sourceFiles(directory) {
   const found = [];
@@ -99,7 +246,8 @@ export function sourceFiles(directory) {
  */
 export function requiredNodeFloor(nvmrc) {
   const major = /^\s*v?(\d+)/.exec(nvmrc);
-  if (major === null) throw new Error(`.nvmrc does not name a Node major: ${JSON.stringify(nvmrc)}`);
+  if (major === null)
+    throw new Error(`.nvmrc does not name a Node major: ${JSON.stringify(nvmrc)}`);
   return `>=${major[1]}`;
 }
 
@@ -320,7 +468,17 @@ function main() {
   for (const entry of packages) {
     failures.push(...packageFailures(entry, names, rootLicense, nodeFloor));
     failures.push(...peerRangeFailures(entry));
+    failures.push(...publicMetadataFailures(entry.manifest));
   }
+  failures.push(
+    ...publicReadmeFailures(readFileSync(join(repoRoot, 'README.md'), 'utf8'), packages)
+  );
+  failures.push(
+    ...publicContext7Failures(
+      JSON.parse(readFileSync(join(repoRoot, 'context7.json'), 'utf8')),
+      packages
+    )
+  );
 
   if (failures.length > 0) {
     console.error('[package-policy] FAILED:');

--- a/tests/package-policy/check.test.mjs
+++ b/tests/package-policy/check.test.mjs
@@ -4,7 +4,7 @@
  * The transform is the only code between a working tree and npm, and npm is a
  * place nothing can be taken back from: a wrong compatibility range or a dangling export
  * condition is public the moment it lands. So its behaviour is pinned here on
- * hand-written manifests rather than only on the eighteen real ones, which all
+ * hand-written manifests rather than only on the seventeen real ones, which all
  * happen to be correct and would therefore prove nothing about the failures.
  */
 import { test } from 'node:test';
@@ -19,6 +19,9 @@ import {
   lockstepViolations,
   packageFailures,
   peerRangeFailures,
+  publicMetadataFailures,
+  publicContext7Failures,
+  publicReadmeFailures,
   requiredNodeFloor,
 } from './check.mjs';
 import {
@@ -75,6 +78,130 @@ test('lockstep reports the buckets, not just that they exist', () => {
       { name: '@domternal/extension-toc', version: '0.16.0' },
     ]),
     ['0.15.0: @domternal/core, @domternal/pm', '0.16.0: @domternal/extension-toc']
+  );
+});
+
+test('public npm metadata is searchable without assigning another framework to a wrapper', () => {
+  const base = {
+    name: '@domternal/react',
+    description: 'MIT-licensed React components for the Domternal rich text editor',
+    keywords: ['react', 'prosemirror', 'editor', 'rich-text-editor', 'typescript', 'domternal'],
+  };
+  assert.deepEqual(publicMetadataFailures(base), []);
+  assert.match(
+    publicMetadataFailures({
+      ...base,
+      keywords: base.keywords.filter((word) => word !== 'react'),
+    })[0],
+    /missing its own framework/
+  );
+  assert.match(
+    publicMetadataFailures({ ...base, keywords: [...base.keywords, 'angular'] }).find((failure) =>
+      failure.includes('another wrapper')
+    ),
+    /"angular"/
+  );
+  assert.match(
+    publicMetadataFailures({ ...base, description: 'React bindings' }).find((failure) =>
+      failure.includes('description')
+    ),
+    /rich text editor/
+  );
+});
+
+test('the public README inventory follows discovered packages and distinguishes JavaScript from CSS', () => {
+  const packages = [
+    { manifest: { name: '@domternal/core' } },
+    { manifest: { name: '@domternal/react' } },
+    { manifest: { name: '@domternal/extension-table' } },
+  ];
+  const readme = `
+JavaScript exports are tree-shakeable; the optional theme ships as one complete CSS stylesheet.
+
+**70+ extensions across core and 1 extension packages**
+**17,000+ automated test executions**
+**150+ CSS custom properties**
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [\`@domternal/core\`](url) | Core |
+| [\`@domternal/react\`](url) | React |
+| [\`@domternal/extension-table\`](url) | Table |
+
+The table above lists all 3 current MIT packages.
+
+## Domternal Pro
+`;
+  assert.deepEqual(publicReadmeFailures(readme, packages), []);
+  assert.match(
+    publicReadmeFailures(readme.replace('all 3 current', 'all 4 current'), packages).find(
+      (failure) => failure.includes('package count')
+    ),
+    /expected 3/
+  );
+  assert.match(
+    publicReadmeFailures(
+      readme.replace('| [`@domternal/react`](url) | React |\n', ''),
+      packages
+    ).find((failure) => failure.includes('not listed')),
+    /@domternal\/react/
+  );
+  assert.match(
+    publicReadmeFailures(
+      readme.replace('JavaScript exports are', 'Every package is'),
+      packages
+    ).find((failure) => failure.includes('theme stylesheet')),
+    /theme stylesheet/
+  );
+  for (const claim of [
+    '70+ extensions',
+    '17,000+ automated test executions',
+    '150+ CSS custom properties',
+  ]) {
+    assert.match(
+      publicReadmeFailures(readme.replace(claim, 'outdated claim'), packages).find((failure) =>
+        failure.includes('threshold')
+      ),
+      /no longer states/
+    );
+  }
+});
+
+test('Context7 keeps framework, package, source and deployment facts precise', () => {
+  const packages = Array.from({ length: 17 }, (_, index) => ({
+    manifest: { name: `@domternal/package-${String(index)}` },
+  }));
+  const config = {
+    description:
+      'Framework-agnostic editor with Angular, React, Vue and Vanilla packages. MIT licensed.',
+    rules: [
+      'JavaScript extension exports are tree-shakeable.',
+      'Domternal Free is the current set of 17 MIT-licensed @domternal packages. Domternal Pro is a separate commercially licensed suite distributed through public npm with a private source repository.',
+      'Domternal Pro requires no Domternal-operated editor cloud. See https://domternal.dev/free-vs-pro/ and https://domternal.dev/license-explained/.',
+    ],
+  };
+  assert.deepEqual(publicContext7Failures(config, packages), []);
+  assert.match(
+    publicContext7Failures(
+      {
+        ...config,
+        rules: config.rules.map((rule) => rule.replace('17 MIT-licensed', '18 MIT-licensed')),
+      },
+      packages
+    )[0],
+    /package inventory/
+  );
+  assert.match(
+    publicContext7Failures(
+      {
+        ...config,
+        rules: [...config.rules, 'Extensions are tree-shakeable: the bundler strips the rest'],
+      },
+      packages
+    ).find((failure) => failure.includes('tree-shaking')),
+    /JavaScript export boundary/
   );
 });
 
@@ -197,9 +324,10 @@ test('an exports target that is missing, or that files does not ship, blocks the
   /* The legacy fields are judged too. Nothing here uses `main` today, but a
      resolver that has not implemented exports reads it, and a dangling one
      fails exactly as hard. */
-  assert.deepEqual(publishBlockers({ ...manifest, exports: undefined, main: './dist/gone.js' }, root), [
-    'the manifest points at ./dist/gone.js, which does not exist',
-  ]);
+  assert.deepEqual(
+    publishBlockers({ ...manifest, exports: undefined, main: './dist/gone.js' }, root),
+    ['the manifest points at ./dist/gone.js, which does not exist']
+  );
 
   /* The shipped case: src/index.ts exists here, so only "files" separates a
      working consumer from ERR_MODULE_NOT_FOUND. That distinction is the whole


### PR DESCRIPTION
# Summary

Public product facts now say what the workspace actually contains: npm descriptions and keywords across all 17 packages, the README claims, and copy in `context7.json`. A policy gate derives those facts from the workspace and fails when they drift again.

# Fix

Package metadata mislabeled the product for anyone reading it on npm. Descriptions for core, the four wrappers, and the theme said "Domternal editor" without naming MIT or a rich text editor, and keywords were thin enough that the packages did not surface for the terms people search. Descriptions now name both, and keywords gain `rich-text-editor`, `typescript`, and per-package terms. Wrapper packages keep only their own framework keyword, so `@domternal/react` cannot surface for an Angular search.

README claims are now ones the repo can defend. Extension and CSS custom property counts became thresholds instead of exact numbers that go stale on the next extension added, the test line counts automated executions rather than implying that many distinct test cases, and the tree-shaking claim is scoped to JavaScript exports, because `@domternal/theme` deliberately ships one complete stylesheet and "every package is tree-shakeable" promised otherwise. The `extension-block-menu` note is reframed so npm's historical, deprecated 0.x entry does not read as an eighteenth current package.

`context7.json` states the Free and Pro split, that Pro runs in customer-chosen infrastructure with no Domternal-operated editor cloud, and links the pages that own product, pricing and licensing facts, so the copy an LLM answers from cannot fill those gaps by inference. Its arrays were also reformatted by Prettier.

# Changes

`tests/package-policy/check.mjs` gained three checks that read the workspace and fail on drift: npm metadata per manifest, the README package table with its claim thresholds, and the `context7.json` facts. The package count, the extension package count and the table contents are derived from the workspace rather than typed in, so adding or removing a package fails the gate until the public copy follows.

# Verified

`node tests/package-policy/check.mjs` (17 packages, ranges and manifests publishable) and `node --test tests/package-policy/check.test.mjs` (21 passing).