### PR TITLE
fix(extension-markdown): support Markdown pasted from source editors

### DIFF
--- a/e2e/markdown.spec.ts
+++ b/e2e/markdown.spec.ts
@@ -1,11 +1,85 @@
 /**
- * Markdown extension across all four demos: markdown-looking plain-text
- * pastes convert to rich content, plain prose stays untouched, and the
+ * Markdown extension across all four demos: plain-text and highlighted-source
+ * pastes convert to rich content, rich HTML stays untouched, and the
  * insertMarkdown / setMarkdownContent commands build rich structures.
  */
 import { test } from './fixtures.js';
 import { expect, type Page } from '@playwright/test';
 import { demoTargets, type DemoTarget } from './targets.js';
+
+const README_MARKDOWN = [
+  '# Clipboard README',
+  '',
+  'Install **Domternal** and follow the [guide](https://example.com/guide).',
+  '',
+  '## Features',
+  '',
+  '- Rich text editing',
+  '- Markdown source paste',
+  '',
+  '| Package | Status |',
+  '| --- | --- |',
+  '| core | ready |',
+  '',
+  '```ts',
+  'const ready = true;',
+  'if (ready) {',
+  '\tconsole.log("ready");',
+  '}',
+  '```',
+  '',
+].join('\n');
+
+function escapeHTML(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+/** VS Code expands tabs and alternates regular/nonbreaking spaces in copied HTML. */
+function sourceEditorLine(line: string): string {
+  let column = 0;
+  let nonbreaking = true;
+  return Array.from(line, (character) => {
+    const width = character === '\t' ? 4 - column % 4 : 1;
+    column += width;
+    if (character !== ' ' && character !== '\t') {
+      nonbreaking = false;
+      return character;
+    }
+    let spaces = '';
+    for (let index = 0; index < width; index++) {
+      spaces += nonbreaking ? '\u00a0' : ' ';
+      nonbreaking = !nonbreaking;
+    }
+    return spaces;
+  }).join('');
+}
+
+/** Model source-editor clipboard markup without adding semantic rich-text tags. */
+function sourceHTML(text: string, lines: 'newlines' | 'divs' | 'br' = 'newlines'): string {
+  const highlighted = text.split('\n').map((line) =>
+    (lines === 'divs' ? sourceEditorLine(line) : line).split(/(\s+)/).filter(Boolean).map((token, index) =>
+      `<span style="color: ${index % 2 === 0 ? '#569cd6' : '#d4d4d4'};">${escapeHTML(token)}</span>`,
+    ).join(''),
+  );
+  const content = lines === 'divs'
+    ? highlighted.map((line) => line ? `<div>${line}</div>` : '<br>').join('')
+    : highlighted.join(lines === 'br' ? '<br>' : '\n');
+  return '<meta charset="utf-8"><div style="color: #d4d4d4; background-color: #1e1e1e; '
+    + `font-family: Consolas, monospace; white-space: pre;">${content}</div>`;
+}
+
+async function expectREADME(page: Page, target: DemoTarget): Promise<void> {
+  const editor = page.locator(target.editorSelector);
+  await expect(editor.locator('h1')).toHaveText('Clipboard README');
+  await expect(editor.locator('h2')).toHaveText('Features');
+  await expect(editor.locator('strong')).toHaveText('Domternal');
+  await expect(editor.locator('a[href="https://example.com/guide"]')).toHaveText('guide');
+  await expect(editor.locator('ul li')).toHaveText(['Rich text editing', 'Markdown source paste']);
+  await expect(editor.locator('table th, table td')).toHaveText(['Package', 'Status', 'core', 'ready']);
+  await expect.poll(() => editor.locator('pre code.language-ts').textContent()).toBe(
+    'const ready = true;\nif (ready) {\n\tconsole.log("ready");\n}',
+  );
+}
 
 async function goNotion(page: Page, target: DemoTarget): Promise<void> {
   await page.goto(target.baseURL + '/');
@@ -42,9 +116,10 @@ async function paste(
       const data = new DataTransfer();
       data.setData('text/plain', text);
       if (html !== undefined) data.setData('text/html', html);
-      el.dispatchEvent(
-        new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
-      );
+      const event = new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true });
+      // Firefox replaces constructor-supplied data with an empty clipboard object.
+      if (event.clipboardData !== data) Object.defineProperty(event, 'clipboardData', { value: data });
+      el.dispatchEvent(event);
     },
     { selector: target.editorSelector, text: flavors.text, html: flavors.html },
   );
@@ -55,14 +130,25 @@ async function pastePlainText(page: Page, target: DemoTarget, text: string): Pro
   await paste(page, target, { text });
 }
 
