### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.3 (2026-09-06)
+
+### Fixes
+
+- Markdown copied from a source editor converts on paste. A syntax-highlighted copy, such as a `.md` file copied from VS Code, carries an HTML flavor next to the plain text, and the paste plugin took any HTML flavor to mean a rich source and stood aside, so the Markdown landed as literal paragraphs, markers and all, instead of as headings, lists and links. The HTML now converts when it holds nothing but source wrappers (`pre`, `div`, `span`, `br`, at most a charset `meta`), preserves whitespace, and renders the same text the plain-text flavor carries. A tab the editor expanded to spaces for display is the one difference allowed, and it is the plain text that gets parsed, so the original indentation is kept. A copy from Google Docs or a web page, a slice copied out of the editor and any element carrying `data-type` still paste through ProseMirror's own HTML handling, and pastes into code blocks stay literal. The extension now sits at priority 110, above the default 100, so the check runs ahead of block-level HTML paste handlers such as `SmartPaste`. (#179)
+
 ## 1.0.2 (2026-09-06)
 
 ### Fixes

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MIT-licensed Angular components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MIT-licensed, framework-agnostic headless rich text editor engine built on ProseMirror",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * Framework-agnostic ProseMirror editor engine
  */
 
-export const VERSION = '1.0.2';
+export const VERSION = '1.0.3';
 
 // === Type exports ===
 export type {

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-controls",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Notion-style block controls for the Domternal editor: BlockHandle (hover gutter + drag), SlashCommand, FloatingMenu, ContextMenu, keyboard reorder, and SmartPaste",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-markdown",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bidirectional Markdown for Domternal: parse Markdown into the editor (paste, insert, setContent) and serialize documents back to GitHub-flavored Markdown, covering the full Notion-style schema",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-math",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "LaTeX math (inline + block) for Domternal editor with a pluggable renderer (KaTeX by default)",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MIT-licensed React components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Light and dark CSS theme for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MIT-licensed framework-free DOM components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MIT-licensed Vue 3 components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release 1.0.3 of the 17 free packages. Contents are in `CHANGELOG.md`: one fix, Markdown pasted from source editors (#179).

## Changes

Version bump on the 17 packages and `VERSION` in core, plus the changelog entry. Peer ranges stay at `>=1.0.0 <2.0.0`, as a patch release keeps them. `domternal.dev` stays on 1.0.2 because it resolves the packages from npm and can only move after publish, at which point its pnpm patch for `@domternal/extension-markdown@1.0.2` is retired.

## Verified

Version-match test in core passes. CI on the PR runs the rest.