### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.2 (2026-09-06)
+
+### Fixes
+
+- Every `@domternal` peer dependency is bounded at the next major. The ranges read `>=1.0.0 <2.0.0` where they read an open `>=1.0.0`, and the publish transform writes the same ceiling onto the internal runtime dependencies it rewrites at pack time. An open range declares that a 1.x extension supports a 2.x core, which is a compatibility nothing here has tested: a consumer upgrading core on its own would have had the old extension resolved as compatible and installed without a warning, and a mismatch of that kind surfaces as a schema or plugin failure at runtime rather than at install time. The four wrapper READMEs and the `@domternal/pm` README state the bounded range with it. (#176)
+
+### Docs
+
+- The npm listing for every package names the product it belongs to. Descriptions carry the MIT licence and "rich text editor" in place of "Domternal editor", and keywords gain `rich-text-editor` and `typescript`, with `wysiwyg`, `headless`, `self-hosted` and `web-components` where each applies, so a package is findable by the words people search with. Each wrapper keeps only its own framework keyword, so `@domternal/react` cannot answer a search for Angular. (#177)
+
 ## 1.0.1 (2026-08-25)
 
 ### Fixes

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MIT-licensed Angular components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MIT-licensed, framework-agnostic headless rich text editor engine built on ProseMirror",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * Framework-agnostic ProseMirror editor engine
  */
 
-export const VERSION = '1.0.1';
+export const VERSION = '1.0.2';
 
 // === Type exports ===
 export type {

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-controls",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Notion-style block controls for the Domternal editor: BlockHandle (hover gutter + drag), SlashCommand, FloatingMenu, ContextMenu, keyboard reorder, and SmartPaste",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-markdown",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Bidirectional Markdown for Domternal: parse Markdown into the editor (paste, insert, setContent) and serialize documents back to GitHub-flavored Markdown, covering the full Notion-style schema",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-math",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "LaTeX math (inline + block) for Domternal editor with a pluggable renderer (KaTeX by default)",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MIT-licensed React components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Light and dark CSS theme for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MIT-licensed framework-free DOM components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MIT-licensed Vue 3 components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
# Summary

Patch release. Contents are in `CHANGELOG.md`.

# Changes

Peer dependency ranges stay at `>=1.0.0 <2.0.0`. A patch keeps the range it inherits, so only the 17 package versions and the `VERSION` constant in `@domternal/core` move.

No README changed. The version appears in none of them, `#176` already restated the bounded peer range where it is quoted, and `@domternal/core`'s "every export is tree-shakeable" stands as written because that package ships no CSS.

`#174` has no changelog entry. It removed the retired `@domternal/extension-block-menu` directory from the workspace, and 1.0.0 already recorded the package as gone under `Packages`, so nothing a consumer installs changed with it. The public fact corrections in the root `README.md` and `context7.json` from `#177` are absent for the same reason: neither file travels in a tarball. The npm-facing half of that PR, the descriptions and keywords, is in the release under `Docs`.

`domternal.dev` still pins 1.0.1. It resolves these packages from npm, so it can only move after step 8 publishes them.

# Verified

`node tests/package-policy/check.mjs` (17 packages at 1.0.2, ranges and manifests publishable), `node --test tests/package-policy/check.test.mjs` (21 passing), and the `@domternal/core` index test that holds `VERSION` and `package.json` in lockstep. The full suite runs in CI on this PR.