-/** Collapse the selection to the very end of the document. */
-async function cursorToEnd(page: Page): Promise<void> {
-  await page.evaluate(() => {
+async function writeClipboard(page: Page, flavors: { text: string; html: string }): Promise<void> {
+  await page.evaluate(async ({ text, html }) => {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        'text/plain': new Blob([text], { type: 'text/plain' }),
+        'text/html': new Blob([html], { type: 'text/html' }),
+      }),
+    ]);
+  }, flavors);
+}
+
+/** Focus a known document position, the document end, or the entire document. */
+async function focusEditor(page: Page, position: string | number = 'end'): Promise<void> {
+  await page.evaluate((position) => {
     const ed = (window as unknown as Record<string, unknown>)['__DEMO_EDITOR__'] as
-      | { commands: { focus: (position?: string) => void } }
+      | { commands: { focus: (position: string | number) => void } }
       | undefined;
-    ed?.commands.focus('end');
-  });
+    ed?.commands.focus(position);
+  }, position);
 }
 
 function runCommand(page: Page, name: string, markdown: string): Promise<boolean> {
@@ -91,6 +177,13 @@ for (const target of demoTargets) {
       await expect(editor.locator('ul li')).toHaveCount(2);
       await expect(editor.locator('blockquote')).toContainText('quoted');
     });
