### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.1.0 (2026-09-09)
+
+### Features
+
+- `Editor.adoptDom(element)` moves an existing editor view to a new mount element without recreating its document, selection, history, or plugin state. The new `adopt` event, `AdoptEventProps` type, and `createAdoptablePluginView` helper let DOM-dependent plugin views rebind to the new host. The existing `mount` and `create` events keep their creation-time behavior. (#181)
+- `SlashCommand.configure({ icons })` accepts trusted SVG overrides for the default slash popup. Missing keys retain the built-in icons, and `createSlashSuggestionRenderer(icons)` accepts the same optional map. Custom render factories continue to own their icon rendering. (#181)
+- `TableOfContents` accepts `activeScrollParent`, `activeRootMargin`, `activeOffset`, and `clickOverrideMs` options for shared heading activity and navigation. Explicit observer options take precedence; omitted options retain the legacy floating-outline configuration. `ActiveStateSnapshot` is exported for custom tracking consumers. (#181)
+
+### Fixes
+
+- React and Vue attach existing editors through DOM adoption, keeping editor state intact while bubble menus, floating menus, block handles, context menus, and table-of-contents UI rebind to the mounted host. (#181)
+- Table-of-contents heading entries keep their DOM references and active/scrolled-over state current without requiring a floating outline. Inline contents, floating navigation, and `scrollToHeading` share the same tracker and scroll root, including after DOM adoption. The saved `tableOfContents` node and `UniqueID` defaults remain unchanged. (#181)
+- React `useEditorState` caches snapshots per selector, so selectors remain independent and stable across subscriptions and selector changes. (#181)
+- Autolinking keeps typed delimiters outside URL links while preserving named links and unrelated marks. (#181)
+- Clearing a blurred select-all decoration uses a valid text cursor and preserves formatting for subsequent typing, with a safe fallback for documents containing only atom nodes. (#181)
+- Slash-menu `hideWhenInside` filtering respects non-list ancestors while preserving the nearest-list and child-paragraph rules. Floating menu descriptions render in Angular, React, Vue, and Vanilla, with matching theme styles; toolbar dropdown tooltips include their keyboard shortcuts. (#181)
+
+### Docs
+
+- Package READMEs document DOM adoption, shared TOC activity options, custom slash icons, floating menu description styling, and the coordinated upgrade. All 17 packages ship as 1.1.0; internal Domternal dependency and peer ranges use `>=1.1.0 <2.0.0` so new wrappers and extensions cannot resolve against a core missing the APIs they use.
+
+### Internal
+
+- Unit and browser regressions cover editor lifecycle, selection, menus, clipboard behavior, and table-of-contents contracts across the framework wrappers. (#181)
+
 ## 1.0.3 (2026-09-06)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The example above wires the minimum schema by hand to show the headless model; i
 
 > **[Getting Started Guide](https://domternal.dev/v1/getting-started)** - headless core, themed UI with toolbar, and Angular/React/Vue component setup
 
+## Version compatibility
+
+The 1.1 release adds DOM adoption, custom slash-menu icons, and shared table-of-contents
+activity tracking. Existing editor APIs and saved document formats remain compatible.
+Upgrade installed `@domternal/*` packages together: 1.1 wrappers require core
+`>=1.1.0 <2.0.0`, and extensions require both core and pm in that range. See
+[CHANGELOG.md](CHANGELOG.md) for the release contents.
+
 ## Packages
 
 | Package                                                                                                              | Description                                                                                                                                                                  |

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -19,7 +19,7 @@ emoji picker, and Notion color picker auto-render from the extensions you load.
 pnpm add @domternal/angular @domternal/core @domternal/theme
 ```
 
-`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=1.0.0 <2.0.0)
+`@angular/core` (>=17.1), `@angular/forms` (>=17.1), `@angular/platform-browser` (>=17.1), and `@domternal/core` (>=1.1.0 <2.0.0)
 are peer dependencies. Add the theme ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme))
 to your global stylesheet (e.g. `styles.scss`):
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/angular",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MIT-licensed Angular components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "@angular/core": ">=17.1.0",
     "@angular/forms": ">=17.1.0",
     "@angular/platform-browser": ">=17.1.0",
-    "@domternal/core": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0"
   },
   "files": [
     "dist"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,6 +29,9 @@ the DOM, so it runs anywhere without it.
 pnpm add linkedom
 ```
 
+The 1.1 release installs `@domternal/pm` in the range `>=1.1.0 <2.0.0`.
+Use matching 1.1 versions of the framework wrappers and extensions when upgrading.
+
 ### One copy of the core, and of ProseMirror
 
 ProseMirror compares classes by identity, and so does this package. Two copies of
@@ -96,6 +99,25 @@ const editor = new Editor({
   extensions: [Document, Paragraph, Text, Bold, History],
 });
 ```
+
+## Moving an existing editor
+
+Use `editor.adoptDom(element)` to move the existing editor view into a new mount
+element while preserving its document, selection, undo history, and plugin state:
+
+```ts
+editor.adoptDom(document.getElementById('next-editor-mount')!);
+```
+
+The `adopt` event reports a changed DOM context and lets host-dependent UI rebind.
+The original `mount` and `create` events remain creation-time events; they are not
+repeated by adoption. Calling `adoptDom` with an unchanged DOM context is a no-op.
+React and Vue wrappers use this path when attaching an existing editor.
+
+Custom plugin views can use `createAdoptablePluginView(editor, view, createView)`
+to recreate their DOM bindings after adoption while retaining plugin state. The
+factory must return a ProseMirror plugin view and clean up its own DOM resources
+in `destroy`. The event payload type is exported as `AdoptEventProps`.
 
 ## Presets
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/core",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MIT-licensed, framework-agnostic headless rich text editor engine built on ProseMirror",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * Framework-agnostic ProseMirror editor engine
  */
 
-export const VERSION = '1.0.3';
+export const VERSION = '1.1.0';
 
 // === Type exports ===
 export type {

--- a/packages/extension-block-controls/README.md
+++ b/packages/extension-block-controls/README.md
@@ -22,6 +22,9 @@ pnpm add @domternal/extension-block-controls
 `@domternal/core` and `@domternal/pm` are peer dependencies and are pulled in by any
 Domternal editor setup.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 Add the extensions you want to your editor's extension list. Most apps use the full set

--- a/packages/extension-block-controls/package.json
+++ b/packages/extension-block-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-block-controls",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Notion-style block controls for the Domternal editor: BlockHandle (hover gutter + drag), SlashCommand, FloatingMenu, ContextMenu, keyboard reorder, and SmartPaste",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-code-block-lowlight/README.md
+++ b/packages/extension-code-block-lowlight/README.md
@@ -27,6 +27,9 @@ it yourself and pass a configured instance via the required `lowlight` option. F
 smaller bundle, start from an empty `createLowlight()` and register only the languages you
 need with `lowlight.register(name, syntax)`.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-code-block-lowlight/package.json
+++ b/packages/extension-code-block-lowlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-code-block-lowlight",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Code block with syntax highlighting via lowlight for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "hast-util-to-html": "^9.0.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0",
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0",
     "lowlight": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/extension-details/README.md
+++ b/packages/extension-details/README.md
@@ -22,6 +22,9 @@ pnpm add @domternal/extension-details
 
 `@domternal/core` and `@domternal/pm` are peer dependencies.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 The `Details` extension automatically pulls in its child nodes (`DetailsSummary`

--- a/packages/extension-details/package.json
+++ b/packages/extension-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-details",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Details/accordion extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-emoji/README.md
+++ b/packages/extension-emoji/README.md
@@ -24,6 +24,9 @@ pnpm add @domternal/extension-emoji
 `@domternal/core` and `@domternal/pm` are peer dependencies (installed with the
 editor itself).
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-emoji/package.json
+++ b/packages/extension-emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-emoji",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Emoji extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-image/README.md
+++ b/packages/extension-image/README.md
@@ -31,6 +31,9 @@ handles, so [`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)
 equivalent CSS of your own, is what makes placement and resizing visible in the editor.
 Exported HTML carries its own inline styles either way.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-image/package.json
+++ b/packages/extension-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-image",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Image node extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-markdown/README.md
+++ b/packages/extension-markdown/README.md
@@ -22,6 +22,9 @@ pnpm add @domternal/extension-markdown
 
 `@domternal/core` and `@domternal/pm` are peer dependencies.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-markdown/package.json
+++ b/packages/extension-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-markdown",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Bidirectional Markdown for Domternal: parse Markdown into the editor (paste, insert, setContent) and serialize documents back to GitHub-flavored Markdown, covering the full Notion-style schema",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "markdown-it": "^14.3.0"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-math/README.md
+++ b/packages/extension-math/README.md
@@ -22,6 +22,9 @@ pnpm add @domternal/extension-math katex
 supported range is `^0.16.0 || ^0.17.0`. You may swap it for any engine implementing the
 `MathRenderer` interface, since the package never imports KaTeX itself.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-math/package.json
+++ b/packages/extension-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-math",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "LaTeX math (inline + block) for Domternal editor with a pluggable renderer (KaTeX by default)",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0",
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0",
     "katex": "^0.16.0 || ^0.17.0"
   },
   "devDependencies": {

--- a/packages/extension-mention/README.md
+++ b/packages/extension-mention/README.md
@@ -22,6 +22,9 @@ pnpm add @domternal/extension-mention
 `@domternal/core` and `@domternal/pm` are peer dependencies and are already installed
 with the editor.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts

--- a/packages/extension-mention/package.json
+++ b/packages/extension-mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-mention",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Mention extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-table/README.md
+++ b/packages/extension-table/README.md
@@ -26,6 +26,9 @@ pnpm add @domternal/extension-table
 `@domternal/core` and `@domternal/pm` are peer dependencies and are already
 present in any Domternal editor setup.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 Add the `Table` extension to your editor. It pulls in `TableRow`, `TableCell`,

--- a/packages/extension-table/package.json
+++ b/packages/extension-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-table",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Table extension for Domternal editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -39,8 +39,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/extension-toc/README.md
+++ b/packages/extension-toc/README.md
@@ -29,6 +29,9 @@ also requires the `UniqueID` extension (from `@domternal/core`) to be loaded: it
 reads UniqueID's `id` attribute on headings as the navigation anchor and stays
 inert without it.
 
+Version 1.1 requires both `@domternal/core` and `@domternal/pm` in the range
+`>=1.1.0 <2.0.0`. Upgrade these packages together with this extension.
+
 ## Usage
 
 ```ts
@@ -75,6 +78,24 @@ list into the document.
 - `onUpdate` - called with the storage object whenever the heading list or the
   active heading changes
 
+Activity tracking belongs to `TableOfContents`, so `HeadingEntry.domNode`,
+`isActive`, and `isScrolledOver` stay current even without `FloatingTocOutline`.
+The inline block, floating outline, and `scrollToHeading` command share its
+navigation state. These observer options are also accepted:
+
+- `activeScrollParent` (default `null`, meaning the window): the scroll container
+- `activeRootMargin` (default `'0px 0px -85% 0px'`): the observer margin that
+  schedules measurements
+- `activeOffset` (default `0`): the activation line in pixels below the scroll
+  root's inner top
+- `clickOverrideMs` (default `500`): how long a navigation target stays active
+  while scrolling catches up
+
+Explicit `TableOfContents` options take precedence. Omitted scroll-parent,
+root-margin, and click-override options inherit the corresponding legacy
+`FloatingTocOutline` options, preserving existing configurations. Use
+`activeOffset` to move the activation line; root margin controls observation.
+
 `FloatingTocOutline.configure({ ... })`:
 
 - `anchor` (default `'editor'`) - `'editor'` pins the outline to the editor
@@ -88,7 +109,7 @@ list into the document.
   for the active-heading tracker. Set it when the editor lives in its own
   scrolling region
 - `activeRootMargin` (default `'0px 0px -85% 0px'`) - `IntersectionObserver`
-  rootMargin defining the active zone
+  rootMargin used to schedule active-heading measurements
 - `clickOverrideMs` (default `500`) - how long scroll-derived updates are ignored
   after a tick is clicked, so the click target stays active until the scroll lands
 - `hoverInDelay` / `hoverOutDelay` (defaults `120` / `350`) - ms before the
@@ -121,3 +142,7 @@ import {
 `walkHeadings`, `scrollToHeading`, and `createActiveStateTracker` are exposed as
 standalone helpers so you can build a custom outline UI on top of the same
 data layer and active-tracking rule.
+
+The tracker snapshot type is exported as `ActiveStateSnapshot`, with `activeId`
+and `scrolledOverIds`. The saved inline node remains `tableOfContents`; no
+document migration or change to `UniqueID` defaults is required.

--- a/packages/extension-toc/package.json
+++ b/packages/extension-toc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/extension-toc",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Notion-style Table of Contents for Domternal: floating right-rail outline with collapsed/expanded states + insertable inline /toc block, both fed by a shared heading-discovery data layer",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "postpublish": "git checkout package.json"
   },
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
-    "@domternal/pm": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0",
+    "@domternal/pm": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -19,7 +19,8 @@ extension. You rarely install it yourself: it ships transitively with `@domterna
 Install it explicitly when you import ProseMirror primitives in your own code, or when a
 strict peer resolver asks for it: every `@domternal/extension-*` package declares
 `@domternal/pm` as a peer dependency with the same minor floor and next-major ceiling as
-`@domternal/core`.
+`@domternal/core`. For the 1.1 release, both ranges are `>=1.1.0 <2.0.0`;
+upgrade core, pm, and the extensions together.
 
 ```bash
 pnpm add @domternal/pm

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/pm",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "ProseMirror package re-exports for Domternal",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ and React 19.
 pnpm add @domternal/react @domternal/core @domternal/theme react react-dom
 ```
 
-`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=1.0.0 <2.0.0) are peer dependencies. Import the theme
+`react` (>=18), `react-dom` (>=18), and `@domternal/core` (>=1.1.0 <2.0.0) are peer dependencies. Import the theme
 ([`@domternal/theme`](https://www.npmjs.com/package/@domternal/theme)) in your entry CSS for default styling:
 
 ```css

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/react",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MIT-licensed React components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/core": ">=1.1.0 <2.0.0",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -93,6 +93,13 @@ inherited from an ancestor, so target those elements rather than a wrapper alone
 }
 ```
 
+## Floating menu descriptions
+
+The 1.1 stylesheet supports the optional `FloatingMenuItem.description` rendered
+by all four framework wrappers. Descriptions appear below the label, wrap long
+text, and use `--dm-muted` for their colour. Upgrade the theme with the wrapper
+so the menu markup and styles stay aligned.
+
 ## The hidden attribute
 
 `hidden` works on every element this theme styles, and on anything inside one:

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/theme",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Light and dark CSS theme for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -22,7 +22,7 @@ Lit, Web Components, or plain HTML - anywhere without a framework runtime.
 pnpm add @domternal/core @domternal/theme @domternal/vanilla
 ```
 
-`@domternal/core` (>=1.0.0 <2.0.0) is a peer dependency. `@domternal/theme` supplies the editor
+`@domternal/core` (>=1.1.0 <2.0.0) is a peer dependency. `@domternal/theme` supplies the editor
 styles (import it once in your app).
 
 ## Usage

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vanilla",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MIT-licensed framework-free DOM components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0"
+    "@domternal/core": ">=1.1.0 <2.0.0"
   },
   "devDependencies": {
     "@domternal/core": "workspace:*",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -19,7 +19,7 @@ editor is created in `onMounted`. Requires Vue 3.3+ and the Composition API.
 pnpm add @domternal/vue @domternal/core @domternal/theme vue
 ```
 
-`vue` (>=3.3) and `@domternal/core` (>=1.0.0 <2.0.0) are peer dependencies. `@domternal/theme`
+`vue` (>=3.3) and `@domternal/core` (>=1.1.0 <2.0.0) are peer dependencies. `@domternal/theme`
 supplies the editor styles.
 
 ## Usage

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domternal/vue",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MIT-licensed Vue 3 components for the Domternal rich text editor",
   "author": "https://github.com/ThomasNowHere",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@domternal/core": ">=1.0.0 <2.0.0",
+    "@domternal/core": ">=1.1.0 <2.0.0",
     "vue": ">=3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary

Prepare the compatible 1.1.0 minor release. Release contents are in `CHANGELOG.md`.

# Changes

All Free packages move together, with internal Domternal dependency and peer ranges bounded to `>=1.1.0 <2.0.0`. Website and PRO dependency updates follow npm publication. The existing Free lockfile remains valid.

# Verified

Offline frozen-lockfile installation, all package builds, core version consistency, package and tarball policies, consumer types, API surface, external modules, and SSR imports passed in an isolated Free checkout. The full CI checks previously passed on the same implementation now merged into main; this release adds version and documentation changes.