+
+    for (const lines of ['divs', 'br'] as const) {
+      test(`pasting highlighted Markdown source with ${lines} converts the README`, async ({ page }) => {
+        await paste(page, target, { text: README_MARKDOWN, html: sourceHTML(README_MARKDOWN, lines) });
+        await expectREADME(page, target);
+      });
+    }
 
     test('pasting plain prose stays plain', async ({ page }) => {
       await pastePlainText(page, target, 'just a plain sentence.');
@@ -134,13 +227,22 @@ for (const target of demoTargets) {
       await expect(editor.locator('h1')).toHaveCount(0);
     });
 
+    test('pasting highlighted Markdown source inside a code block stays literal', async ({ page }) => {
+      await setContent(page, '<pre><code>start\n</code></pre>');
+      await focusEditor(page, 7);
+      await paste(page, target, { text: README_MARKDOWN, html: sourceHTML(README_MARKDOWN, 'divs') }, { click: false });
+      const editor = page.locator(target.editorSelector);
+      await expect.poll(() => editor.locator('pre code').textContent()).toBe('start\n' + README_MARKDOWN);
+      await expect(editor.locator('h1, h2, ul, table')).toHaveCount(0);
+    });
+
     test('pasting a bare URL still becomes a link, not markdown', async ({ page }) => {
       await pastePlainText(page, target, 'https://example.com/x');
       const editor = page.locator(target.editorSelector);
       await expect(editor.locator('a[href="https://example.com/x"]')).toHaveCount(1);
     });
 
-    test('pastes with an HTML flavor are left to the default handling', async ({ page }) => {
+    test('pastes with a rich HTML flavor are left to the default handling', async ({ page }) => {
       await paste(page, target, {
         text: '# md text',
         html: '<p><em>html wins</em></p>',
@@ -150,9 +252,21 @@ for (const target of demoTargets) {
       await expect(editor.locator('h1')).toHaveCount(0);
     });
 
+    test('rich HTML matching Markdown-looking plain text keeps its formatting', async ({ page }) => {
+      await paste(page, target, {
+        text: '# Keep this literal',
+        html: '<p><strong># Keep</strong> <em>this literal</em></p>',
+      });
+      const editor = page.locator(target.editorSelector);
+      await expect(editor.locator('p')).toHaveText('# Keep this literal');
+      await expect(editor.locator('strong')).toHaveText('# Keep');
+      await expect(editor.locator('em')).toHaveText('this literal');
+      await expect(editor.locator('h1')).toHaveCount(0);
+    });
+
     test('single-paragraph markdown pastes merge inline into existing text', async ({ page }) => {
       await setContent(page, '<p>keep:</p>');
-      await cursorToEnd(page);
+      await focusEditor(page);
       await paste(page, target, { text: 'has **bold** inline' }, { click: false });
       const editor = page.locator(target.editorSelector);
       await expect(editor.locator('p')).toHaveCount(1);
@@ -188,7 +302,7 @@ for (const target of demoTargets) {
 
     test('pasting a markdown list into an existing list keeps every item', async ({ page }) => {
       await setContent(page, '<ul><li><p>one</p></li></ul>');
-      await cursorToEnd(page);
+      await focusEditor(page);
       await paste(page, target, { text: '- two\n- three' }, { click: false });
       const editor = page.locator(target.editorSelector);
       await expect(editor.locator('li')).toHaveCount(3);
@@ -216,3 +330,53 @@ for (const target of demoTargets) {
     });
   });
 }
+
+test.describe('native Markdown clipboard', () => {
+  // Browser clipboard contents are shared, so native copy/paste tests run serially.
+  test.describe.configure({ mode: 'default' });
+
+  for (const target of demoTargets) {
+    test.describe(`${target.name} - markdown clipboard`, () => {
+      test.beforeEach(async ({ page, context, browserName }) => {
+        test.skip(browserName !== 'chromium', 'Native ClipboardItem permissions are Chromium-only.');
+        await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: target.baseURL });
+        await goNotion(page, target);
+        await setContent(page, '<p></p>');
+      });
+
+      test('pasting a source-editor README through the browser clipboard converts and undoes in one step', async ({ page }) => {
+        await writeClipboard(page, { text: README_MARKDOWN, html: sourceHTML(README_MARKDOWN, 'divs') });
+        await focusEditor(page);
+        await page.keyboard.press('ControlOrMeta+v');
+        await expectREADME(page, target);
+
+        await page.keyboard.press('ControlOrMeta+z');
+        const editor = page.locator(target.editorSelector);
+        await expect(editor.locator('h1, h2, ul, table, pre')).toHaveCount(0);
+        await expect(editor).toHaveText('');
+      });
+
+      test('a code block copied from the editor is not reparsed as Markdown', async ({ page }) => {
+        const code = '# Keep as code\n\n- literal list';
+        await setContent(page, `<pre><code class="language-markdown">${escapeHTML(code)}</code></pre>`);
+        await focusEditor(page, 'all');
+        await page.keyboard.press('ControlOrMeta+c');
+        const copiedHTML = await page.evaluate(async () => {
+          for (const item of await navigator.clipboard.read()) {
+            if (item.types.includes('text/html')) return (await item.getType('text/html')).text();
+          }
+          throw new Error('The editor copy did not put HTML on the clipboard');
+        });
+        expect(copiedHTML).toContain('data-pm-slice');
+        expect(copiedHTML).toContain('<pre');
+
+        await setContent(page, '<p></p>');
+        await focusEditor(page);
+        await page.keyboard.press('ControlOrMeta+v');
+        const editor = page.locator(target.editorSelector);
+        await expect(editor.locator('pre code.language-markdown')).toHaveText(code);
+        await expect(editor.locator('h1, ul')).toHaveCount(0);
+      });
+    });
+  }
+});

--- a/packages/extension-markdown/README.md
+++ b/packages/extension-markdown/README.md
@@ -44,7 +44,7 @@ const { markdown, warnings } = getMarkdown(editor);
 const saved = downloadMarkdown(editor, 'notes.md');
 ```
 
-Markdown-looking plain-text pastes convert automatically. Pastes that carry an HTML flavor, plain prose, and pastes into code blocks are never touched. Disable with `Markdown.configure({ paste: false })`. The test the plugin applies is exported as `looksLikeMarkdown(text)`, so a handler that takes over the paste path can reuse the same heuristic.
+Markdown-looking plain-text pastes convert automatically. Syntax-highlighted source copies, such as Markdown copied from VS Code, convert too when their HTML contains only source wrappers (`pre`, `div`, `span`, `br`), preserves whitespace, and matches the clipboard's plain text. HTML display formatting may expand tabs, but the original Markdown and its indentation are used for parsing. HTML with rich-text elements or editor metadata, copied editor code blocks, plain prose, and pastes into code blocks keep their usual handling. Disable with `Markdown.configure({ paste: false })`. The test the plugin applies is exported as `looksLikeMarkdown(text)`, so a handler that takes over the paste path can reuse the same heuristic.
 
 ## Options
 

--- a/packages/extension-markdown/src/Markdown.test.ts
+++ b/packages/extension-markdown/src/Markdown.test.ts
@@ -10,6 +10,8 @@ import {
   CodeBlock,
   Document,
   Editor,
+  Extension,
+  HardBreak,
   Heading,
   Italic,
   Link,
@@ -18,7 +20,8 @@ import {
   Paragraph,
   Text,
 } from '@domternal/core';
-import { TextSelection } from '@domternal/pm/state';
+import { Plugin, TextSelection } from '@domternal/pm/state';
+import { Table, TableCell, TableHeader, TableRow } from '@domternal/extension-table';
 import { downloadMarkdown } from './download.js';
 import { getMarkdown, Markdown } from './Markdown.js';
 import type { MarkdownStorage } from './Markdown.js';
@@ -37,6 +40,11 @@ const baseExtensions = [
   Italic,
   Code,
   Link,
+  HardBreak,
+  Table,
+  TableRow,
+  TableHeader,
+  TableCell,
 ];
 
 let editor: Editor | undefined;
@@ -63,12 +71,30 @@ interface FakeClipboardOptions {
 }
 
 function pasteEvent({ text, html = '' }: FakeClipboardOptions): ClipboardEvent {
-  return {
-    clipboardData: {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
       getData: (type: string) => (type === 'text/plain' ? text : type === 'text/html' ? html : ''),
     },
-    preventDefault: () => undefined,
-  } as unknown as ClipboardEvent;
+  });
+  return event as ClipboardEvent;
+}
+
+function pasteClipboard(target: Editor, clipboard: FakeClipboardOptions): void {
+  const event = pasteEvent(clipboard);
+  target.view.dom.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+}
+
+function escapeHtml(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function vscodeHtml(text: string): string {
+  const lines = text.replaceAll('\r\n', '\n').split('\n');
+  return '<meta charset="utf-8"><div style="color: #d4d4d4; font-family: Consolas, monospace; white-space: pre;">'
+    + lines.map((line) => line === '' ? '<br>' : `<div><span style="color: #569cd6">${escapeHtml(line)}</span></div>`).join('')
+    + '</div>';
 }
 
 function dispatchPaste(target: Editor, event: ClipboardEvent): boolean {
@@ -198,6 +224,309 @@ describe('markdown paste', () => {
     );
     expect(handled).toBe(false);
     expect(instance.state.doc.eq(before)).toBe(true);
+  });
+});
+
+describe('Markdown source clipboard HTML', () => {
+  const readme = [
+    '# Clipboard README',
+    '',
+    'Install **Domternal** and read the [guide](https://domternal.dev).',
+    '',
+    '- First item',
+    '- Second item',
+    '',
+    '| Package | Status |',
+    '| --- | --- |',
+    '| core | ready |',
+    '',
+    '```ts',
+    'const value = "<tag>";',
+    '  console.log(value);',
+    '```',
+  ].join('\n');
+
+  it('pastes a VS Code README as headings, marks, lists, tables, and fenced code', () => {
+    const instance = mount();
+    pasteClipboard(instance, { text: readme, html: vscodeHtml(readme) });
+
+    const doc = instance.state.doc;
+    expect(Array.from({ length: doc.childCount }, (_, index) => doc.child(index).type.name))
+      .toEqual(['heading', 'paragraph', 'bulletList', 'table', 'codeBlock']);
+    expect(doc.firstChild?.attrs['level']).toBe(1);
+    expect(doc.child(1).child(1).marks.some((mark) => mark.type.name === 'bold')).toBe(true);
+    expect(doc.child(1).child(3).marks.find((mark) => mark.type.name === 'link')?.attrs['href'])
+      .toBe('https://domternal.dev');
+    expect(doc.child(2).childCount).toBe(2);
+    expect(doc.child(3).childCount).toBe(2);
+    expect(doc.child(3).firstChild?.firstChild?.type.name).toBe('tableHeader');
+    expect(doc.lastChild?.attrs['language']).toBe('ts');
+    expect(doc.lastChild?.textContent).toBe('const value = "<tag>";\n  console.log(value);');
+  });
+
+  it.each([
+    ['a pre element with highlighted spans', '<pre><span># </span><span>Title</span>\n\n<span>- first</span>\n<span>- second</span></pre>'],
+    ['preserved lines separated by br', '<div style="white-space: pre-wrap"><span># Title</span><br><br><span>- first</span><br><span>- second</span></div>'],
+    ['a preserved span', '<span style="white-space: break-spaces"># Title\n\n- first\n- second</span>'],
+  ])('recognizes source presented as %s', (_name, html) => {
+    const instance = mount();
+    pasteClipboard(instance, { text: '# Title\n\n- first\n- second', html });
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.lastChild?.type.name).toBe('bulletList');
+    expect(instance.state.doc.lastChild?.childCount).toBe(2);
+  });
+
+  it('retains blank lines, nested indentation, tabs, and CRLF source when HTML uses nonbreaking spaces', () => {
+    const instance = mount();
+    const text = '# Whitespace\r\n\r\n- parent\r\n    - child\r\n\r\n```ts\r\n\tconst x = 1;\r\n  x++;\r\n```';
+    const html = vscodeHtml(text).replaceAll('    - child', '&nbsp;&nbsp;&nbsp;&nbsp;- child')
+      .replaceAll('  x++;', '&nbsp;&nbsp;x++;');
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.childCount).toBe(3);
+    expect(instance.state.doc.child(1).firstChild?.lastChild?.type.name).toBe('bulletList');
+    expect(instance.state.doc.child(1).firstChild?.lastChild?.textContent).toBe('child');
+    expect(instance.state.doc.lastChild?.textContent).toBe('\tconst x = 1;\n  x++;');
+  });
+
+  it('restores original Go source tabs when VS Code expands them to spaces in clipboard HTML', () => {
+    const instance = mount();
+    const source = [
+      '# Go example', '', '```go', 'func main() {',
+      '\tfmt.Println("ready")',
+      '  \tfmt.Println("mixed")',
+      '\t\tfmt.Println("nested")',
+      '}', '```',
+    ].join('\n');
+    const rendered = [
+      '# Go example', '', '```go', 'func main() {',
+      '\u00a0 \u00a0 fmt.Println("ready")',
+      '\u00a0 \u00a0 fmt.Println("mixed")',
+      '\u00a0 \u00a0 \u00a0 \u00a0 fmt.Println("nested")',
+      '}', '```',
+    ].join('\n');
+    pasteClipboard(instance, { text: source, html: vscodeHtml(rendered) });
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.lastChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.lastChild?.attrs['language']).toBe('go');
+    expect(instance.state.doc.lastChild?.textContent).toBe([
+      'func main() {', '\tfmt.Println("ready")', '  \tfmt.Println("mixed")',
+      '\t\tfmt.Println("nested")', '}',
+    ].join('\n'));
+  });
+
+  it.each([
+    ['\tvalue', ' value'],
+    ['\t\tvalue', '  value'],
+    ['  \tvalue', '   value'],
+    ['\t  \tvalue', '    value'],
+  ])('accepts tab expansion at the minimum remaining tab-stop width for %j', (source, rendered) => {
+    const instance = mount();
+    pasteClipboard(instance, {
+      text: `\`\`\`text\n${source}\n\`\`\``,
+      html: `<pre>\`\`\`text\n${rendered}\n\`\`\`</pre>`,
+    });
+    expect(instance.state.doc.firstChild?.textContent).toBe(source);
+  });
+
+  it.each([
+    ['changed literal spaces', 'left  right', 'left right'],
+    ['changed literal spaces after an expanded tab', '\tleft  right', '    left right'],
+    ['a missing tab', '\tvalue', 'value'],
+    ['two tabs rendered as one space', '\t\tvalue', ' value'],
+    ['fewer spaces than the literal spaces and tabs require', ' \t value', '  value'],
+    ['a removed line break after a tab', '\tfirst\nsecond', '    first second'],
+    ['a removed blank line after a tab', '\tfirst\n\nsecond', '    first\nsecond'],
+    ['HTML introducing a tab', '    value', '\tvalue'],
+  ])('rejects tab-related flavor conflicts with %s', (_name, source, rendered) => {
+    const instance = mount();
+    const text = `\`\`\`text\n${source}\n\`\`\``;
+    const html = `<pre>\`\`\`text\n${rendered}\n\`\`\`</pre>`;
+    const before = instance.state.doc;
+    expect(dispatchPaste(instance, pasteEvent({ text, html }))).toBe(false);
+    expect(instance.state.doc.eq(before)).toBe(true);
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.firstChild?.textContent).toBe(`\`\`\`text\n${rendered}\n\`\`\``);
+  });
+
+  it('uses the plain flavor as the source of code whitespace after HTML normalization', () => {
+    const instance = mount();
+    const text = '```text\n\u00a0indented\ntrailing  \n```';
+    const html = `<pre>${escapeHtml(text).replaceAll('\u00a0', ' ')}</pre>`;
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.firstChild?.textContent).toBe('\u00a0indented\ntrailing  ');
+  });
+
+  it.each([
+    ['# Title\n', '<pre># Title</pre>'],
+    ['# Title', '<pre># Title\n</pre>'],
+  ])('allows a clipboard line ending without changing source content', (text, html) => {
+    const instance = mount();
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.textContent).toBe('Title');
+  });
+
+  it.each(['\n', '\n\n'])('accepts VS Code source ending with %j', (ending) => {
+    const instance = mount();
+    const text = `# Final lines\n\n- item${ending}`;
+    pasteClipboard(instance, { text, html: vscodeHtml(text) });
+    expect(instance.state.doc.childCount).toBe(2);
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.lastChild?.type.name).toBe('bulletList');
+    expect(instance.state.doc.lastChild?.textContent).toBe('item');
+  });
+
+  it('accepts VS Code tab expansion together with a final source newline', () => {
+    const instance = mount();
+    const text = '```go\n\tfmt.Println("ready")\n```\n';
+    const rendered = '```go\n    fmt.Println("ready")\n```\n';
+    pasteClipboard(instance, { text, html: vscodeHtml(rendered) });
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.firstChild?.attrs['language']).toBe('go');
+    expect(instance.state.doc.firstChild?.textContent).toBe('\tfmt.Println("ready")');
+  });
+
+  it.each([
+    ['two extra HTML line breaks', '# Title', '# Title\n\n'],
+    ['three extra HTML line breaks', '# Title', '# Title\n\n\n'],
+    ['multiple missing HTML line breaks', '# Title\n\n\n', '# Title'],
+  ])('rejects conflicting final source whitespace with %s', (_name, text, rendered) => {
+    const instance = mount();
+    const html = `<pre>${rendered}</pre>`;
+    const before = instance.state.doc;
+    expect(dispatchPaste(instance, pasteEvent({ text, html }))).toBe(false);
+    expect(instance.state.doc.eq(before)).toBe(true);
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.firstChild?.textContent).toBe(rendered);
+  });
+
+  it.each([
+    ['semantic heading', '<h2># Literal heading</h2>', '# Literal heading'],
+    ['semantic bold mark', '<div style="white-space: pre"><strong>**Literal bold**</strong></div>', '**Literal bold**'],
+    ['semantic link', '<div style="white-space: pre"><a href="https://example.com"># Literal link</a></div>', '# Literal link'],
+    ['semantic list', '<ul><li># Literal item</li></ul>', '# Literal item'],
+    ['semantic table', '<table><tbody><tr><td># Literal cell</td></tr></tbody></table>', '# Literal cell'],
+    ['copied editor code block', '<pre><code># Literal code\n- still code</code></pre>', '# Literal code\n- still code'],
+    ['ProseMirror slice', '<div data-pm-slice="0 0 []" style="white-space: pre"># Literal slice</div>', '# Literal slice'],
+    ['nested ProseMirror slice', '<div style="white-space: pre"><span data-pm-slice="0 0 []"># Literal slice</span></div>', '# Literal slice'],
+    ['editor node marker', '<div data-type="codeBlock" style="white-space: pre"># Literal node</div>', '# Literal node'],
+    ['ordinary browser wrapper', '<div><span># Literal text</span></div>', '# Literal text'],
+    ['whitespace preservation overridden by a child', '<div style="white-space: pre"><span style="white-space: normal"># Literal text</span></div>', '# Literal text'],
+  ])('defers %s to the existing HTML paste pipeline', (_name, html, text) => {
+    const instance = mount();
+    const before = instance.state.doc;
+    expect(dispatchPaste(instance, pasteEvent({ text, html }))).toBe(false);
+    expect(instance.state.doc.eq(before)).toBe(true);
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.textContent).toBe(text);
+  });
+
+  it('preserves rendered rich HTML marks and heading level through the paste event', () => {
+    const instance = mount();
+    pasteClipboard(instance, {
+      text: '# **Literal heading**',
+      html: '<h3><strong># **Literal heading**</strong></h3>',
+    });
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.firstChild?.attrs['level']).toBe(3);
+    expect(instance.state.doc.firstChild?.firstChild?.marks[0]?.type.name).toBe('bold');
+    expect(instance.state.doc.textContent).toBe('# **Literal heading**');
+  });
+
+  it.each([
+    ['different content', '# Plain title', '<pre># HTML title</pre>'],
+    ['missing indentation', '```\n  indented\n```', '<pre>```\nindented\n```</pre>'],
+    ['missing blank line', '# Title\n\n- item', '<pre># Title\n- item</pre>'],
+    ['extra trailing spaces', '# Title  ', '<pre># Title</pre>'],
+    ['empty plain flavor', '', '<pre># HTML title</pre>'],
+  ])('rejects conflicting clipboard flavors with %s', (_name, text, html) => {
+    const instance = mount();
+    expect(dispatchPaste(instance, pasteEvent({ text, html }))).toBe(false);
+    pasteClipboard(instance, { text, html });
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.textContent).not.toContain('Plain title');
+  });
+
+  it('keeps source HTML literal when pasted inside a code block', () => {
+    const instance = mount({ content: '<pre><code>existing:</code></pre>' });
+    instance.view.dispatch(instance.state.tr.setSelection(TextSelection.atEnd(instance.state.doc)));
+    const text = '# Literal\n\n- item';
+    expect(dispatchPaste(instance, pasteEvent({ text, html: vscodeHtml(text) }))).toBe(false);
+    pasteClipboard(instance, { text, html: vscodeHtml(text) });
+    expect(instance.state.doc.childCount).toBe(1);
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.textContent).toBe(`existing:${text}`);
+  });
+
+  it('honors the disabled paste option for source HTML', () => {
+    const instance = mount({ markdownOptions: { paste: false } });
+    pasteClipboard(instance, { text: '# Literal title', html: '<pre># Literal title</pre>' });
+    expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(instance.state.doc.textContent).toBe('# Literal title');
+  });
+
+  it('lets the HTML pipeline recover when parsing eligible source throws', () => {
+    const instance = mount();
+    const parser = (instance.storage['markdown'] as MarkdownStorage).parser;
+    if (parser === null) throw new Error('Markdown parser not initialized');
+    const parse = vi.spyOn(parser, 'parse').mockImplementation(() => { throw new Error('parse failure'); });
+    try {
+      pasteClipboard(instance, { text: '# Recoverable', html: '<pre># Recoverable</pre>' });
+      expect(parse).toHaveBeenCalledWith('# Recoverable');
+      expect(instance.state.doc.firstChild?.type.name).toBe('codeBlock');
+      expect(instance.state.doc.textContent).toBe('# Recoverable');
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it.each([false, true])('handles source before a block-paste plugin regardless of registration order (%s)', (markdownFirst) => {
+    const fallback = vi.fn();
+    // Source HTML becomes a code-block slice before handlePaste runs. This
+    // normal-priority fallback models a block-paste plugin claiming that slice.
+    const blockPaste = Extension.create({
+      name: 'blockPasteFallback',
+      addProseMirrorPlugins() {
+        return [new Plugin({ props: { handlePaste(view, _event, slice) {
+          fallback(slice.content.firstChild?.type.name);
+          view.dispatch(view.state.tr.replaceSelection(slice));
+          return true;
+        } } })];
+      },
+    });
+    editor = new Editor({
+      extensions: [...baseExtensions, ...(markdownFirst ? [Markdown, blockPaste] : [blockPaste, Markdown])],
+      content: '<p></p>',
+    });
+    pasteClipboard(editor, { text: '# Title\n\n- item', html: '<pre># Title\n\n- item</pre>' });
+    expect(editor.state.doc.firstChild?.type.name).toBe('heading');
+    expect(editor.state.doc.lastChild?.type.name).toBe('bulletList');
+    expect(fallback).not.toHaveBeenCalled();
+
+    editor.commands.setContent('<p></p>');
+    pasteClipboard(editor, { text: '# Literal code', html: '<pre><code># Literal code</code></pre>' });
+    expect(fallback).toHaveBeenCalledExactlyOnceWith('codeBlock');
+    expect(editor.state.doc.firstChild?.type.name).toBe('codeBlock');
+    expect(editor.state.doc.textContent).toBe('# Literal code');
+  });
+
+  it('handles a large source clipboard without losing content', () => {
+    const instance = mount();
+    const body = 'source content '.repeat(15_000);
+    const text = `# Large README\n\n${body}`;
+    expect(dispatchPaste(instance, pasteEvent({ text, html: `<pre>${text}</pre>` }))).toBe(true);
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.lastChild?.textContent).toBe(body.trimEnd());
+  });
+
+  it('handles deeply nested source decoration without recursive traversal failure', () => {
+    const instance = mount();
+    const html = `<pre>${'<span>'.repeat(400)}# Nested title${'</span>'.repeat(400)}</pre>`;
+    expect(dispatchPaste(instance, pasteEvent({ text: '# Nested title', html }))).toBe(true);
+    expect(instance.state.doc.firstChild?.type.name).toBe('heading');
+    expect(instance.state.doc.textContent).toBe('Nested title');
   });
 });
 

--- a/packages/extension-markdown/src/Markdown.ts
+++ b/packages/extension-markdown/src/Markdown.ts
@@ -27,8 +27,8 @@ declare module '@domternal/core' {
 export interface MarkdownOptions {
   /**
    * Convert Markdown-looking plain-text pastes into rich content. Pastes
-   * that carry an HTML flavor, plain prose, and pastes into code blocks are
-   * never touched.
+   * with matching source-formatting HTML convert too. Rich HTML, plain prose,
+   * and pastes into code blocks are never touched.
    * @default true
    */
   paste: boolean;
@@ -63,6 +63,9 @@ export function getMarkdown(editor: Editor): SerializeMarkdownResult {
 
 export const Markdown = Extension.create<MarkdownOptions, MarkdownStorage>({
   name: 'markdown',
+
+  // Source copies must convert before block-level HTML handlers such as SmartPaste.
+  priority: 110,
 
   addOptions() {
     return {

--- a/packages/extension-markdown/src/pastePlugin.ts
+++ b/packages/extension-markdown/src/pastePlugin.ts
@@ -1,7 +1,7 @@
 /**
  * Markdown paste: when the clipboard carries plain text that looks like
- * Markdown (and no HTML flavor), parse it into rich content. Plain prose,
- * bare URLs (linkPastePlugin territory), and code block targets pass through.
+ * Markdown, including syntax-highlighted source HTML, parse it into rich content.
+ * Plain prose, bare URLs (linkPastePlugin territory), and code block targets pass through.
  */
 import { Slice } from '@domternal/pm/model';
 import { Plugin, PluginKey } from '@domternal/pm/state';
@@ -20,6 +20,121 @@ export function looksLikeMarkdown(text: string): boolean {
   return BLOCK_SYNTAX.test(text) || INLINE_SYNTAX.test(text);
 }
 
+/** Accept source formatting only when it represents the same literal text. */
+function isMarkdownSourceHTML(html: string, text: string, ownerDocument: Document): boolean {
+  const template = ownerDocument.createElement('template');
+  template.innerHTML = html;
+  const elements = template.content.querySelectorAll('*');
+  const preservesSpaces = (value: string): boolean =>
+    value === 'pre' || value === 'pre-wrap' || value === 'break-spaces';
+  let preservesWhitespace = false;
+
+  for (const element of Array.from(elements)) {
+    // Editor slices and semantic content must keep their original structure.
+    if (element.hasAttribute('data-pm-slice') || element.hasAttribute('data-type')) return false;
+    const tag = element.tagName;
+    if (tag === 'META' && element.hasAttribute('charset') && element.attributes.length === 1) {
+      continue;
+    }
+    if (!['PRE', 'DIV', 'SPAN', 'BR'].includes(tag)) return false;
+    if (tag === 'PRE' || preservesSpaces((element as HTMLElement).style.whiteSpace)) {
+      preservesWhitespace = true;
+    }
+  }
+  if (!preservesWhitespace) return false;
+
+  const chunks: string[] = [];
+  const output = { length: 0, endsWithNewline: false };
+  const append = (value: string): void => {
+    if (value === '') return;
+    chunks.push(value);
+    output.length += value.length;
+    output.endsWithNewline = value.endsWith('\n');
+  };
+  interface Frame {
+    node: Node;
+    sourceWhitespace?: boolean;
+    blockStart?: number;
+  }
+  const stack: Frame[] = [{ node: template.content }];
+
+  // An explicit stack also handles deeply nested source spans without recursion.
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (entry === undefined) break;
+    if (entry.blockStart !== undefined) {
+      if (output.length === entry.blockStart || !output.endsWithNewline) append('\n');
+      continue;
+    }
+    const { node } = entry;
+    if (node.nodeType === 3) {
+      const value = node.nodeValue ?? '';
+      if (entry.sourceWhitespace !== true && value.trim() !== '') return false;
+      append(value);
+      continue;
+    }
+    const whitespace = node.nodeType === 1 ? (node as HTMLElement).style.whiteSpace : '';
+    const sourceWhitespace =
+      whitespace === ''
+        ? node.nodeName === 'PRE' || entry.sourceWhitespace === true
+        : preservesSpaces(whitespace);
+    if (node.nodeName === 'BR') {
+      append('\n');
+      continue;
+    }
+    const isBlock = node.nodeName === 'DIV' || node.nodeName === 'PRE';
+    if (isBlock) {
+      if (output.length > 0 && !output.endsWithNewline) append('\n');
+      stack.push({ node, blockStart: output.length });
+    }
+    for (let child = node.lastChild; child !== null; child = child.previousSibling) {
+      stack.push({ node: child, sourceWhitespace });
+    }
+  }
+
+  const normalize = (value: string): string =>
+    value.replace(/\r\n?/g, '\n').replace(/\u00a0/g, ' ');
+  let rendered = normalize(chunks.join(''));
+  let source = normalize(text);
+  // A block wrapper may add one final line break, or a clipboard flavor may omit it.
+  const trailingLines = (value: string): number => {
+    let offset = value.length;
+    while (offset > 0 && value[offset - 1] === '\n') offset--;
+    return value.length - offset;
+  };
+  const finalLineDifference = trailingLines(rendered) - trailingLines(source);
+  if (finalLineDifference === 1) rendered = rendered.slice(0, -1);
+  else if (finalLineDifference === -1) source = source.slice(0, -1);
+  if (rendered === source) return true;
+  if (!source.includes('\t')) return false;
+
+  // Source editors expand tabs for HTML display. Only those whitespace runs
+  // may differ; the parser still receives the original text and its indentation.
+  let renderedOffset = 0;
+  let sourceOffset = 0;
+  while (sourceOffset < source.length) {
+    const character = source[sourceOffset];
+    if (character === ' ' || character === '\t') {
+      let spaces = 0;
+      let tabs = 0;
+      while (source[sourceOffset] === ' ' || source[sourceOffset] === '\t') {
+        if (source[sourceOffset] === '\t') tabs++;
+        else spaces++;
+        sourceOffset++;
+      }
+      const renderedStart = renderedOffset;
+      while (rendered[renderedOffset] === ' ') renderedOffset++;
+      const renderedSpaces = renderedOffset - renderedStart;
+      if (tabs > 0 ? renderedSpaces < spaces + tabs : renderedSpaces !== spaces) return false;
+    } else {
+      if (rendered[renderedOffset] !== character) return false;
+      renderedOffset++;
+      sourceOffset++;
+    }
+  }
+  return renderedOffset === rendered.length;
+}
+
 export function markdownPastePlugin(getParser: () => MarkdownParser): Plugin {
   return new Plugin({
     key: markdownPastePluginKey,
@@ -27,9 +142,6 @@ export function markdownPastePlugin(getParser: () => MarkdownParser): Plugin {
       handlePaste(view, event) {
         const clipboard = event.clipboardData;
         if (clipboard === null) return false;
-        // An HTML flavor means a rich source; ProseMirror's own paste
-        // handling preserves more fidelity than a Markdown reparse.
-        if (clipboard.getData('text/html') !== '') return false;
         const text = clipboard.getData('text/plain');
         if (text === '' || !looksLikeMarkdown(text)) return false;
         // Inside code blocks, pasted text stays literal.
@@ -37,6 +149,9 @@ export function markdownPastePlugin(getParser: () => MarkdownParser): Plugin {
 
         let doc;
         try {
+          const html = clipboard.getData('text/html');
+          if (html !== '' && !isMarkdownSourceHTML(html, text, view.dom.ownerDocument))
+            return false;
           doc = getParser().parse(text);
         } catch {
           // A parser failure must fall back to the default plain-text paste,


### PR DESCRIPTION
# Summary

Fix Markdown paste from VS Code and other source editors that copy both plain text and syntax-highlighted HTML.

# Fix

The paste handler previously rejected every HTML flavor, so copied Markdown could remain literal instead of becoming headings, lists, tables and code blocks.

Recognize source-formatting HTML when it matches the plain-text payload, accounting for expanded tabs and clipboard line endings. Parse the original text to preserve indentation and process Markdown before block-level paste handlers. Preserve existing handling for semantic rich HTML, editor slices and code-block targets.

# Changes

Add unit and browser regressions covering source HTML, whitespace, trailing blank lines, plugin ordering, rich HTML preservation and single-step undo. Correct synthetic clipboard handling in Firefox.

# Verified

- 154 package unit tests passed.
- 56 Vanilla demo E2E tests passed across Chromium, Firefox and WebKit.
- Four native clipboard tests were skipped in Firefox/WebKit because they require Chromium clipboard permissions.
- 12 HOME and Free/Pro playground integration tests passed against the locally built package.
- Package build, lint, TypeScript checks and E2E typecheck passed.